### PR TITLE
Validate export annotation filename

### DIFF
--- a/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
+++ b/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
@@ -5,6 +5,7 @@ import { downloadJSONFile } from '../../../shared/download-json-file';
 import { withServices } from '../../service-context';
 import type { AnnotationsExporter } from '../../services/annotations-exporter';
 import { useSidebarStore } from '../../store';
+import { suggestedFilename } from '../../util/export-annotations';
 import LoadingSpinner from './LoadingSpinner';
 
 export type ExportAnnotationsProps = {
@@ -13,7 +14,6 @@ export type ExportAnnotationsProps = {
 };
 
 // TODO: Validate user-entered filename
-// TODO: Initial filename suggestion (date + group name + ...?)
 // TODO: does the Input need a label?
 
 /**
@@ -61,7 +61,7 @@ function ExportAnnotations({ annotationsExporter }: ExportAnnotationsProps) {
           <Input
             data-testid="export-filename"
             id="export-filename"
-            defaultValue="suggested-filename-tbd"
+            defaultValue={suggestedFilename({ group })}
             elementRef={inputRef}
           />
         </>

--- a/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
+++ b/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
@@ -3,8 +3,7 @@ import { mount } from 'enzyme';
 import { checkAccessibility } from '../../../../test-util/accessibility';
 import { mockImportedComponents } from '../../../../test-util/mock-imported-components';
 import * as fixtures from '../../../test/annotation-fixtures';
-import ExportAnnotations from '../ExportAnnotations';
-import { $imports } from '../ExportAnnotations';
+import ExportAnnotations, { $imports } from '../ExportAnnotations';
 
 describe('ExportAnnotations', () => {
   let fakeStore;
@@ -46,6 +45,9 @@ describe('ExportAnnotations', () => {
         downloadJSONFile: fakeDownloadJSONFile,
       },
       '../../store': { useSidebarStore: () => fakeStore },
+      '../../util/export-annotations': {
+        suggestedFilename: () => 'suggested-filename',
+      },
     });
 
     // Restore this very simple component to get it test coverage
@@ -96,10 +98,12 @@ describe('ExportAnnotations', () => {
     );
   });
 
-  it('provides a filename field', () => {
+  it('provides a filename field with a default suggested name', () => {
     const wrapper = createComponent();
+    const input = wrapper.find('Input');
 
-    assert.isTrue(wrapper.find('Input').exists());
+    assert.isTrue(input.exists());
+    assert.equal(input.prop('defaultValue'), 'suggested-filename');
   });
 
   describe('export button clicked', () => {

--- a/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
+++ b/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
@@ -103,7 +103,7 @@ describe('ExportAnnotations', () => {
     const input = wrapper.find('Input');
 
     assert.isTrue(input.exists());
-    assert.equal(input.prop('defaultValue'), 'suggested-filename');
+    assert.equal(input.prop('value'), 'suggested-filename');
   });
 
   describe('export button clicked', () => {
@@ -126,93 +126,10 @@ describe('ExportAnnotations', () => {
 
     it('downloads a file using user-entered filename appended with `.json`', () => {
       const wrapper = createComponent();
+      const input = wrapper.find('input[data-testid="export-filename"]');
 
-      wrapper.find('input[data-testid="export-filename"]').getDOMNode().value =
-        'my-filename';
-
-      wrapper.find('button[data-testid="export-button"]').simulate('click');
-
-      assert.calledOnce(fakeDownloadJSONFile);
-      assert.calledWith(
-        fakeDownloadJSONFile,
-        sinon.match.object,
-        'my-filename.json',
-      );
-    });
-  });
-
-  context('no annotations available to export', () => {
-    beforeEach(() => {
-      fakeStore.savedAnnotations.returns([]);
-    });
-
-    it('shows a message that no annotations are available', () => {
-      const wrapper = createComponent();
-
-      assert.include(
-        wrapper.find('[data-testid="no-annotations-message"]').text(),
-        'There are no annotations available for export',
-      );
-    });
-
-    it('disables the export button', () => {
-      const wrapper = createComponent();
-
-      assert.isTrue(
-        wrapper.find('button[data-testid="export-button"]').props().disabled,
-      );
-    });
-
-    it('does not show the filename input field', () => {
-      const wrapper = createComponent();
-
-      assert.isFalse(wrapper.find('Input').exists());
-    });
-  });
-
-  context('there are draft annotations', () => {
-    it('shows a message with a count of draft annotations', () => {
-      fakeStore.countDrafts.returns(1);
-      const wrapperSingular = createComponent();
-
-      fakeStore.countDrafts.returns(2);
-      const wrapperPlural = createComponent();
-
-      assert.include(
-        wrapperSingular.find('[data-testid="drafts-message"]').text(),
-        'You have 1 unsaved annotation that',
-      );
-
-      assert.include(
-        wrapperPlural.find('[data-testid="drafts-message"]').text(),
-        'You have 2 unsaved annotations that',
-      );
-    });
-  });
-
-  describe('export button clicked', () => {
-    it('builds an export file from the non-draft annotations', () => {
-      const wrapper = createComponent();
-      const annotationsToExport = [
-        fixtures.oldAnnotation(),
-        fixtures.oldAnnotation(),
-      ];
-      fakeStore.savedAnnotations.returns(annotationsToExport);
-
-      wrapper.find('button[data-testid="export-button"]').simulate('click');
-
-      assert.calledOnce(fakeAnnotationsExporter.buildExportContent);
-      assert.calledWith(
-        fakeAnnotationsExporter.buildExportContent,
-        annotationsToExport,
-      );
-    });
-
-    it('downloads a file using user-entered filename appended with `.json`', () => {
-      const wrapper = createComponent();
-
-      wrapper.find('input[data-testid="export-filename"]').getDOMNode().value =
-        'my-filename';
+      input.getDOMNode().value = 'my-filename';
+      input.simulate('input');
 
       wrapper.find('button[data-testid="export-button"]').simulate('click');
 

--- a/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
+++ b/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
@@ -54,11 +54,6 @@ describe('ExportAnnotations', () => {
     $imports.$restore({
       './LoadingSpinner': true,
     });
-
-    // Restore this very simple component to get it test coverage
-    $imports.$restore({
-      './LoadingSpinner': true,
-    });
   });
 
   afterEach(() => {

--- a/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
+++ b/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
@@ -54,6 +54,11 @@ describe('ExportAnnotations', () => {
     $imports.$restore({
       './LoadingSpinner': true,
     });
+
+    // Restore this very simple component to get it test coverage
+    $imports.$restore({
+      './LoadingSpinner': true,
+    });
   });
 
   afterEach(() => {
@@ -104,6 +109,90 @@ describe('ExportAnnotations', () => {
 
     assert.isTrue(input.exists());
     assert.equal(input.prop('defaultValue'), 'suggested-filename');
+  });
+
+  describe('export button clicked', () => {
+    it('builds an export file from the non-draft annotations', () => {
+      const wrapper = createComponent();
+      const annotationsToExport = [
+        fixtures.oldAnnotation(),
+        fixtures.oldAnnotation(),
+      ];
+      fakeStore.savedAnnotations.returns(annotationsToExport);
+
+      wrapper.find('button[data-testid="export-button"]').simulate('click');
+
+      assert.calledOnce(fakeAnnotationsExporter.buildExportContent);
+      assert.calledWith(
+        fakeAnnotationsExporter.buildExportContent,
+        annotationsToExport,
+      );
+    });
+
+    it('downloads a file using user-entered filename appended with `.json`', () => {
+      const wrapper = createComponent();
+
+      wrapper.find('input[data-testid="export-filename"]').getDOMNode().value =
+        'my-filename';
+
+      wrapper.find('button[data-testid="export-button"]').simulate('click');
+
+      assert.calledOnce(fakeDownloadJSONFile);
+      assert.calledWith(
+        fakeDownloadJSONFile,
+        sinon.match.object,
+        'my-filename.json',
+      );
+    });
+  });
+
+  context('no annotations available to export', () => {
+    beforeEach(() => {
+      fakeStore.savedAnnotations.returns([]);
+    });
+
+    it('shows a message that no annotations are available', () => {
+      const wrapper = createComponent();
+
+      assert.include(
+        wrapper.find('[data-testid="no-annotations-message"]').text(),
+        'There are no annotations available for export',
+      );
+    });
+
+    it('disables the export button', () => {
+      const wrapper = createComponent();
+
+      assert.isTrue(
+        wrapper.find('button[data-testid="export-button"]').props().disabled,
+      );
+    });
+
+    it('does not show the filename input field', () => {
+      const wrapper = createComponent();
+
+      assert.isFalse(wrapper.find('Input').exists());
+    });
+  });
+
+  context('there are draft annotations', () => {
+    it('shows a message with a count of draft annotations', () => {
+      fakeStore.countDrafts.returns(1);
+      const wrapperSingular = createComponent();
+
+      fakeStore.countDrafts.returns(2);
+      const wrapperPlural = createComponent();
+
+      assert.include(
+        wrapperSingular.find('[data-testid="drafts-message"]').text(),
+        'You have 1 unsaved annotation that',
+      );
+
+      assert.include(
+        wrapperPlural.find('[data-testid="drafts-message"]').text(),
+        'You have 2 unsaved annotations that',
+      );
+    });
   });
 
   describe('export button clicked', () => {

--- a/src/sidebar/util/export-annotations.ts
+++ b/src/sidebar/util/export-annotations.ts
@@ -1,0 +1,27 @@
+import type { Group } from '../../types/api';
+
+const formatDate = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+};
+
+type SuggestedFilenameOptions = {
+  group: Group | null;
+  /** Test seam */
+  date?: Date;
+};
+
+export const suggestedFilename = ({
+  group,
+  date = new Date(),
+}: SuggestedFilenameOptions) => {
+  const filenameSegments = [formatDate(date), 'Hypothesis'];
+  if (group) {
+    filenameSegments.push(group.name.replace(/ /g, '-'));
+  }
+
+  return filenameSegments.join('-');
+};

--- a/src/sidebar/util/export-annotations.ts
+++ b/src/sidebar/util/export-annotations.ts
@@ -25,3 +25,9 @@ export const suggestedFilename = ({
 
   return filenameSegments.join('-');
 };
+
+export const validateFilename = (filename: string): boolean => {
+  // Allow filenames between 1 and 255 characters.
+  // Characters \n, :, \, /, *, ?, ", ', < and > are not allowed.
+  return /^[^\n:\\/*?"'<>]{1,255}$/.test(filename);
+};

--- a/src/sidebar/util/test/export-annotations-test.js
+++ b/src/sidebar/util/test/export-annotations-test.js
@@ -1,4 +1,4 @@
-import { suggestedFilename } from '../export-annotations';
+import { suggestedFilename, validateFilename } from '../export-annotations';
 
 describe('suggestedFilename', () => {
   [
@@ -21,5 +21,23 @@ describe('suggestedFilename', () => {
     it('builds expected filename for provided arguments', () => {
       assert.equal(suggestedFilename({ date, group }), expectedResult);
     });
+  });
+});
+
+describe('validateFilename', () => {
+  ['\\n', ':', '\\', '/', '*', '?', '"', "'", '<', '>'].forEach(character => {
+    it(`returns 'false' when filename includes '${character}'`, () => {
+      assert.isFalse(validateFilename(`filename${character}`));
+    });
+  });
+
+  ['', ''.padStart(256, 'a')].forEach(filename => {
+    it('returns `false` when filename does not have a valid length', () => {
+      assert.isFalse(validateFilename(filename));
+    });
+  });
+
+  it('returns `true` for valid filenames', () => {
+    assert.isTrue(validateFilename('my-file-name'));
   });
 });

--- a/src/sidebar/util/test/export-annotations-test.js
+++ b/src/sidebar/util/test/export-annotations-test.js
@@ -1,0 +1,25 @@
+import { suggestedFilename } from '../export-annotations';
+
+describe('suggestedFilename', () => {
+  [
+    {
+      date: new Date(2023, 5, 23),
+      group: null,
+      expectedResult: '2023-06-23-Hypothesis',
+    },
+    {
+      date: new Date(2019, 0, 5),
+      group: null,
+      expectedResult: '2019-01-05-Hypothesis',
+    },
+    {
+      date: new Date(2020, 10, 5),
+      group: { name: 'My group name' },
+      expectedResult: '2020-11-05-Hypothesis-My-group-name',
+    },
+  ].forEach(({ date, group, expectedResult }) => {
+    it('builds expected filename for provided arguments', () => {
+      assert.equal(suggestedFilename({ date, group }), expectedResult);
+    });
+  });
+});


### PR DESCRIPTION
This PR converts the export annotations filename input into a controlled input, replacing the `inputRef` by a piece of local state that is updated `onChange`.

This allows to have a piece of derived state telling if the input value is valid or not, and use it to disable the export button and display an error message.

> Another possible approach would be to keep the ref, and validate the input when the button is pressed, but I thought it would make more sense to provide real-time feedback, as it is just client-side validation.

The validation consists on testing the input value against this regexp `/^[^\n:\\/*?"'<>]{1,255}$/` (ban characters `\n`, `:`, `\`, `/`, `*`, `?`, `"`, `'`, `<` and `>`. Allow filenames between 1 and 255 characters).

### TODO

- [ ] Display error message, and consider styling the input differently (for example, with red border).
- [ ] Add/fix tests