### PR TITLE
Recompose `ShareAnnotationsPanel` => `ShareDialog`, Part 1

### DIFF
--- a/src/sidebar/components/HypothesisApp.tsx
+++ b/src/sidebar/components/HypothesisApp.tsx
@@ -16,7 +16,7 @@ import AnnotationView from './AnnotationView';
 import HelpPanel from './HelpPanel';
 import NotebookView from './NotebookView';
 import ProfileView from './ProfileView';
-import ShareAnnotationsPanel from './ShareAnnotationsPanel';
+import ShareDialog from './ShareDialog';
 import SidebarView from './SidebarView';
 import StreamView from './StreamView';
 import ToastMessages from './ToastMessages';
@@ -160,7 +160,7 @@ function HypothesisApp({
       <div className="container">
         <ToastMessages />
         <HelpPanel />
-        <ShareAnnotationsPanel />
+        <ShareDialog />
 
         {route && (
           <main>

--- a/src/sidebar/components/ShareDialog/LoadingSpinner.tsx
+++ b/src/sidebar/components/ShareDialog/LoadingSpinner.tsx
@@ -1,0 +1,16 @@
+import { Spinner } from '@hypothesis/frontend-shared';
+
+/**
+ * Render a consistently sized and positioned loading spinner for dialog or
+ * tab content
+ */
+export default function LoadingSpinner() {
+  return (
+    <div
+      className="flex flex-row items-center justify-center"
+      data-testid="loading-spinner"
+    >
+      <Spinner size="md" />
+    </div>
+  );
+}

--- a/src/sidebar/components/ShareDialog/ShareDialog.tsx
+++ b/src/sidebar/components/ShareDialog/ShareDialog.tsx
@@ -9,7 +9,6 @@ import {
   Input,
   InputGroup,
   LockIcon,
-  Spinner,
   TabList,
   Tab,
 } from '@hypothesis/frontend-shared';
@@ -24,17 +23,7 @@ import { useSidebarStore } from '../../store';
 import { copyText } from '../../util/copy-to-clipboard';
 import ShareLinks from '../ShareLinks';
 import SidebarPanel from '../SidebarPanel';
-
-function LoadingSpinner() {
-  return (
-    <div
-      className="flex flex-row items-center justify-center"
-      data-testid="loading-spinner"
-    >
-      <Spinner size="md" />
-    </div>
-  );
-}
+import LoadingSpinner from './LoadingSpinner';
 
 /**
  * Render a header to go above a Card, with contents in a TabList

--- a/src/sidebar/components/ShareDialog/ShareDialog.tsx
+++ b/src/sidebar/components/ShareDialog/ShareDialog.tsx
@@ -17,13 +17,13 @@ import classnames from 'classnames';
 import type { ComponentChildren, JSX } from 'preact';
 import { useCallback, useState } from 'preact/hooks';
 
-import { pageSharingLink } from '../helpers/annotation-sharing';
-import { withServices } from '../service-context';
-import type { ToastMessengerService } from '../services/toast-messenger';
-import { useSidebarStore } from '../store';
-import { copyText } from '../util/copy-to-clipboard';
-import ShareLinks from './ShareLinks';
-import SidebarPanel from './SidebarPanel';
+import { pageSharingLink } from '../../helpers/annotation-sharing';
+import { withServices } from '../../service-context';
+import type { ToastMessengerService } from '../../services/toast-messenger';
+import { useSidebarStore } from '../../store';
+import { copyText } from '../../util/copy-to-clipboard';
+import ShareLinks from '../ShareLinks';
+import SidebarPanel from '../SidebarPanel';
 
 function LoadingSpinner() {
   return (
@@ -213,7 +213,7 @@ function ExportPanelContent({
   );
 }
 
-export type ShareAnnotationPanelProps = {
+export type ShareDialogProps = {
   // injected
   toastMessenger: ToastMessengerService;
 };
@@ -225,7 +225,7 @@ export type ShareAnnotationPanelProps = {
  * are on the current page (as defined by the main frame's URI) and contained
  * within the app's currently-focused group.
  */
-function ShareAnnotationsPanel({ toastMessenger }: ShareAnnotationPanelProps) {
+function ShareDialog({ toastMessenger }: ShareDialogProps) {
   const store = useSidebarStore();
   const mainFrame = store.mainFrame();
   const focusedGroup = store.focusedGroup();
@@ -329,4 +329,4 @@ function ShareAnnotationsPanel({ toastMessenger }: ShareAnnotationPanelProps) {
   );
 }
 
-export default withServices(ShareAnnotationsPanel, ['toastMessenger']);
+export default withServices(ShareDialog, ['toastMessenger']);

--- a/src/sidebar/components/ShareDialog/ShareDialog.tsx
+++ b/src/sidebar/components/ShareDialog/ShareDialog.tsx
@@ -2,18 +2,13 @@ import {
   Button,
   Card,
   CardActions,
-  CardTitle,
-  CloseButton,
   CopyIcon,
   IconButton,
   Input,
   InputGroup,
   LockIcon,
-  TabList,
   Tab,
 } from '@hypothesis/frontend-shared';
-import classnames from 'classnames';
-import type { ComponentChildren, JSX } from 'preact';
 import { useCallback, useState } from 'preact/hooks';
 
 import { pageSharingLink } from '../../helpers/annotation-sharing';
@@ -24,63 +19,8 @@ import { copyText } from '../../util/copy-to-clipboard';
 import ShareLinks from '../ShareLinks';
 import SidebarPanel from '../SidebarPanel';
 import LoadingSpinner from './LoadingSpinner';
-
-/**
- * Render a header to go above a Card, with contents in a TabList
- */
-function TabHeader({ children }: { children: ComponentChildren }) {
-  return (
-    <div data-testid="tab-header" className="flex items-center">
-      <CloseButton
-        classes={classnames(
-          // This element comes first in source order before tabs, but is
-          // positioned last. This puts this button earlier in the tab
-          // sequence than the tabs, allowing tabs to be immediately adjacent
-          // to their controlled tab panels/tab content in the tab sequence.
-          'order-last',
-          // Always render this button at 16px square regardless of parent
-          // font size
-          'text-[16px]',
-          'text-grey-6 hover:text-grey-7 hover:bg-grey-3/50'
-        )}
-        title="Close"
-        variant="custom"
-        size="sm"
-      />
-      <TabList classes="grow gap-x-1 -mb-[1px] z-2">{children}</TabList>
-    </div>
-  );
-}
-
-type TabPanelProps = {
-  active?: boolean;
-  title?: ComponentChildren;
-} & JSX.HTMLAttributes<HTMLDivElement>;
-
-/**
- * Render a `role="tabpanel"` element within a Card layout. It will be
- * visually hidden unless `active`.
- */
-function TabPanel({
-  children,
-  active,
-  title,
-  ...htmlAttributes
-}: TabPanelProps) {
-  return (
-    <div
-      role="tabpanel"
-      {...htmlAttributes}
-      className={classnames('p-3 focus-visible-ring ring-inset', {
-        hidden: !active,
-      })}
-      hidden={!active}
-    >
-      {title && <CardTitle>{title}</CardTitle>}
-      <div className="space-y-3 pt-2">{children}</div>
-    </div>
-  );
-}
+import TabHeader from './TabHeader';
+import TabPanel from './TabPanel';
 
 type SharePanelContentProps = {
   loading: boolean;

--- a/src/sidebar/components/ShareDialog/TabHeader.tsx
+++ b/src/sidebar/components/ShareDialog/TabHeader.tsx
@@ -1,0 +1,34 @@
+import { CloseButton, TabList } from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
+import type { ComponentChildren } from 'preact';
+
+/**
+ * Render a header to go above a Card, with contents in a TabList
+ */
+export default function TabHeader({
+  children,
+}: {
+  children: ComponentChildren;
+}) {
+  return (
+    <div data-testid="tab-header" className="flex items-center">
+      <CloseButton
+        classes={classnames(
+          // This element comes first in source order before tabs, but is
+          // positioned last. This puts this button earlier in the tab
+          // sequence than the tabs, allowing tabs to be immediately adjacent
+          // to their controlled tab panels/tab content in the tab sequence.
+          'order-last',
+          // Always render this button at 16px square regardless of parent
+          // font size
+          'text-[16px]',
+          'text-grey-6 hover:text-grey-7 hover:bg-grey-3/50'
+        )}
+        title="Close"
+        variant="custom"
+        size="sm"
+      />
+      <TabList classes="grow gap-x-1 -mb-[1px] z-2">{children}</TabList>
+    </div>
+  );
+}

--- a/src/sidebar/components/ShareDialog/TabPanel.tsx
+++ b/src/sidebar/components/ShareDialog/TabPanel.tsx
@@ -1,0 +1,33 @@
+import { CardTitle } from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
+import type { ComponentChildren, JSX } from 'preact';
+
+export type TabPanelProps = {
+  active?: boolean;
+  title?: ComponentChildren;
+} & JSX.HTMLAttributes<HTMLDivElement>;
+
+/**
+ * Render a `role="tabpanel"` element within a Card layout. It will be
+ *  hidden unless `active`.
+ */
+export default function TabPanel({
+  children,
+  active,
+  title,
+  ...htmlAttributes
+}: TabPanelProps) {
+  return (
+    <div
+      role="tabpanel"
+      {...htmlAttributes}
+      className={classnames('p-3 focus-visible-ring ring-inset', {
+        hidden: !active,
+      })}
+      hidden={!active}
+    >
+      {title && <CardTitle>{title}</CardTitle>}
+      <div className="space-y-3 pt-2">{children}</div>
+    </div>
+  );
+}

--- a/src/sidebar/components/ShareDialog/index.ts
+++ b/src/sidebar/components/ShareDialog/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ShareDialog';

--- a/src/sidebar/components/ShareDialog/test/ShareDialog-test.js
+++ b/src/sidebar/components/ShareDialog/test/ShareDialog-test.js
@@ -45,8 +45,12 @@ describe('ShareDialog', () => {
     };
 
     $imports.$mock(mockImportedComponents());
-    // Don't mock this very simple component
-    $imports.$restore({ './LoadingSpinner': true });
+    // Don't mock these simple components for now
+    $imports.$restore({
+      './LoadingSpinner': true,
+      './TabHeader': true,
+      './TabPanel': true,
+    });
     $imports.$mock({
       '../../store': { useSidebarStore: () => fakeStore },
       '../../helpers/annotation-sharing': {

--- a/src/sidebar/components/ShareDialog/test/ShareDialog-test.js
+++ b/src/sidebar/components/ShareDialog/test/ShareDialog-test.js
@@ -80,13 +80,6 @@ describe('ShareDialog', () => {
   });
 
   describe('share panel content', () => {
-    it('does not render share panel content if needed info not available', () => {
-      fakeStore.focusedGroup.returns(undefined);
-
-      const wrapper = createComponent();
-      assert.isFalse(wrapper.exists('.ShareAnnotationsPanel'));
-    });
-
     it('renders a spinner if focused group not available yet', () => {
       fakeStore.focusedGroup.returns(undefined);
 

--- a/src/sidebar/components/ShareDialog/test/ShareDialog-test.js
+++ b/src/sidebar/components/ShareDialog/test/ShareDialog-test.js
@@ -1,12 +1,12 @@
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
 
-import { checkAccessibility } from '../../../test-util/accessibility';
-import { mockImportedComponents } from '../../../test-util/mock-imported-components';
-import ShareAnnotationsPanel from '../ShareAnnotationsPanel';
-import { $imports } from '../ShareAnnotationsPanel';
+import { checkAccessibility } from '../../../../test-util/accessibility';
+import { mockImportedComponents } from '../../../../test-util/mock-imported-components';
+import ShareDialog from '../ShareDialog';
+import { $imports } from '../ShareDialog';
 
-describe('ShareAnnotationsPanel', () => {
+describe('ShareDialog', () => {
   let fakeStore;
   let fakeBouncerLink;
   let fakePageSharingLink;
@@ -19,10 +19,8 @@ describe('ShareAnnotationsPanel', () => {
     id: 'testprivate',
   };
 
-  const createShareAnnotationsPanel = props =>
-    mount(
-      <ShareAnnotationsPanel toastMessenger={fakeToastMessenger} {...props} />
-    );
+  const createComponent = props =>
+    mount(<ShareDialog toastMessenger={fakeToastMessenger} {...props} />);
 
   beforeEach(() => {
     fakeBouncerLink = 'http://hyp.is/go?url=http%3A%2F%2Fwww.example.com';
@@ -48,11 +46,11 @@ describe('ShareAnnotationsPanel', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../store': { useSidebarStore: () => fakeStore },
-      '../helpers/annotation-sharing': {
+      '../../store': { useSidebarStore: () => fakeStore },
+      '../../helpers/annotation-sharing': {
         pageSharingLink: fakePageSharingLink,
       },
-      '../util/copy-to-clipboard': fakeCopyToClipboard,
+      '../../util/copy-to-clipboard': fakeCopyToClipboard,
     });
   });
 
@@ -62,7 +60,7 @@ describe('ShareAnnotationsPanel', () => {
 
   describe('panel dialog title', () => {
     it("sets sidebar panel dialog title to include group's name", () => {
-      const wrapper = createShareAnnotationsPanel();
+      const wrapper = createComponent();
 
       assert.equal(
         wrapper.find('SidebarPanel').prop('title'),
@@ -73,7 +71,7 @@ describe('ShareAnnotationsPanel', () => {
     it('sets a temporary title if focused group not available', () => {
       fakeStore.focusedGroup = sinon.stub().returns({});
 
-      const wrapper = createShareAnnotationsPanel();
+      const wrapper = createComponent();
       assert.equal(
         wrapper.find('SidebarPanel').prop('title'),
         'Share Annotations in ...'
@@ -85,19 +83,19 @@ describe('ShareAnnotationsPanel', () => {
     it('does not render share panel content if needed info not available', () => {
       fakeStore.focusedGroup.returns(undefined);
 
-      const wrapper = createShareAnnotationsPanel();
+      const wrapper = createComponent();
       assert.isFalse(wrapper.exists('.ShareAnnotationsPanel'));
     });
 
     it('renders a spinner if focused group not available yet', () => {
       fakeStore.focusedGroup.returns(undefined);
 
-      const wrapper = createShareAnnotationsPanel();
+      const wrapper = createComponent();
       assert.isTrue(wrapper.find('Spinner').exists());
     });
 
     it('renders panel content if needed info available', () => {
-      const wrapper = createShareAnnotationsPanel();
+      const wrapper = createComponent();
       assert.isFalse(wrapper.find('Spinner').exists());
     });
   });
@@ -129,7 +127,7 @@ describe('ShareAnnotationsPanel', () => {
         id: 'testid,',
       });
 
-      const wrapper = createShareAnnotationsPanel();
+      const wrapper = createComponent();
 
       assert.match(
         wrapper.find('[data-testid="sharing-intro"]').text(),
@@ -146,7 +144,7 @@ describe('ShareAnnotationsPanel', () => {
       it('renders explanatory text about inability to share', () => {
         fakePageSharingLink.returns(null);
 
-        const wrapper = createShareAnnotationsPanel();
+        const wrapper = createComponent();
 
         const panelEl = wrapper.find('[data-testid="no-sharing"]');
         assert.include(panelEl.text(), 'These annotations cannot be shared');
@@ -156,7 +154,7 @@ describe('ShareAnnotationsPanel', () => {
 
   describe('web share link', () => {
     it('displays web share link in readonly form input', () => {
-      const wrapper = createShareAnnotationsPanel();
+      const wrapper = createComponent();
 
       const inputEl = wrapper.find('input');
       assert.equal(inputEl.prop('value'), fakeBouncerLink);
@@ -166,7 +164,7 @@ describe('ShareAnnotationsPanel', () => {
     context('document URI cannot be shared', () => {
       it('does not render an input field with share link', () => {
         fakePageSharingLink.returns(null);
-        const wrapper = createShareAnnotationsPanel();
+        const wrapper = createComponent();
 
         const inputEl = wrapper.find('input');
         assert.isFalse(inputEl.exists());
@@ -175,7 +173,7 @@ describe('ShareAnnotationsPanel', () => {
 
     describe('copy link to clipboard', () => {
       it('copies link to clipboard when copy button clicked', () => {
-        const wrapper = createShareAnnotationsPanel();
+        const wrapper = createComponent();
 
         wrapper.find('IconButton').props().onClick();
 
@@ -183,7 +181,7 @@ describe('ShareAnnotationsPanel', () => {
       });
 
       it('confirms link copy when successful', () => {
-        const wrapper = createShareAnnotationsPanel();
+        const wrapper = createComponent();
 
         wrapper.find('IconButton').props().onClick();
 
@@ -195,7 +193,7 @@ describe('ShareAnnotationsPanel', () => {
 
       it('flashes an error if link copying unsuccessful', () => {
         fakeCopyToClipboard.copyText.throws();
-        const wrapper = createShareAnnotationsPanel();
+        const wrapper = createComponent();
 
         wrapper.find('IconButton').props().onClick();
 
@@ -206,7 +204,7 @@ describe('ShareAnnotationsPanel', () => {
 
   describe('tabbed dialog panel', () => {
     it('does not render a tabbed dialog if export feature flag is not enabled', () => {
-      const wrapper = createShareAnnotationsPanel();
+      const wrapper = createComponent();
 
       assert.isFalse(wrapper.find('TabHeader').exists());
     });
@@ -217,7 +215,7 @@ describe('ShareAnnotationsPanel', () => {
       });
 
       it('renders a tabbed dialog with share panel active', () => {
-        const wrapper = createShareAnnotationsPanel();
+        const wrapper = createComponent();
 
         assert.isTrue(wrapper.find('TabHeader').exists());
         assert.isTrue(
@@ -229,7 +227,7 @@ describe('ShareAnnotationsPanel', () => {
       });
 
       it('shows the export tab panel when export tab clicked', () => {
-        const wrapper = createShareAnnotationsPanel();
+        const wrapper = createComponent();
         const shareTabSelector = 'Tab[aria-controls="share-panel"]';
         const exportTabSelector = 'Tab[aria-controls="export-panel"]';
 
@@ -265,7 +263,7 @@ describe('ShareAnnotationsPanel', () => {
       });
 
       it('shows a loading indicator on the export tab if not ready', () => {
-        const wrapper = createShareAnnotationsPanel();
+        const wrapper = createComponent();
         const exportTabSelector = 'Tab[aria-controls="export-panel"]';
         fakeStore.isLoading.returns(true);
 
@@ -293,7 +291,7 @@ describe('ShareAnnotationsPanel', () => {
   it(
     'should pass a11y checks',
     checkAccessibility({
-      content: () => createShareAnnotationsPanel(),
+      content: () => createComponent(),
     })
   );
 });

--- a/src/sidebar/components/ShareDialog/test/ShareDialog-test.js
+++ b/src/sidebar/components/ShareDialog/test/ShareDialog-test.js
@@ -45,6 +45,8 @@ describe('ShareDialog', () => {
     };
 
     $imports.$mock(mockImportedComponents());
+    // Don't mock this very simple component
+    $imports.$restore({ './LoadingSpinner': true });
     $imports.$mock({
       '../../store': { useSidebarStore: () => fakeStore },
       '../../helpers/annotation-sharing': {


### PR DESCRIPTION
This PR is part 1 of 2 or 3 PRs to restructure the former `ShareAnnotationsPanel` now that it has grown in size and scope. I'm breaking this work up to keep the diffs from getting unwieldy.

The structure of the sharing dialog has changed here from a single, bloated `ShareAnnotationsPanel` component to:

```
ShareDialog
|- test
|- index.ts
|- LoadingSpinner.tsx
|- ShareDialog.tsx
|- TabHeader.tsx
|- TabPanel.tsx
```

Similarly to the structure of the `Annotation` component directory, `ShareDialog/index` exports default `ShareDialog`.

As the extracted components `LoadingSpinner`, `TabHeader` and `TabPanel` are presentational, they are not presently mocked in `ShareDialog` tests. `TabHeader` and `TabPanel` are both candidates for extraction to the shared package at some point. At the very least, we'll reuse them for the `HelpPanel`, so they will be moving in the near future.

No functional or visual changes here.

Next step: Extract the content for each "tab" of the dialog into `ExportAnnotations` and `ShareAnnotations` components, respectively. Already done on a branch with the exception of a failing a11y test that I've noted in a Slack thread.