### PR TITLE
Make sure user input is not overridden by export suggestions

### DIFF
--- a/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
+++ b/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
@@ -1,5 +1,5 @@
 import { Button, CardActions, Input } from '@hypothesis/frontend-shared';
-import { useRef } from 'preact/hooks';
+import { useMemo, useState } from 'preact/hooks';
 
 import { downloadJSONFile } from '../../../shared/download-json-file';
 import { withServices } from '../../service-context';
@@ -14,8 +14,6 @@ export type ExportAnnotationsProps = {
   annotationsExporter: AnnotationsExporter;
   toastMessenger: ToastMessengerService;
 };
-
-// TODO: does the Input need a label?
 
 /**
  * Render content for "export" tab panel: allow user to export annotations
@@ -32,7 +30,11 @@ function ExportAnnotations({
   const exportCount = exportableAnnotations.length;
   const draftCount = store.countDrafts();
 
-  const inputRef = useRef<HTMLInputElement | null>(null);
+  const defaultFilename = useMemo(
+    () => suggestedFilename({ groupName: group?.name }),
+    [group],
+  );
+  const [customFilename, setCustomFilename] = useState<string>();
 
   if (!exportReady) {
     return <LoadingSpinner />;
@@ -42,7 +44,7 @@ function ExportAnnotations({
     e.preventDefault();
 
     try {
-      const filename = `${inputRef.current!.value}.json`;
+      const filename = `${customFilename ?? defaultFilename}.json`;
       const exportData = annotationsExporter.buildExportContent(
         exportableAnnotations,
       );
@@ -75,8 +77,11 @@ function ExportAnnotations({
           <Input
             data-testid="export-filename"
             id="export-filename"
-            defaultValue={suggestedFilename({ groupName: group?.name })}
-            elementRef={inputRef}
+            defaultValue={defaultFilename}
+            value={customFilename}
+            onChange={e =>
+              setCustomFilename((e.target as HTMLInputElement).value)
+            }
             required
             maxLength={250}
           />

--- a/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
+++ b/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
@@ -135,9 +135,12 @@ describe('ExportAnnotations', () => {
 
     it('downloads a file using user-entered filename appended with `.json`', () => {
       const wrapper = createComponent();
+      const filenameInput = wrapper.find(
+        'input[data-testid="export-filename"]',
+      );
 
-      wrapper.find('input[data-testid="export-filename"]').getDOMNode().value =
-        'my-filename';
+      filenameInput.getDOMNode().value = 'my-filename';
+      filenameInput.simulate('change');
 
       submitExportForm(wrapper);
 


### PR DESCRIPTION
> Depends on https://github.com/hypothesis/client/pull/5723

Change the annotations export input and make it a controlled input.

This allows to use suggested filenames as default values, while we still track the user input on a different piece of state.

With this, if the selected group changes and the user did not interact with the input, we will change to a new suggested name based on the new selected group name.

On the other hand, if the user changed the input value, this will prevail over the suggested name.

 ### Testing steps

1. Open the export annotations panel (you need to enable `export_annotations` feature flag on your local `h` instance)
2. Check that the input displays a value containing the currently selected group name.
3. Change selected group. The input should display a different suggested filename now.
4. Edit the input value and set any content on it.
5. Change selected group again. This time it should keep the value that was manually introduced.