### PR TITLE
Add `MediaTimeSelector` selectors and associated anchoring logic

### DIFF
--- a/src/annotator/anchoring/test/html-test.js
+++ b/src/annotator/anchoring/test/html-test.js
@@ -371,6 +371,30 @@ describe('HTML anchoring', () => {
     });
   });
 
+  it('anchors "MediaTimeSelector" selectors', async () => {
+    const container = document.createElement('div');
+    container.innerHTML = `<p data-time-start="0" data-time-end="10">One</p>
+<p data-time-start="10" data-time-end="20">Two</p>`;
+    const range = new Range();
+    range.setStart(container.querySelector('p').firstChild, 0);
+    range.setEnd(container.querySelector('p:nth-of-type(2)').firstChild, 3);
+
+    const selectors = html.describe(container, range);
+
+    const mediaTimeSelector = selectors.find(
+      s => s.type === 'MediaTimeSelector'
+    );
+    assert.ok(mediaTimeSelector);
+    assert.deepEqual(mediaTimeSelector, {
+      type: 'MediaTimeSelector',
+      start: 0,
+      end: 20,
+    });
+
+    const anchored = await html.anchor(container, [mediaTimeSelector]);
+    assert.equal(anchored.toString(), 'One\nTwo');
+  });
+
   describe('When anchoring fails', () => {
     const validQuoteSelector = {
       type: 'TextQuoteSelector',

--- a/src/annotator/anchoring/test/types-test.js
+++ b/src/annotator/anchoring/test/types-test.js
@@ -1,5 +1,8 @@
+import { render } from 'preact';
+
 import { TextRange } from '../text-range';
 import {
+  MediaTimeAnchor,
   RangeAnchor,
   TextPositionAnchor,
   TextQuoteAnchor,
@@ -446,6 +449,142 @@ describe('annotator/anchoring/types', () => {
 
         const newRange = anchor.toRange();
         assert.equal(newRange.toString(), 'Four');
+      });
+    });
+  });
+
+  describe('MediaTimeAnchor', () => {
+    function createTranscript() {
+      const container = document.createElement('div');
+      render(
+        <article>
+          <p data-time-start="0" data-time-end="2.2">
+            First segment.
+          </p>
+          <p data-time-start="2.2" data-time-end="5.6">
+            Second segment.
+          </p>
+          <p data-time-start="5.6" data-time-end="10.02">
+            Third segment.
+          </p>
+          <p data-time-start="invalid" data-time-end="12">
+            Invalid one
+          </p>
+          <p data-time-start="12" data-time-end="invalid">
+            Invalid two
+          </p>
+        </article>,
+        container
+      );
+      return container;
+    }
+
+    function createRange(
+      container,
+      startPara,
+      startOffset,
+      endPara,
+      endOffset
+    ) {
+      const range = new Range();
+      range.setStart(
+        container.querySelector(`p:nth-of-type(${startPara + 1})`).firstChild,
+        startOffset
+      );
+      range.setEnd(
+        container.querySelector(`p:nth-of-type(${endPara + 1})`).firstChild,
+        endOffset
+      );
+      return range;
+    }
+
+    describe('#fromRange', () => {
+      it('can convert a range to a selector', () => {
+        const container = createTranscript();
+        const range = createRange(container, 0, 6, 1, 5);
+
+        const anchor = MediaTimeAnchor.fromRange(container, range);
+        assert.isNotNull(anchor);
+        const selector = anchor.toSelector();
+
+        assert.deepEqual(selector, {
+          type: 'MediaTimeSelector',
+          start: 0,
+          end: 5.6,
+        });
+      });
+
+      function replaceAttr(elem, attr, val) {
+        if (val === null) {
+          elem.removeAttribute(attr);
+        } else {
+          elem.setAttribute(attr, val);
+        }
+      }
+
+      [null, '', 'abc', '-2'].forEach(startAttr => {
+        it('returns `null` if start time is missing or invalid', () => {
+          const container = createTranscript();
+          const range = createRange(container, 0, 6, 1, 5);
+
+          replaceAttr(
+            range.startContainer.parentElement,
+            'data-time-start',
+            startAttr
+          );
+          const anchor = MediaTimeAnchor.fromRange(container, range);
+
+          assert.isNull(anchor);
+        });
+      });
+
+      [null, '', 'abc', '-2'].forEach(endAttr => {
+        it('returns `null` if end time is missing or invalid', () => {
+          const container = createTranscript();
+          const range = createRange(container, 0, 6, 1, 5);
+
+          replaceAttr(
+            range.endContainer.parentElement,
+            'data-time-end',
+            endAttr
+          );
+          const anchor = MediaTimeAnchor.fromRange(container, range);
+
+          assert.isNull(anchor);
+        });
+      });
+    });
+
+    describe('#toRange', () => {
+      it('can convert a selector to a range', () => {
+        const container = createTranscript();
+        const selector = {
+          type: 'MediaTimeSelector',
+          start: 0,
+          end: 5.6,
+        };
+        const range = MediaTimeAnchor.fromSelector(
+          container,
+          selector
+        ).toRange();
+        assert.equal(range.toString(), 'First segment.Second segment.');
+      });
+
+      [
+        { start: 20, end: 22, error: 'Start segment not found' },
+        { start: 0, end: -1, error: 'End segment not found' },
+      ].forEach(({ start, end, error }) => {
+        it('throws error if elements with matching time ranges are not found', () => {
+          const container = createTranscript();
+          const selector = {
+            type: 'MediaTimeSelector',
+            start,
+            end,
+          };
+          assert.throws(() => {
+            MediaTimeAnchor.fromSelector(container, selector).toRange();
+          }, error);
+        });
       });
     });
   });

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -38,6 +38,19 @@ export type IndexResponse = {
 export type LinksResponse = Record<string, string>;
 
 /**
+ * Selector which indicates the time range within a video or audio file that
+ * an annotation refers to.
+ */
+export type MediaTimeSelector = {
+  type: 'MediaTimeSelector';
+
+  /** Offset from start of media in seconds. */
+  start: number;
+  /** Offset from start of media in seconds. */
+  end: number;
+};
+
+/**
  * Selector which identifies a document region using the selected text plus
  * the surrounding context.
  */
@@ -127,6 +140,7 @@ export type Selector =
   | TextPositionSelector
   | RangeSelector
   | EPUBContentSelector
+  | MediaTimeSelector
   | PageSelector;
 
 /**


### PR DESCRIPTION
Add a `MediaTimeSelector` selector that represents the time range in a piece of media which an annotation refers to, expressed as seconds since the start of the media.

For annotations of audio and videos, this can be used for several purposes:

- To display the time range that an annotation refers to in various contexts, including those where the transcript is not available
- To enable anchoring to be robust to changes in the transcript. For example if a user annotates a transcript with significant errors and that transcript is later replaced with a different one, the client can still locate the time range that the annotation refers to.

In order to capture media time selectors, the application presenting the transcript must add `data-time-start` and `data-time-end` attributes to each segment of the transcript, where the values are offsets in seconds since the start of the media. When the user creates an annotation, the client will capture this information in a selector that looks like:

```json
{
  "type": "MediaTimeSelector",
  "start": 65,
  "end": 122.05
}
```

When anchoring, the client will first try text-based anchors. If those fail, but a media time selector has been captured, and the HTML contains `data-time-{start, end}` attributes, the client will anchor annotations to the complete text of the segments whose time ranges span the `start` and `end` times from the media time selector.

Part of https://github.com/hypothesis/via/issues/941

----

**Limitations:**

- It is assumed that time information is always expressed as an offset from the start of the media. If we ever support ongoing live media in future, we might have to generalize these selectors to support eg. ISO timestamps instead.
- It is assumed that the page contains exactly one set of elements with `data-time-*` attributes. If there are scenarios in future where a document contains multiple audio or video files, some additional work will be needed to pick the right transcript.

**Testing:**

1. Check out this branch in the client and https://github.com/hypothesis/via/pull/1116 in Via
2. Open a video in Via and create some new annotations
3. Apply the diff below to disable anchoring using text-based selectors, to simulate a major change to the transcript's text
4. Reload the video
5. Un-do the diff below, and reload the video

When use of text-based selectors is disabled, the client will now fall back to highlighting the video segments that were annotated, based on the media time information. When use of text-based selectors is enabled, they will be used as before.

```diff
diff --git a/src/annotator/anchoring/html.ts b/src/annotator/anchoring/html.ts
index 8845b7e3b..f7129d50c 100644
--- a/src/annotator/anchoring/html.ts
+++ b/src/annotator/anchoring/html.ts
@@ -46,16 +46,16 @@ export function anchor(
   // Collect all the selectors
   for (const selector of selectors) {
     switch (selector.type) {
-      case 'TextPositionSelector':
-        position = selector;
-        options.hint = position.start; // TextQuoteAnchor hint
-        break;
-      case 'TextQuoteSelector':
-        quote = selector;
-        break;
-      case 'RangeSelector':
-        range = selector;
-        break;
+      // case 'TextPositionSelector':
+      //   position = selector;
+      //   options.hint = position.start; // TextQuoteAnchor hint
+      //   break;
+      // case 'TextQuoteSelector':
+      //   quote = selector;
+      //   break;
+      // case 'RangeSelector':
+      //   range = selector;
+      //   break;
       case 'MediaTimeSelector':
         mediaTime = selector;
         break;
```