### PR TITLE
Prepare `ShareAnnotationsPanel` for tabbed dialog (Export tab)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.16.7",
     "@hypothesis/frontend-build": "^2.0.0",
-    "@hypothesis/frontend-shared": "^6.4.0",
+    "@hypothesis/frontend-shared": "^6.5.0",
     "@npmcli/arborist": "^6.1.1",
     "@octokit/rest": "^20.0.1",
     "@rollup/plugin-babel": "^6.0.0",

--- a/src/sidebar/components/ShareAnnotationsPanel.tsx
+++ b/src/sidebar/components/ShareAnnotationsPanel.tsx
@@ -53,7 +53,11 @@ function ShareAnnotationsPanel({ toastMessenger }: ShareAnnotationPanelProps) {
   };
 
   return (
-    <SidebarPanel title={panelTitle} panelName="shareGroupAnnotations">
+    <SidebarPanel
+      title={panelTitle}
+      panelName="shareGroupAnnotations"
+      variant="custom"
+    >
       {!sharingReady && (
         <div className="flex flex-row items-center justify-center">
           <Spinner size="md" />

--- a/src/sidebar/components/ShareAnnotationsPanel.tsx
+++ b/src/sidebar/components/ShareAnnotationsPanel.tsx
@@ -6,6 +6,7 @@ import {
   LockIcon,
   Spinner,
 } from '@hypothesis/frontend-shared';
+import { useCallback } from 'preact/hooks';
 
 import { pageSharingLink } from '../helpers/annotation-sharing';
 import { withServices } from '../service-context';
@@ -19,6 +20,98 @@ export type ShareAnnotationPanelProps = {
   // injected
   toastMessenger: ToastMessengerService;
 };
+
+type SharePanelContentProps = {
+  loading: boolean;
+  shareURI?: string | null;
+  /** Callback for when "copy URL" button is clicked */
+  onCopyShareLink: () => void;
+  groupName?: string;
+  groupType?: string;
+};
+
+/**
+ * Render content for "share" panel or tab
+ */
+function SharePanelContent({
+  groupName,
+  groupType,
+  loading,
+  onCopyShareLink,
+  shareURI,
+}: SharePanelContentProps) {
+  if (loading) {
+    return (
+      <div className="flex flex-row items-center justify-center">
+        <Spinner size="md" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-color-text-light space-y-3">
+      {shareURI ? (
+        <>
+          <div
+            className="text-color-text font-medium"
+            data-testid="sharing-intro"
+          >
+            {groupType === 'private' ? (
+              <p>
+                Use this link to share these annotations with other group
+                members:
+              </p>
+            ) : (
+              <p>Use this link to share these annotations with anyone:</p>
+            )}
+          </div>
+          <div>
+            <InputGroup>
+              <Input
+                aria-label="Use this URL to share these annotations"
+                type="text"
+                value={shareURI}
+                readOnly
+              />
+              <IconButton
+                icon={CopyIcon}
+                onClick={onCopyShareLink}
+                title="Copy share link"
+                variant="dark"
+              />
+            </InputGroup>
+          </div>
+          <p data-testid="sharing-details">
+            {groupType === 'private' ? (
+              <span>
+                Annotations in the private group <em>{groupName}</em> are only
+                visible to group members.
+              </span>
+            ) : (
+              <span>
+                Anyone using this link may view the annotations in the group{' '}
+                <em>{groupName}</em>.
+              </span>
+            )}{' '}
+            <span>
+              Private (
+              <LockIcon className="inline w-em h-em ml-0.5 -mt-0.5" />{' '}
+              <em>Only Me</em>) annotations are only visible to you.
+            </span>
+          </p>
+          <div className="text-[24px]">
+            <ShareLinks shareURI={shareURI} />
+          </div>
+        </>
+      ) : (
+        <p data-testid="no-sharing">
+          These annotations cannot be shared because this document is not
+          available on the web.
+        </p>
+      )}
+    </div>
+  );
+}
 
 /**
  * A panel for sharing the current group's annotations on the current document.
@@ -41,7 +134,7 @@ function ShareAnnotationsPanel({ toastMessenger }: ShareAnnotationPanelProps) {
   const shareURI =
     sharingReady && pageSharingLink(mainFrame.uri, focusedGroup.id);
 
-  const copyShareLink = () => {
+  const copyShareLink = useCallback(() => {
     try {
       if (shareURI) {
         copyText(shareURI);
@@ -50,83 +143,17 @@ function ShareAnnotationsPanel({ toastMessenger }: ShareAnnotationPanelProps) {
     } catch (err) {
       toastMessenger.error('Unable to copy link');
     }
-  };
+  }, [shareURI, toastMessenger]);
 
   return (
-    <SidebarPanel
-      title={panelTitle}
-      panelName="shareGroupAnnotations"
-      variant="custom"
-    >
-      {!sharingReady && (
-        <div className="flex flex-row items-center justify-center">
-          <Spinner size="md" />
-        </div>
-      )}
-      {sharingReady && (
-        <div className="text-color-text-light space-y-3">
-          {shareURI ? (
-            <>
-              <div
-                className="text-color-text font-medium"
-                data-testid="sharing-intro"
-              >
-                {focusedGroup!.type === 'private' ? (
-                  <p>
-                    Use this link to share these annotations with other group
-                    members:
-                  </p>
-                ) : (
-                  <p>Use this link to share these annotations with anyone:</p>
-                )}
-              </div>
-              <div>
-                <InputGroup>
-                  <Input
-                    aria-label="Use this URL to share these annotations"
-                    type="text"
-                    value={shareURI}
-                    readOnly
-                  />
-                  <IconButton
-                    icon={CopyIcon}
-                    onClick={copyShareLink}
-                    title="Copy share link"
-                    variant="dark"
-                  />
-                </InputGroup>
-              </div>
-              <p data-testid="sharing-details">
-                {focusedGroup!.type === 'private' ? (
-                  <span>
-                    Annotations in the private group{' '}
-                    <em>{focusedGroup.name}</em> are only visible to group
-                    members.
-                  </span>
-                ) : (
-                  <span>
-                    Anyone using this link may view the annotations in the group{' '}
-                    <em>{focusedGroup.name}</em>.
-                  </span>
-                )}{' '}
-                <span>
-                  Private (
-                  <LockIcon className="inline w-em h-em ml-0.5 -mt-0.5" />{' '}
-                  <em>Only Me</em>) annotations are only visible to you.
-                </span>
-              </p>
-              <div className="text-[24px]">
-                <ShareLinks shareURI={shareURI} />
-              </div>
-            </>
-          ) : (
-            <p data-testid="no-sharing">
-              These annotations cannot be shared because this document is not
-              available on the web.
-            </p>
-          )}
-        </div>
-      )}
+    <SidebarPanel title={panelTitle} panelName="shareGroupAnnotations">
+      <SharePanelContent
+        groupName={focusedGroup?.name}
+        groupType={focusedGroup?.type}
+        loading={!sharingReady}
+        onCopyShareLink={copyShareLink}
+        shareURI={shareURI}
+      />
     </SidebarPanel>
   );
 }

--- a/src/sidebar/components/SidebarPanel.tsx
+++ b/src/sidebar/components/SidebarPanel.tsx
@@ -20,6 +20,8 @@ export type SidebarPanelProps = {
   title: string;
   /** Optional callback to invoke when this panel's active status changes */
   onActiveChanged?: (active: boolean) => void;
+  /** What Dialog variant to use */
+  variant?: 'panel' | 'custom';
 };
 
 /**
@@ -31,6 +33,7 @@ export default function SidebarPanel({
   icon,
   panelName,
   title,
+  variant = 'panel',
   onActiveChanged,
 }: SidebarPanelProps) {
   const store = useSidebarStore();
@@ -65,6 +68,7 @@ export default function SidebarPanel({
           icon={icon}
           onClose={closePanel}
           transitionComponent={Slider}
+          variant={variant}
         >
           {children}
         </Dialog>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1819,15 +1819,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^6.4.0":
-  version: 6.4.0
-  resolution: "@hypothesis/frontend-shared@npm:6.4.0"
+"@hypothesis/frontend-shared@npm:^6.5.0":
+  version: 6.5.0
+  resolution: "@hypothesis/frontend-shared@npm:6.5.0"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^2.10.0-alpha.1
   peerDependencies:
     preact: ^10.4.0
-  checksum: f417c7fcde5661a5381e3411cfaca9de6ccf0379cc38d5ba1013dbd1d7bd8e665cbb075c1e96fb2069c5b21696a3240d33f12c0615fcaa5f7b6b9fbf0f6ad54a
+  checksum: 1f333a627c6057beb9d475c5ba3bf4db7ecaaaba39656486817c0f31d3d37e95ed695659f680747710cd83881cf56a56c8b8e267226141753377977ae59da1e7
   languageName: node
   linkType: hard
 
@@ -6824,7 +6824,7 @@ __metadata:
     "@babel/preset-react": ^7.0.0
     "@babel/preset-typescript": ^7.16.7
     "@hypothesis/frontend-build": ^2.0.0
-    "@hypothesis/frontend-shared": ^6.4.0
+    "@hypothesis/frontend-shared": ^6.5.0
     "@npmcli/arborist": ^6.1.1
     "@octokit/rest": ^20.0.1
     "@rollup/plugin-babel": ^6.0.0


### PR DESCRIPTION
This utility PR performs some internal refactor on `ShareAnnotationsPanel` and extends `SidebarPanel` to pass through a `variant` prop to `Dialog`[^1]. These steps are to prepare for a tabbed-dialog variant of the share panel (we'll be adding an Export tab for users with the associated feature flag enabled). We still need to be able to use the current non-tabbed variant for users without the flag enabled, so a little pre-cleanup was in order.

There are no functional or user-facing changes here.

Part of https://github.com/hypothesis/client/issues/5618

[^1]: `@hypothesis/frontend-shared` is bumped in this PR to get updated `Dialog` with the `variant` prop.