### PR TITLE
Refactor AnnotationsExporter to receive the annotations list

### DIFF
--- a/src/sidebar/services/annotations-exporter.ts
+++ b/src/sidebar/services/annotations-exporter.ts
@@ -1,4 +1,4 @@
-import type { APIAnnotationData } from '../../types/api';
+import type { Annotation, APIAnnotationData } from '../../types/api';
 import { stripInternalProperties } from '../helpers/strip-internal-properties';
 import { VersionData } from '../helpers/version-data';
 import type { SidebarStore } from '../store';
@@ -22,21 +22,21 @@ export class AnnotationsExporter {
     this._store = store;
   }
 
-  /**
-   * @param now - Test seam
-   */
-  buildExportContent(now = new Date()): ExportContent {
+  buildExportContent(
+    annotations: Annotation[],
+    /* istanbul ignore next - test seam */
+    now = new Date()
+  ): ExportContent {
     const profile = this._store.profile();
-    const annotations = this._store
-      .allAnnotations()
-      .map(stripInternalProperties) as APIAnnotationData[];
     const versionData = new VersionData(profile, []);
 
     return {
       export_date: now.toISOString(),
       export_userid: profile.userid ?? '',
       client_version: versionData.version,
-      annotations,
+      annotations: annotations.map(
+        stripInternalProperties
+      ) as APIAnnotationData[],
     };
   }
 }

--- a/src/sidebar/services/test/annotations-exporter-test.js
+++ b/src/sidebar/services/test/annotations-exporter-test.js
@@ -8,7 +8,6 @@ describe('AnnotationsExporter', () => {
   beforeEach(() => {
     fakeStore = {
       profile: sinon.stub().returns({ userid: 'userId' }),
-      allAnnotations: sinon.stub(),
     };
     exporter = new AnnotationsExporter(fakeStore);
   });
@@ -27,9 +26,8 @@ describe('AnnotationsExporter', () => {
         $highlight: true,
       },
     ];
-    fakeStore.allAnnotations.returns(annotations);
 
-    const result = exporter.buildExportContent(now);
+    const result = exporter.buildExportContent(annotations, now);
 
     assert.deepEqual(result, {
       export_date: now.toISOString(),


### PR DESCRIPTION
On the first iteration we discussed if the annotations to be exported should be passed to the `AnnotationsExporter`, or if it should be smart enough to resolve them.

Initially we went with the second option, but after more iterations (see https://github.com/hypothesis/client/issues/5661), it has been made clear to us that the responsibility to resolve the annotations to export should be on consumers.

This gives more flexibility to determine which annotations should be exported on every situation, to allow filtering logic to be applied, and to always know which annotations will **not** be exported and why.

Trying to handle all possible cases internally would make it too complex to maintain.