### PR TITLE
Create promiseWithResolvers helper, behaving like Promise.withResolvers

### DIFF
--- a/src/shared/promise-with-resolvers.ts
+++ b/src/shared/promise-with-resolvers.ts
@@ -1,0 +1,20 @@
+export type PromiseWithResolvers<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: any) => void;
+};
+
+/**
+ * This function behaves like Promise.withResolvers
+ * See https://tc39.es/proposal-promise-with-resolvers/
+ */
+export function promiseWithResolvers<T = unknown>(): PromiseWithResolvers<T> {
+  let resolve: PromiseWithResolvers<T>['resolve'];
+  let reject: PromiseWithResolvers<T>['reject'];
+  const promise = new Promise<T>((resolve_, reject_) => {
+    resolve = resolve_;
+    reject = reject_;
+  });
+
+  return { promise, resolve: resolve!, reject: reject! };
+}

--- a/src/shared/test/promise-with-resolvers-test.js
+++ b/src/shared/test/promise-with-resolvers-test.js
@@ -1,0 +1,23 @@
+import { promiseWithResolvers } from '../promise-with-resolvers';
+
+describe('promiseWithResolvers', () => {
+  it('resolves returned promise with `resolve` callback', async () => {
+    const { promise, resolve } = promiseWithResolvers();
+    const expected = 'some value';
+
+    resolve(expected);
+
+    const result = await promise;
+
+    assert.equal(result, expected);
+  });
+
+  it('rejects returned promise with `reject` callback', async () => {
+    const { promise, reject } = promiseWithResolvers();
+    const expected = 'some error';
+
+    reject(new Error(expected));
+
+    await assert.rejects(promise, expected);
+  });
+});


### PR DESCRIPTION
A replacement for `Promise.withResolvers` until TS 5.2 is released.