### PR TITLE
Remove runtime check for case that can be checked via types

### DIFF
--- a/src/annotator/config/index.ts
+++ b/src/annotator/config/index.ts
@@ -31,15 +31,11 @@ type ConfigDefinitionMap = Record<string, ConfigDefinition>;
  */
 type Context = 'sidebar' | 'notebook' | 'profile' | 'annotator' | 'all';
 
-function throwInvalidContext(context: string): never {
-  throw new Error(`Invalid application context used: "${context}"`);
-}
-
 /**
  * Returns the configuration keys that are relevant to a particular context.
  */
 function configurationKeys(context: Context): string[] {
-  const contexts = {
+  const contexts: Record<Exclude<Context, 'all'>, string[]> = {
     annotator: [
       'clientUrl',
       'contentInfoBanner',
@@ -82,7 +78,7 @@ function configurationKeys(context: Context): string[] {
     return Object.values(contexts).flat();
   }
 
-  return contexts[context] ?? throwInvalidContext(context);
+  return contexts[context];
 }
 
 const getHostPageSetting: ValueGetter = (settings, name) =>

--- a/src/annotator/config/test/index-test.js
+++ b/src/annotator/config/test/index-test.js
@@ -282,10 +282,4 @@ describe('annotator/config/index', () => {
       });
     });
   });
-
-  it(`throws an error if an invalid context was passed`, () => {
-    assert.throws(() => {
-      getConfig('fake', 'WINDOW');
-    }, 'Invalid application context used: "fake"');
-  });
 });


### PR DESCRIPTION
This PR removes a runtime validation of a value which can actually be checked by types, as it only accepts a subset of values we control, and therefore we don't need to check what happens when a different value is provided.

> This was brought up during the review of another PR https://github.com/hypothesis/client/pull/5605/files#r1255615654