### PR TITLE
Add Export tab to `ShareAnnotationsPanel` when export feature flag on

### DIFF
--- a/src/shared/components/BaseToastMessages.tsx
+++ b/src/shared/components/BaseToastMessages.tsx
@@ -86,7 +86,12 @@ export default function BaseToastMessages({
       <ul
         aria-live="polite"
         aria-relevant="additions"
-        className="absolute z-2 left-0 w-full"
+        className={classnames(
+          // Set an aggressive z-index as we want to ensure toast messages are
+          // rendered above other content
+          'z-10',
+          'absolute left-0 w-full'
+        )}
       >
         {messages.map(message => (
           <li


### PR DESCRIPTION
This PR converts the `ShareAnnotationsPanel` to a tabbed interface, with an Export tab, when the `export_annotations` feature flag is enabled. When not enabled, the interface looks and behaves as before.

To put this work in context, it is part of these steps:

1. Establish code path to switch between tabbed and non-tabbed dialogs for the share panel. Establish basic Export tab content (non-functional). <-- This work.
2. Decompose `ShareAnnotationsPanel` into constituent components <-- Next.
3. Make Export tab function <-- after that.

As such, the `ShareAnnotationsPanel` component in this changeset is quite long. I've ensured that test coverage is sufficient, but tests will presumably be refactored and split up in the next set of work, also. You'll see some TODOs. But I wanted to keep this diff from getting unpleasantly huge.

I will be embarking on step 2 immediately.

## Testing

Running this branch, click on the "Share" icon in the top bar. The share-annotations panel should appear as it always has, non-tabbed.

Now, go to http://localhost:5000/admin/features and enable the `export_annotations` feature flag (ensure you have pulled changes from `h` reasonably recently so that feature flag shows up).

Now, go back to the local dev area for the client and click on the Share icon in the top bar. You should see:

<img width="426" alt="image" src="https://github.com/hypothesis/client/assets/439947/04aad538-5874-4198-b051-28083cd3926e">

If you click on the copy-URL button, you should verify that the toast message is not obscured by the tabs (I had to fix this regression. This style of tabs need a little bit of z-index to render "in front of" the Card they correspond to, but should still be "behind" the toast messages).

If you click on the Export tab, you should see something like:

<img width="426" alt="image" src="https://github.com/hypothesis/client/assets/439947/800005f7-fb08-4838-95b0-9bf2b41c7fc3">

The count of annotations is real-ish. The other UI elements are non-functional/placeholder for now.

If you click on the close button, you should see an exit transition.

With the Export tab selected, try switching to different groups in the groups menu. While loading, you should see a loading indicator. Try throttling your network if you want to slow it down.

Part of #5618