### PR TITLE
Define server-only Annotation type

### DIFF
--- a/src/sidebar/services/annotations.ts
+++ b/src/sidebar/services/annotations.ts
@@ -77,10 +77,8 @@ export class AnnotationsService {
     // We need a unique local/app identifier for this new annotation such
     // that we might look it up later in the store. It won't have an ID yet,
     // as it has not been persisted to the service.
-    const $tag = 's:' + generateHexString(8);
-
-    /** @type {Annotation} */
-    const annotation = Object.assign(
+    const $tag = `s:${generateHexString(8)}`;
+    const annotation: Annotation = Object.assign(
       {
         created: now.toISOString(),
         group: groupid,

--- a/src/types/annotator.ts
+++ b/src/types/annotator.ts
@@ -1,6 +1,6 @@
 import type { TinyEmitter } from 'tiny-emitter';
 
-import type { Annotation, Selector, Target } from './api';
+import type { APIAnnotationData, Selector, Target } from './api';
 import type { ClientAnnotationData } from './shared';
 
 /**
@@ -66,7 +66,7 @@ export type SegmentInfo = {
  * the document.
  */
 export type AnnotationData = ClientAnnotationData &
-  Pick<Annotation, 'target' | 'uri'> & {
+  Pick<APIAnnotationData, 'target' | 'uri'> & {
     document?: DocumentMetadata;
   };
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -144,20 +144,12 @@ export type UserInfo = {
   display_name: string | null;
 };
 
-export type Annotation = ClientAnnotationData & {
+export type APIAnnotationData = {
   /**
    * The server-assigned ID for the annotation. This is only set once the
    * annotation has been saved to the backend.
    */
   id?: string;
-
-  /**
-   * A locally-generated unique identifier for annotations.
-   *
-   * This is set for all annotations, whether they have been saved to the
-   * backend or not.
-   */
-  $tag: string;
 
   references?: string[];
   created: string;
@@ -204,6 +196,8 @@ export type Annotation = ClientAnnotationData & {
 
   user_info?: UserInfo;
 };
+
+export type Annotation = ClientAnnotationData & APIAnnotationData;
 
 /**
  * An annotation which has been saved to the backend and assigned an ID.

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -13,6 +13,7 @@ export type HighlightCluster =
  */
 export type ClientAnnotationData = {
   $cluster?: HighlightCluster;
+
   /**
    * Client-side identifier: set even if annotation does not have a
    * server-provided `id` (i.e. is unsaved)


### PR DESCRIPTION
This PR adds a couple of changes on annotation type definitions:

* There's now an exported server-only type called ~`ServerAnnotationData`~ `APIAnnotationData`. It represents the annotation as documented in https://h.readthedocs.io/en/latest/api-reference/v2/, but keeping the `id` as optional, since that is an annotation in the client that has not been saved yet.
* The `$tag` property is now defined in `ClientAnnotationData` only. It was previously in the "server" part as well. My assumption is that it was there for historical reasons but not actually needed.
* The `Annotation` type is a combination of ~`ServerAnnotationData`~ `APIAnnotationData` and `ClientAnnotationData`.

The changes are backwards compatible, as the resulting types are effectively the same, but having a type that represents the server annotation will allow for type-safe clean-ups for annotation exports.

### Considerations

~I'm not sure if `ServerAnnotationData` is the best name. I also considered `APIAnnotation`, or something in those lines. I'm open to suggestions here.~

Decision is to use `APIAnnotationData`: https://github.com/hypothesis/client/pull/5658#discussion_r1273394510

> This PR is part of https://github.com/hypothesis/client/issues/5640