### PR TITLE
Add messaging, export functionality to export tab of share dialog

### DIFF
--- a/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
+++ b/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
@@ -1,34 +1,93 @@
 import { Button, CardActions, Input } from '@hypothesis/frontend-shared';
+import { useRef } from 'preact/hooks';
 
+import { downloadJSONFile } from '../../../shared/download-json-file';
+import { withServices } from '../../service-context';
+import type { AnnotationsExporter } from '../../services/annotations-exporter';
 import { useSidebarStore } from '../../store';
 import LoadingSpinner from './LoadingSpinner';
 
+export type ExportAnnotationsProps = {
+  // injected
+  annotationsExporter: AnnotationsExporter;
+};
+
+// TODO: Validate user-entered filename
+// TODO: Initial filename suggestion (date + group name + ...?)
+// TODO: does the Input need a label?
+
 /**
- * Render content for "export" tab panel
+ * Render content for "export" tab panel: allow user to export annotations
+ * with a specified filename.
  */
-export default function ExportAnnotations() {
+function ExportAnnotations({ annotationsExporter }: ExportAnnotationsProps) {
   const store = useSidebarStore();
   const group = store.focusedGroup();
   const exportReady = group && !store.isLoading();
-  const annotations = store.allAnnotations();
+  const exportableAnnotations = store.savedAnnotations();
+  const exportCount = exportableAnnotations.length;
+  const draftCount = store.countDrafts();
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
 
   if (!exportReady) {
     return <LoadingSpinner />;
   }
 
-  // TODO: Handle 0 annotations
+  const exportAnnotations = () => {
+    const filename = `${inputRef.current!.value}.json`;
+    const exportData = annotationsExporter.buildExportContent(
+      exportableAnnotations
+    );
+    downloadJSONFile(exportData, filename);
+  };
+
+  // Naive simple English pluralization
+  const pluralize = (str: string, count: number) => {
+    return count === 1 ? str : `${str}s`;
+  };
+
   return (
     <>
-      <p>
-        Export <strong>{annotations.length} annotations</strong> in a file
-        named:
-      </p>
-      <Input id="export-filename" value="filename-tbd-export.json" />
+      {exportCount > 0 ? (
+        <>
+          <p data-testid="export-count">
+            Export{' '}
+            <strong>
+              {exportCount} {pluralize('annotation', exportCount)}
+            </strong>{' '}
+            in a file named:
+          </p>
+          <Input
+            data-testid="export-filename"
+            id="export-filename"
+            defaultValue="suggested-filename-tbd"
+            elementRef={inputRef}
+          />
+        </>
+      ) : (
+        <p data-testid="no-annotations-message">
+          There are no annotations available for export.
+        </p>
+      )}
+      {draftCount > 0 && (
+        <p data-testid="drafts-message">
+          You have {draftCount} unsaved {pluralize('annotation', draftCount)}
+          {exportCount > 0 && <> that will not be included</>}.
+        </p>
+      )}
       <CardActions>
-        <Button variant="primary" disabled>
+        <Button
+          data-testid="export-button"
+          variant="primary"
+          disabled={!exportCount}
+          onClick={exportAnnotations}
+        >
           Export
         </Button>
       </CardActions>
     </>
   );
 }
+
+export default withServices(ExportAnnotations, ['annotationsExporter']);


### PR DESCRIPTION
This PR does a first basic pass at wiring up export functionality. It:

* updates the annotations used for export (and their counts) to be based on saved annotations only
* adds messaging if there are no available (saved) annotations for export
* adds messaging if there are any unsaved (draft) annotations
* downloads annotations when export button is clicked, using the current filename in the input field appended with `.json` as a filename

Still to do:

* Styling of said messaging, and tweaking of the messaging itself. What's here is "logical" implementation, not styling or wording.
* Any and all validation of user-inputted filename
* Provide initial suggested filename, likely based on date and group name (I aborted on this because formatting JS `Date`s too time-consuming for the moment)

## Testing

On this branch with the `export_annotations` feature flag enabled, try out the "Export" tab of the Share dialog in the following scenarios:

Go to a document/group combination that has no loaded annotations (of any kind, including page notes and orphans). Open the Share -> Export tab.

1. You should see messaging that there is nothing to export.
2. On this same document/group, highlight some text and click "annotate". You should see the messaging update to note that there is one unsaved annotation.
3. Now highlight some text and click "Highlight." As highlights save immediately, you should see the export panel now come to life and allow you to set a filename and export.

Now go to a document/group combination with a bunch of annotations and navigate to the Export tab.

1. You should see a count of annotations for export.
2. You should be able to change the name of the file.
3. When you click export, things should export!
4. Try clicking the edit button on a few annotations to go into edit mode. The messaging in the export tab should update to reflect the number of unsaved annotations.

Part of #5619