### PR TITLE
Consolidate border-radius styles for future fun

### DIFF
--- a/src/annotator/components/AdderToolbar.tsx
+++ b/src/annotator/components/AdderToolbar.tsx
@@ -19,7 +19,7 @@ function NumberIcon({ badgeCount }: { badgeCount: number }) {
   return (
     <span
       className={classnames(
-        'rounded px-1 py-0.5',
+        'rounded-[4px] px-1 py-0.5',
         // The background color is inherited from the current text color in
         // the containing button and will vary depending on hover state.
         'bg-current'
@@ -238,7 +238,7 @@ export default function AdderToolbar({
         // default border values from Tailwind and have to be explicit about all
         // border attributes.
         'border border-solid border-grey-3',
-        'absolute select-none bg-white rounded shadow-adder-toolbar',
+        'absolute select-none bg-white rounded-[4px] shadow-adder-toolbar',
         // Start at a very low opacity as we're going to fade in in the animation
         'opacity-5',
         {

--- a/src/annotator/components/ClusterToolbar.tsx
+++ b/src/annotator/components/ClusterToolbar.tsx
@@ -37,7 +37,7 @@ function ClusterStyleControl({
     <div className="space-y-2">
       <div className="flex items-center gap-x-2 text-annotator-base">
         <div
-          className="grow text-color-text px-2 py-1 rounded"
+          className="grow text-color-text px-2 py-1 rounded-[4px]"
           style={{
             backgroundColor: highlightStyles[appliedStyleName].color,
           }}

--- a/src/annotator/components/Toolbar.tsx
+++ b/src/annotator/components/Toolbar.tsx
@@ -31,7 +31,7 @@ function ToolbarButton({ icon: Icon, ...buttonProps }: ToolbarButtonProps) {
   return (
     <Button
       classes={classnames(
-        'justify-center rounded-px',
+        'justify-center rounded-[4px]',
         'w-[30px] h-[30px]',
         'shadow border bg-white text-grey-6 hover:text-grey-9'
       )}

--- a/src/sidebar/components/MarkdownEditor.tsx
+++ b/src/sidebar/components/MarkdownEditor.tsx
@@ -186,7 +186,7 @@ function TextArea({
   return (
     <textarea
       className={classnames(
-        'border rounded-sm p-2',
+        'border rounded p-2',
         'text-color-text-light bg-grey-0',
         'focus:bg-white focus:outline-none focus:shadow-focus-inner',
         classes

--- a/src/sidebar/components/MarkdownEditor.tsx
+++ b/src/sidebar/components/MarkdownEditor.tsx
@@ -225,7 +225,7 @@ function Toolbar({ isPreviewing, onCommand, onTogglePreview }: ToolbarProps) {
       className={classnames(
         // Allow buttons to wrap to second line if necessary.
         'flex flex-wrap w-full items-center',
-        'p-1 border-x border-t rounded-t bg-white',
+        'p-1 border-x border-t rounded-t-[4px] bg-white',
         // For touch interfaces, allow height to scale to larger button targets.
         // Don't wrap buttons but instead scroll horizontally. Add bottom
         // padding to provide some space for scrollbar.

--- a/src/sidebar/components/Menu.tsx
+++ b/src/sidebar/components/Menu.tsx
@@ -194,7 +194,7 @@ export default function Menu({
         aria-haspopup={true}
         className={classnames(
           'focus-visible-ring',
-          'flex items-center justify-center rounded-sm transition-colors',
+          'flex items-center justify-center rounded transition-colors',
           {
             'text-grey-7 hover:text-grey-9': !isOpen,
             'text-brand': isOpen,

--- a/src/sidebar/components/ProfileView.tsx
+++ b/src/sidebar/components/ProfileView.tsx
@@ -39,7 +39,7 @@ function ToastBadge({
   return (
     <div
       className={classnames(
-        'flex items-center gap-x-1 py-1 px-2 rounded',
+        'flex items-center gap-x-1 py-1 px-2 rounded-[4px]',
         'bg-green-success/10 animate-pulse-fade-out',
         classes
       )}

--- a/src/sidebar/components/TagListItem.tsx
+++ b/src/sidebar/components/TagListItem.tsx
@@ -22,7 +22,7 @@ export default function TagListItem({
   tag,
 }: TagListItemProps) {
   return (
-    <li className="flex items-center border rounded-sm bg-grey-0">
+    <li className="flex items-center border rounded bg-grey-0">
       <div className="grow px-1.5 py-1 touch:p-2">
         {href ? (
           <Link
@@ -54,7 +54,7 @@ export default function TagListItem({
             // Rounded border to match container edges and make keyboard focus
             // ring shape conform. Turn off left side
             // border radius to maintain a straight dividing line
-            'border-l rounded-sm rounded-l-none',
+            'border-l rounded rounded-l-none',
             'text-grey-6 hover:text-color-text hover:bg-grey-2',
             // Emulates transitions on *Button shared component styling
             'transition-colors duration-200',

--- a/src/styles/sidebar/_base.scss
+++ b/src/styles/sidebar/_base.scss
@@ -17,7 +17,7 @@
     // Ensure the tag has width in order for :focus styling to render correctly.
     @apply inline-block;
     // Give links a radius to allow :focus styling to appear similar to that of buttons
-    @apply rounded-sm;
+    @apply rounded;
     @apply text-brand no-underline;
   }
 

--- a/src/styles/sidebar/components/StyledText.scss
+++ b/src/styles/sidebar/components/StyledText.scss
@@ -89,7 +89,7 @@
     }
 
     pre code {
-      @apply block p-3 bg-grey-1 rounded-sm overflow-scroll;
+      @apply block p-3 bg-grey-1 rounded overflow-scroll;
     }
 
     a {

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -26,12 +26,8 @@ export default {
         'slide-in-from-right': 'slide-in-from-right 0.3s forwards ease-in-out',
       },
       borderRadius: {
-        // Tailwind provides a default set of border-radius utility styles
-        // in rem units. Add some values for places where border radius needs
-        // to be a fixed size and not scale with changes to root font size
-        // example: bucket bar indicator buttons
-        'px-sm': '2px',
-        px: '4px',
+        // Equivalent to tailwind default `rounded-sm` size
+        DEFAULT: '0.125rem',
       },
       boxShadow: {
         'adder-toolbar': '0px 2px 10px 0px rgba(0, 0, 0, 0.25)',
@@ -232,8 +228,8 @@ export default {
         },
         // Tailwind does not provide this specific break utility: https://tailwindcss.com/docs/word-break
         '.break-anywhere': {
-          'overflow-wrap': 'anywhere'
-        }
+          'overflow-wrap': 'anywhere',
+        },
       });
       addComponents({
         // Add a custom class to set all properties to initial values. Used


### PR DESCRIPTION
Ahkay, so I know that we're going to be hearing in the near future about going more roundy in our styling. So this is a PR to get our ducks in order for that (it's been something on my mind for a little while anyway).

Minor changes here but I'd like to explain, as I also plan to do the same quick update across the other frontend repos that use `@hypothesis/frontend-shared`.

Our current default border radius size across design patterns is very subtle, a mere 2px.

The mistake I made in the past was _"ah, well, 2px is equivalent to tailwind's `rounded-sm` size, so I'll use that throughout to apply our default border radius, which happens to be small"_. So when you see `rounded-sm`, the actual intent is _"use default border radius size."_ There's a semantic mismatch here.

Compounding the confusion is the use of the un-qualified `rounded` class in several places, by which I meant _"apply border radius that's one tick larger than our default"_, which happens to work out to 4px. But `rounded` here does not mean default-rounded, it means literally 4px.

This PR

* Changes uses of `rounded` to `rounded-[4px]`[^1]
* Sets a `DEFAULT` `borderRadius` size in the local tailwind configuration.
* Changes uses of `rounded-sm` to `rounded` to correctly reflect the intent of applying the default border radius.

The plan here is:

1. Make equivalent changes in other projects that use shared components
2. Make equivalent changes in the shared package. Once this is done, everything involved will be using `rounded` to apply default border radius, and each project will set a `DEFAULT` for border radius to 2px (or equivalent).
3. Bump up the default border radius in the shared package. This will allow us to preview and tune shared components with a stronger border radius. But local project `DEFAULT` values for border radius will be respected (overrides shared preset value), so we don't have a danger of mixed border radius values.
4. As we desire, flip the switch in projects by either changing the local `DEFAULT` for border radius or removing it altogether to prefer the shared/preset value. This will have the effect of updating the default border radius on all components (local and shared) in one easy go.

Oh, there should be no user-visible changes here.

[^1]: It's possible that when we review updated components with a larger default border radius, these will still look correct at 4px, at which point we can pose the question to ourselves whether the intent here is really "default border radius, but at the time we were aching for that default to be more like 4px" and decide whether to stick with the arbitrary units or use `rounded`.