### PR TITLE
Separate annotation and reply counts in exports

### DIFF
--- a/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
+++ b/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
@@ -83,24 +83,41 @@ describe('ExportAnnotations', () => {
     });
   });
 
-  it('shows a count of annotations for export', () => {
-    fakeStore.savedAnnotations.returns([fixtures.oldAnnotation()]);
-    const wrapperSingular = createComponent();
-    fakeStore.savedAnnotations.returns([
-      fixtures.oldAnnotation(),
-      fixtures.oldAnnotation(),
-    ]);
-    const wrapperPlural = createComponent();
-
-    assert.include(
-      wrapperSingular.find('[data-testid="export-count"]').text(),
-      'Export 1 annotation in a file',
-    );
-
-    assert.include(
-      wrapperPlural.find('[data-testid="export-count"]').text(),
-      'Export 2 annotations in a file',
-    );
+  [
+    {
+      annotations: [fixtures.oldAnnotation()],
+      message: 'Export 1 annotation in a file',
+    },
+    {
+      annotations: [fixtures.oldAnnotation(), fixtures.oldAnnotation()],
+      message: 'Export 2 annotations in a file',
+    },
+    {
+      annotations: [
+        fixtures.oldAnnotation(),
+        fixtures.oldAnnotation(),
+        fixtures.oldReply(),
+      ],
+      message: 'Export 2 annotations (and 1 reply) in a file',
+    },
+    {
+      annotations: [
+        fixtures.oldAnnotation(),
+        fixtures.oldAnnotation(),
+        fixtures.oldReply(),
+        fixtures.oldReply(),
+      ],
+      message: 'Export 2 annotations (and 2 replies) in a file',
+    },
+  ].forEach(({ annotations, message }) => {
+    it('shows a count of annotations for export', () => {
+      fakeStore.savedAnnotations.returns(annotations);
+      const wrapper = createComponent();
+      assert.include(
+        wrapper.find('[data-testid="export-count"]').text(),
+        message,
+      );
+    });
   });
 
   it('provides a filename field with a default suggested name', () => {
@@ -211,12 +228,12 @@ describe('ExportAnnotations', () => {
 
       assert.include(
         wrapperSingular.find('[data-testid="drafts-message"]').text(),
-        'You have 1 unsaved annotation that',
+        'You have 1 unsaved draft that',
       );
 
       assert.include(
         wrapperPlural.find('[data-testid="drafts-message"]').text(),
-        'You have 2 unsaved annotations that',
+        'You have 2 unsaved drafts that',
       );
     });
   });

--- a/src/sidebar/store/modules/annotations.ts
+++ b/src/sidebar/store/modules/annotations.ts
@@ -554,9 +554,10 @@ const orphanCount = createSelector(
 /**
  * Return all loaded annotations which have been saved to the server
  */
-function savedAnnotations(state: State): SavedAnnotation[] {
-  return state.annotations.filter(ann => isSaved(ann)) as SavedAnnotation[];
-}
+const savedAnnotations = createSelector(
+  (state: State) => state.annotations,
+  annotations => annotations.filter(ann => isSaved(ann)) as SavedAnnotation[],
+);
 
 export const annotationsModule = createStoreModule(initialState, {
   namespace: 'annotations',


### PR DESCRIPTION
This ensures that the count of annotations displayed in the Export tab matches the count of top-level annotations that we show in the user list, and actually import, in the Import tab.

<img width="423" alt="Export tab with separate annotation and reply counts" src="https://github.com/hypothesis/client/assets/2458/e6eeff8e-e8f1-4d9e-bcee-208312e33b08">

When reporting unsaved annotations, use the term "draft" which covers both annotations and replies.

Part of https://github.com/hypothesis/client/issues/5742
