### PR TITLE
Apply automatic opening of the details tag before scrolling to the annotation

### DIFF
--- a/src/annotator/util/scroll.ts
+++ b/src/annotator/util/scroll.ts
@@ -91,7 +91,7 @@ export async function scrollElementIntoView(
   }
 
   // Ensure that the details are open before scrolling, in case the annotation
-  // is within the details tag.This guarantees that the user can promptly view
+  // is within the details tag. This guarantees that the user can promptly view
   // the content on the screen.
   const details = element.closest('details');
   if (details && !details.hasAttribute('open')) {

--- a/src/annotator/util/scroll.ts
+++ b/src/annotator/util/scroll.ts
@@ -90,6 +90,14 @@ export async function scrollElementIntoView(
     });
   }
 
+  // Ensure that the details are open before scrolling, in case the annotation
+  // is within the details tag.This guarantees that the user can promptly view
+  // the content on the screen.
+  const details = element.closest('details');
+  if (details && !details.hasAttribute('open')) {
+    details.setAttribute('open', '');
+  }
+
   await new Promise(resolve =>
     scrollIntoView(element, { time: maxDuration }, resolve),
   );

--- a/src/annotator/util/scroll.ts
+++ b/src/annotator/util/scroll.ts
@@ -95,7 +95,7 @@ export async function scrollElementIntoView(
   // the content on the screen.
   const details = element.closest('details');
   if (details && !details.hasAttribute('open')) {
-    details.setAttribute('open', '');
+    details.open = true;
   }
 
   await new Promise(resolve =>

--- a/src/annotator/util/test/scroll-test.js
+++ b/src/annotator/util/test/scroll-test.js
@@ -129,15 +129,9 @@ describe('annotator/util/scroll', () => {
       }
     });
 
-    it('scrolls element into view when the target is within the details tag', async () => {
+    it('opens containing `<details>` tag to make content visible', async () => {
       const container = createContainer();
-      container.style.height = '500px';
-      container.style.overflow = 'auto';
-      container.style.position = 'relative';
-
       const details = document.createElement('details');
-      details.style.position = 'absolute';
-      details.style.top = '1000px';
       container.append(details);
 
       const summary = document.createElement('summary');
@@ -145,18 +139,11 @@ describe('annotator/util/scroll', () => {
       details.append(summary);
 
       const target = document.createElement('div');
-      target.style.height = '20px';
-      target.style.width = '100px';
       details.append(target);
 
+      assert.isFalse(details.open);
       await scrollElementIntoView(target, { maxDuration: 1 });
-
-      const containerRect = container.getBoundingClientRect();
-      const targetRect = target.getBoundingClientRect();
-
       assert.isTrue(details.open);
-      assert.isTrue(containerRect.top <= targetRect.top);
-      assert.isTrue(containerRect.bottom >= targetRect.bottom);
     });
   });
 });

--- a/src/annotator/util/test/scroll-test.js
+++ b/src/annotator/util/test/scroll-test.js
@@ -128,5 +128,37 @@ describe('annotator/util/scroll', () => {
         delete document.body.tagName;
       }
     });
+
+
+    // A test for scrolling when there is a target within the 'details' tag.
+    it('scrolls element into view when the target is within the details tag',async () => {
+      const container = document.createElement('div');
+      container.style.height = '500px';
+      container.style.overflow = 'auto';
+      container.style.position = 'relative';
+      document.body.append(container);
+
+      const details = document.createElement('details');
+      details.style.position = 'absolute';
+      details.style.top = '1000px';
+      container.append(details);
+
+      const summary = document.createElement('summary');
+      summary.append('Summary');
+      details.append(summary);
+
+      const target = document.createElement('div');
+      target.style.height = '20px';
+      target.style.width = '100px';
+      details.append(target);
+
+      await scrollElementIntoView(target, { maxDuration: 1 });
+
+      const containerRect = container.getBoundingClientRect();
+      const targetRect = target.getBoundingClientRect();
+
+      assert.isTrue(containerRect.top <= targetRect.top);
+      assert.isTrue(containerRect.bottom >= targetRect.bottom);
+    });
   });
 });

--- a/src/annotator/util/test/scroll-test.js
+++ b/src/annotator/util/test/scroll-test.js
@@ -129,7 +129,6 @@ describe('annotator/util/scroll', () => {
       }
     });
 
-    // A test for scrolling when there is a target within the 'details' tag.
     it('scrolls element into view when the target is within the details tag', async () => {
       const container = createContainer();
       container.style.height = '500px';

--- a/src/annotator/util/test/scroll-test.js
+++ b/src/annotator/util/test/scroll-test.js
@@ -129,14 +129,12 @@ describe('annotator/util/scroll', () => {
       }
     });
 
-
     // A test for scrolling when there is a target within the 'details' tag.
-    it('scrolls element into view when the target is within the details tag',async () => {
-      const container = document.createElement('div');
+    it('scrolls element into view when the target is within the details tag', async () => {
+      const container = createContainer();
       container.style.height = '500px';
       container.style.overflow = 'auto';
       container.style.position = 'relative';
-      document.body.append(container);
 
       const details = document.createElement('details');
       details.style.position = 'absolute';
@@ -157,6 +155,7 @@ describe('annotator/util/scroll', () => {
       const containerRect = container.getBoundingClientRect();
       const targetRect = target.getBoundingClientRect();
 
+      assert.isTrue(details.open);
       assert.isTrue(containerRect.top <= targetRect.top);
       assert.isTrue(containerRect.bottom >= targetRect.bottom);
     });


### PR DESCRIPTION
Hello everyone,
I'm excited to be contributing to this project for the first time. I've found the hypothesis to be valuable, and I want to extend my thanks to all the contributors who are dedicated to improving this project.

## Description

While reading the [react.dev](https://react.dev/), I encountered an issue related to scrolling. When trying to access annotations within the 'Deep Dive' section, which allows toggling to view detailed information, the page didn't scroll accurately to the intended location.

For your reference, I have attached a video demonstrating the situation.

https://github.com/hypothesis/client/assets/37607373/eae9711b-938b-4f15-9922-578fc49aa763

## Changes Made

The issue stems from annotations within the \<details\> tag. When the \<details\> tag is closed, the content remains concealed.
In this pull request, I have resolved the problem by ensuring that the \<details\> tag is opened before scrolling. This guarantees that the content is correctly displayed.

For your review, I have also attached a video showing the results.

https://github.com/hypothesis/client/assets/37607373/8ddbdff9-9fb7-4c5b-8c6d-67732322861b

If there are any parts of the code that need adjustment or things I might have missed during the contribution process, please feel free to let me know. Your feedback would be greatly appreciated.
