### PR TITLE
Exclude replies from import

### DIFF
--- a/src/sidebar/helpers/annotation-metadata.ts
+++ b/src/sidebar/helpers/annotation-metadata.ts
@@ -121,7 +121,7 @@ function titleTextFromAnnotation(annotation: Annotation): string {
 /**
  * Return `true` if the given annotation is a reply, `false` otherwise.
  */
-export function isReply(annotation: Annotation): boolean {
+export function isReply(annotation: APIAnnotationData): boolean {
   return (annotation.references || []).length > 0;
 }
 


### PR DESCRIPTION
In the initial implementation of import, we have decided to exclude replies to simplify the feature. In other words, the import feature only supports importing top level annotations from a single user.

On `main`, replies are included in the count of annotations available to import from a user, and then actually imported as top level annotations when you click "Import". In this PR, replies are excluded from both the counts of annotations available to import, as well as the actually imported annotations.

The export dialog has _not_ yet been updated, and still counts replies in the "Export N annotations..." message. This will be addressed separately.

Part of https://github.com/hypothesis/client/issues/5742.