### PR TITLE
Add accessibility tests to FileInput component

### DIFF
--- a/src/sidebar/components/ShareDialog/FileInput.tsx
+++ b/src/sidebar/components/ShareDialog/FileInput.tsx
@@ -27,7 +27,6 @@ export default function FileInput({
         disabled={disabled}
         className="invisible absolute w-0 h-0"
         aria-hidden
-        tabIndex={-1}
         data-testid="file-input"
         onChange={e => {
           const files = (e.target as HTMLInputElement)!.files;

--- a/src/sidebar/components/ShareDialog/test/FileInput-test.js
+++ b/src/sidebar/components/ShareDialog/test/FileInput-test.js
@@ -1,5 +1,6 @@
 import { mount } from 'enzyme';
 
+import { checkAccessibility } from '../../../../test-util/accessibility';
 import FileInput from '../FileInput';
 
 describe('FileInput', () => {
@@ -96,4 +97,18 @@ describe('FileInput', () => {
       assert.equal(proxyButton.prop('disabled'), disabled);
     });
   });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility([
+      {
+        content: () =>
+          mount(
+            <div>
+              <FileInput onFileSelected={fakeOnFileSelected} />
+            </div>,
+          ),
+      },
+    ]),
+  );
 });


### PR DESCRIPTION
I forgot to add accessibility tests when creating the `FileInput`.

It was covered, because it's used by `ImportAnnotations`, and it's not mocked there, but just in case that changes at some point, it makes sense to have it covered on its own test.