### PR TITLE
Exclude draft annotations from annotations export

### DIFF
--- a/src/sidebar/services/test/annotations-exporter-test.js
+++ b/src/sidebar/services/test/annotations-exporter-test.js
@@ -1,4 +1,7 @@
-import { publicAnnotation } from '../../test/annotation-fixtures';
+import {
+  newAnnotation,
+  publicAnnotation,
+} from '../../test/annotation-fixtures';
 import { AnnotationsExporter } from '../annotations-exporter';
 
 describe('AnnotationsExporter', () => {
@@ -17,6 +20,7 @@ describe('AnnotationsExporter', () => {
     const now = new Date();
     const firstBaseAnnotation = publicAnnotation();
     const secondBaseAnnotation = publicAnnotation();
+    const draftAnnotation = newAnnotation();
     const annotations = [
       {
         ...firstBaseAnnotation,
@@ -26,16 +30,22 @@ describe('AnnotationsExporter', () => {
         ...secondBaseAnnotation,
         $highlight: true,
       },
+
+      // These two annotations will be excluded from the export, as they don't
+      // have an id, which means they have not been saved yet
+      draftAnnotation,
+      draftAnnotation,
     ];
     fakeStore.allAnnotations.returns(annotations);
 
-    const result = exporter.buildExportContent(now);
+    const { content, excludedAnnotations } = exporter.buildExportContent(now);
 
-    assert.deepEqual(result, {
+    assert.deepEqual(content, {
       export_date: now.toISOString(),
       export_userid: 'userId',
       client_version: '__VERSION__',
       annotations: [firstBaseAnnotation, secondBaseAnnotation],
     });
+    assert.equal(excludedAnnotations, 2);
   });
 });


### PR DESCRIPTION
This PR extends the `AnnotationsExporter` to:

* Exclude annotations with no `id` from the export. These annotations are known by the client only, and have not been saved yet.
* Evolve the `AnnotationsExporter.buildExportContent` method, so that it returns the contents to export and the amount of annotations that were excluded, so that we can eventually tell the user.

### Testing steps

Apply this diff to the branch:

```diff
diff --git a/src/sidebar/components/SelectionTabs.tsx b/src/sidebar/components/SelectionTabs.tsx
index 5429a086e..d4c0a835a 100644
--- a/src/sidebar/components/SelectionTabs.tsx
+++ b/src/sidebar/components/SelectionTabs.tsx
@@ -9,11 +9,13 @@ import {
 import classnames from 'classnames';
 import type { ComponentChildren } from 'preact';
 
+import { downloadJSONFile } from '../../shared/download-json-file';
 import type { SidebarSettings } from '../../types/config';
 import type { TabName } from '../../types/sidebar';
 import { applyTheme } from '../helpers/theme';
 import { withServices } from '../service-context';
 import type { AnnotationsService } from '../services/annotations';
+import type { AnnotationsExporter } from '../services/annotations-exporter';
 import { useSidebarStore } from '../store';
 
 type TabProps = {
@@ -89,6 +91,7 @@ export type SelectionTabProps = {
   // injected
   settings: SidebarSettings;
   annotationsService: AnnotationsService;
+  annotationsExporter: AnnotationsExporter;
 };
 
 /**
@@ -96,6 +99,7 @@ export type SelectionTabProps = {
  */
 function SelectionTabs({
   annotationsService,
+  annotationsExporter,
   isLoading,
   settings,
 }: SelectionTabProps) {
@@ -126,6 +130,14 @@ function SelectionTabs({
       )}
     >
       <div className="flex gap-x-6 theme-clean:ml-[15px]" role="tablist">
+        <button
+          onClick={() => {
+            const { content } = annotationsExporter.buildExportContent();
+            downloadJSONFile(content, 'annotations-export.json');
+          }}
+        >
+          Export
+        </button>
         <Tab
           count={annotationCount}
           isWaitingToAnchor={isWaitingToAnchorAnnotations}
@@ -199,4 +211,8 @@ function SelectionTabs({
   );
 }
 
-export default withServices(SelectionTabs, ['annotationsService', 'settings']);
+export default withServices(SelectionTabs, [
+  'annotationsService',
+  'annotationsExporter',
+  'settings',
+]);
```

This will add an "Export" button to the top of the sidebar, which will generate the export file with existing annotations.

If you try to create a new nnotation and click "Export" before saving, this annotation should not be included in the export file. In `main` branch, it would be included.

> This PR is part of https://github.com/hypothesis/client/issues/5661