### PR TITLE
Create function that reads and JSON-parses a File object

### DIFF
--- a/src/shared/read-json-file.ts
+++ b/src/shared/read-json-file.ts
@@ -1,0 +1,28 @@
+import { promiseWithResolvers } from './promise-with-resolvers';
+
+/**
+ * Reads and tries to JSON-parse a file
+ * @return - Promise that resolves to parsed content or rejects with any error
+ *           that occurred during parsing
+ */
+export function readJSONFile(
+  file: File,
+  /* istanbul ignore next - test seam */
+  fileReader = new FileReader(),
+): Promise<unknown> {
+  const { promise, resolve, reject } = promiseWithResolvers();
+
+  fileReader.addEventListener('loadend', (e: ProgressEvent<FileReader>) => {
+    try {
+      const content = e.target?.result?.toString() ?? '';
+      const parsed = JSON.parse(content);
+
+      resolve(parsed);
+    } catch (error) {
+      reject(error);
+    }
+  });
+  fileReader.readAsText(file);
+
+  return promise;
+}

--- a/src/shared/test/read-json-file-test.js
+++ b/src/shared/test/read-json-file-test.js
@@ -1,0 +1,45 @@
+import { readJSONFile } from '../read-json-file';
+
+describe('readJSONFile', () => {
+  const file = new File([], 'my-file');
+
+  function createFakeFileReader(fileContent) {
+    return {
+      addEventListener: sinon.stub().callsArgWith(1, {
+        target: {
+          result: fileContent,
+        },
+      }),
+      readAsText: sinon.stub(),
+    };
+  }
+
+  it('rejects when content is not valid JSON', async () => {
+    const fakeFileReader = createFakeFileReader('not JSON');
+
+    await assert.rejects(
+      readJSONFile(file, fakeFileReader),
+      'Unexpected token \'o\', "not JSON" is not valid JSON',
+    );
+    assert.calledWith(fakeFileReader.readAsText, file);
+    assert.calledWith(
+      fakeFileReader.addEventListener,
+      'loadend',
+      sinon.match.func,
+    );
+  });
+
+  it('resolves when content is valid JSON', async () => {
+    const fakeFileReader = createFakeFileReader('{ "foo": "bar" }');
+
+    const content = await readJSONFile(file, fakeFileReader);
+
+    assert.deepEqual(content, { foo: 'bar' });
+    assert.calledWith(fakeFileReader.readAsText, file);
+    assert.calledWith(
+      fakeFileReader.addEventListener,
+      'loadend',
+      sinon.match.func,
+    );
+  });
+});


### PR DESCRIPTION
> Part of https://github.com/hypothesis/client/issues/5697

Implement a function that, provided a `File` (potentially coming from a file-input), reads its content and JSON-parses it.

This function returns a promise resolved with the parsed content if everything was ok, or rejected with any error occurred during the process.

### Testing steps.

You can test this function by applying this diff to this branch:

```diff
diff --git a/src/sidebar/components/SelectionTabs.tsx b/src/sidebar/components/SelectionTabs.tsx
index fb7980e98..831b89005 100644
--- a/src/sidebar/components/SelectionTabs.tsx
+++ b/src/sidebar/components/SelectionTabs.tsx
@@ -9,6 +9,7 @@ import {
 import classnames from 'classnames';
 import type { ComponentChildren } from 'preact';
 
+import { readJSONFile } from '../../shared/read-json-file';
 import type { SidebarSettings } from '../../types/config';
 import type { TabName } from '../../types/sidebar';
 import { applyTheme } from '../helpers/theme';
@@ -125,6 +126,17 @@ function SelectionTabs({
         'space-y-3 pb-[9px]',
       )}
     >
+      <input
+        type="file"
+        accept="application/json"
+        onChange={async e => {
+          const [file] = (e.target as HTMLInputElement).files ?? [];
+          if (file) {
+            console.log(await readJSONFile(file));
+          }
+        }}
+      />
       <div className="flex gap-x-6 theme-clean:ml-[15px]" role="tablist">
         <Tab
           count={annotationCount}
```

This will render a file-input on the top of the sidebar, whcih only allows JSON files to be selected.

Once a file is selected it will pass it to the function and console-log its result.

> **Warning**
> We will need further manual testing later, same as with exporting functionality, because tests provided here mock the actual file "uploading".