### PR TITLE
Validate export filename

### DIFF
--- a/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
+++ b/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
@@ -126,9 +126,10 @@ describe('ExportAnnotations', () => {
 
     it('downloads a file using user-entered filename appended with `.json`', () => {
       const wrapper = createComponent();
+      const input = wrapper.find('input[data-testid="export-filename"]');
 
-      wrapper.find('input[data-testid="export-filename"]').getDOMNode().value =
-        'my-filename';
+      input.getDOMNode().value = 'my-filename';
+      input.simulate('input');
 
       wrapper.find('button[data-testid="export-button"]').simulate('click');
 
@@ -186,6 +187,32 @@ describe('ExportAnnotations', () => {
       assert.include(
         wrapperPlural.find('[data-testid="drafts-message"]').text(),
         'You have 2 unsaved annotations that',
+      );
+    });
+  });
+
+  context('when filename is invalid', () => {
+    const createComponentWithInvalidFilename = () => {
+      const wrapper = createComponent();
+      const input = wrapper.find('input[data-testid="export-filename"]');
+
+      input.getDOMNode().value = 'invalid*';
+      input.simulate('input');
+
+      return wrapper;
+    };
+
+    it('disables export button', () => {
+      const wrapper = createComponentWithInvalidFilename();
+      assert.isTrue(
+        wrapper.find('Button[data-testid="export-button"]').prop('disabled'),
+      );
+    });
+
+    it('sets filename input with error', () => {
+      const wrapper = createComponentWithInvalidFilename();
+      assert.isTrue(
+        wrapper.find('Input[data-testid="export-filename"]').prop('hasError'),
       );
     });
   });

--- a/src/sidebar/util/export-annotations.ts
+++ b/src/sidebar/util/export-annotations.ts
@@ -23,3 +23,9 @@ export const suggestedFilename = ({
 
   return filenameSegments.join('-');
 };
+
+export const validateFilename = (filename: string): boolean => {
+  // Allow filenames between 1 and 255 characters.
+  // Characters \n, :, \, /, *, ?, ", ', < and > are not allowed.
+  return /^[^\n:\\/*?"'<>]{1,255}$/.test(filename);
+};

--- a/src/sidebar/util/test/export-annotations-test.js
+++ b/src/sidebar/util/test/export-annotations-test.js
@@ -1,4 +1,4 @@
-import { suggestedFilename } from '../export-annotations';
+import { suggestedFilename, validateFilename } from '../export-annotations';
 
 describe('suggestedFilename', () => {
   [
@@ -19,5 +19,23 @@ describe('suggestedFilename', () => {
     it('builds expected filename for provided arguments', () => {
       assert.equal(suggestedFilename({ date, groupName }), expectedResult);
     });
+  });
+});
+
+describe('validateFilename', () => {
+  ['\\n', ':', '\\', '/', '*', '?', '"', "'", '<', '>'].forEach(character => {
+    it(`returns 'false' when filename includes '${character}'`, () => {
+      assert.isFalse(validateFilename(`filename${character}`));
+    });
+  });
+
+  ['', ''.padStart(256, 'a')].forEach(filename => {
+    it('returns `false` when filename does not have a valid length', () => {
+      assert.isFalse(validateFilename(filename));
+    });
+  });
+
+  it('returns `true` for valid filenames', () => {
+    assert.isTrue(validateFilename('my-file-name'));
   });
 });


### PR DESCRIPTION
This PR adds basic validation to the export annotations filename.

The validation consists on testing the input value against this regexp `/^[^\n:\\/*?"'<>]{1,255}$/` (ban characters `\n`, `:`, `\`, `/`, `*`, `?`, `"`, `'`, `<` and `>`. Allow filenames between 1 and 255 characters).

If introduced value is invalid, the "export" button is disabled, and the `Input` is marked as erroneous via `hasError` prop.

[screen-recording.webm](https://github.com/hypothesis/client/assets/2719332/fa24de9d-01c7-4e3b-9346-be9df0779e04)

### TODO

- [x] Display error message, or consider styling the input differently (for example, with red border).
- [x] Add/fix tests

### Testing steps

1. Make sure you have the `export_annotations` feature flag enabled here http://localhost:5000/admin/features
2. Go to the export annotations panel.
3. Initially, a valid name should have been suggested, so the "Export" button is enabled.
4. If you introduce an invalid filename (empty or longer than 255 characters, or containing any of these characters: `\n`, `:`, `\`, `/`, `*`, `?`, `"`, `'`, `<`, `>`), the "Export" button should be immediately disabled, and a red ring should appear in the input.

> **Warning**
> Notice there's a small glitch, which makes the red ring not appear right away, but only if the input looses focus, or one more character is input.
>
> I think it's because there's some style conflict with the focus ring, but it could also be a re-rendering issue. I will investigate this later.