### PR TITLE
Strip client-specific properties from annotations before exporting

### DIFF
--- a/src/sidebar/helpers/strip-internal-properties.ts
+++ b/src/sidebar/helpers/strip-internal-properties.ts
@@ -1,0 +1,15 @@
+/**
+ * Return a shallow clone of `obj` with all client-only properties removed.
+ * Client-only properties are marked by a '$' prefix.
+ */
+export function stripInternalProperties(
+  obj: Record<string, unknown>
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (!key.startsWith('$')) {
+      result[key] = value;
+    }
+  }
+  return result;
+}

--- a/src/sidebar/services/annotations-exporter.ts
+++ b/src/sidebar/services/annotations-exporter.ts
@@ -1,4 +1,5 @@
-import type { Annotation } from '../../types/api';
+import type { APIAnnotationData } from '../../types/api';
+import { stripInternalProperties } from '../helpers/strip-internal-properties';
 import { VersionData } from '../helpers/version-data';
 import type { SidebarStore } from '../store';
 
@@ -6,7 +7,7 @@ export type ExportContent = {
   export_date: string;
   export_userid: string;
   client_version: string;
-  annotations: Annotation[];
+  annotations: APIAnnotationData[];
 };
 
 /**
@@ -26,7 +27,9 @@ export class AnnotationsExporter {
    */
   buildExportContent(now = new Date()): ExportContent {
     const profile = this._store.profile();
-    const annotations = this._store.allAnnotations();
+    const annotations = this._store
+      .allAnnotations()
+      .map(stripInternalProperties) as APIAnnotationData[];
     const versionData = new VersionData(profile, []);
 
     return {

--- a/src/sidebar/services/api.ts
+++ b/src/sidebar/services/api.ts
@@ -5,27 +5,12 @@ import type {
   RouteMetadata,
   Profile,
 } from '../../types/api';
+import { stripInternalProperties } from '../helpers/strip-internal-properties';
 import type { SidebarStore } from '../store';
 import { fetchJSON } from '../util/fetch';
 import { replaceURLParams } from '../util/url';
 import type { APIRoutesService } from './api-routes';
 import type { AuthService } from './auth';
-
-/**
- * Return a shallow clone of `obj` with all client-only properties removed.
- * Client-only properties are marked by a '$' prefix.
- */
-function stripInternalProperties(
-  obj: Record<string, unknown>
-): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(obj)) {
-    if (!key.startsWith('$')) {
-      result[key] = value;
-    }
-  }
-  return result;
-}
 
 /**
  * Types of value that can be passed as a parameter to API calls.

--- a/src/sidebar/services/test/annotations-exporter-test.js
+++ b/src/sidebar/services/test/annotations-exporter-test.js
@@ -1,3 +1,4 @@
+import { publicAnnotation } from '../../test/annotation-fixtures';
 import { AnnotationsExporter } from '../annotations-exporter';
 
 describe('AnnotationsExporter', () => {
@@ -14,7 +15,18 @@ describe('AnnotationsExporter', () => {
 
   it('generates export content with provided annotations', () => {
     const now = new Date();
-    const annotations = [{}, {}];
+    const firstBaseAnnotation = publicAnnotation();
+    const secondBaseAnnotation = publicAnnotation();
+    const annotations = [
+      {
+        ...firstBaseAnnotation,
+        $tag: '',
+      },
+      {
+        ...secondBaseAnnotation,
+        $highlight: true,
+      },
+    ];
     fakeStore.allAnnotations.returns(annotations);
 
     const result = exporter.buildExportContent(now);
@@ -23,7 +35,7 @@ describe('AnnotationsExporter', () => {
       export_date: now.toISOString(),
       export_userid: 'userId',
       client_version: '__VERSION__',
-      annotations,
+      annotations: [firstBaseAnnotation, secondBaseAnnotation],
     });
   });
 });


### PR DESCRIPTION
> This PR is part of https://github.com/hypothesis/client/issues/5640

This PR changes the logic to map annotations for an export file, so that client-specific properties are stripped out.

### Testing

You can follow the same "testing steps" described in https://github.com/hypothesis/client/pull/5642, and check that downloaded file now includes no client-specific properties.

> **Note**
> I have tried my best to make `stripInternalProperties` have better types, trying to infer input and output, but couldn't get a working version that didn't require casting the type somewhere, so I thought it was reasonable to leave `... as Annotation[]` when invoked from the `AnnotationsExporter`.
> I event tried ChatGPT to get me something that worked, but it also failed or was too naive 😅 