### PR TITLE
Fix toast message animations

### DIFF
--- a/tailwind-annotator.config.mjs
+++ b/tailwind-annotator.config.mjs
@@ -4,6 +4,7 @@ export default {
   presets: [tailwindConfig],
   content: [
     './src/annotator/components/**/*.{js,ts,tsx}',
+    './src/shared/components/**/*.{js,ts,tsx}',
     './node_modules/@hypothesis/frontend-shared/lib/**/*.{js,ts,tsx}',
     // This module references `sidebar-frame` and related classes
     './src/annotator/sidebar.{js,ts,tsx}',

--- a/tailwind-sidebar.config.mjs
+++ b/tailwind-sidebar.config.mjs
@@ -4,6 +4,7 @@ export default {
   presets: [tailwindConfig],
   content: [
     './src/sidebar/components/**/*.{js,ts,tsx}',
+    './src/shared/components/**/*.{js,ts,tsx}',
     './dev-server/ui-playground/components/**/*.{js,ts,tsx}',
     './node_modules/@hypothesis/frontend-shared/lib/**/*.{js,ts,tsx}',
   ],

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -8,7 +8,6 @@ export default {
   content: [
     './src/sidebar/components/**/*.{js,ts,tsx}',
     './src/annotator/components/**/*.{js,ts,tsx}',
-    './src/shared/components/**/*.{js,ts,tsx}',
     './dev-server/ui-playground/components/**/*.{js,ts,tsx}',
     './node_modules/@hypothesis/frontend-shared/lib/**/*.{js,ts,tsx}',
     // This module references `sidebar-frame` and related classes


### PR DESCRIPTION
Some time ago we refactored a bit how toast messages were rendered in the client, and extracted a new component into a `shared/components` directory which was not tracked by tailwind yet.

This was caught during review, so we added it to `tailwind.config.mjs`. However, that config gets overwritten by both `tailwind-annotator.config.mjs` and `tailwind-sidebar.config.mjs`, which made that change useless.

This PR fixes tailwind's annotator and sidebar specific config files so that they are aware of the `shared/components` directory.