### PR TITLE
Make FileInput component be focused as a whole

### DIFF
--- a/src/sidebar/components/ShareDialog/FileInput.tsx
+++ b/src/sidebar/components/ShareDialog/FileInput.tsx
@@ -36,7 +36,7 @@ export default function FileInput({
         }}
       />
       <label htmlFor={inputId}>Select Hypothesis export file:</label>
-      <InputGroup>
+      <InputGroup classes="focus-within-ring rounded">
         <Input
           id={inputId}
           onClick={() => fileInputRef.current?.click()}
@@ -45,6 +45,7 @@ export default function FileInput({
           value={fileInputRef.current?.files![0]?.name ?? 'Select a file'}
           data-testid="file-input-proxy-input"
           classes="cursor-pointer"
+          tabIndex={-1}
         />
         <IconButton
           title="Select a file"

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -216,7 +216,9 @@ export default {
       // element had the `.theme-clean` class.
       addVariant('theme-clean', '.theme-clean &');
     }),
-    plugin(({ addComponents, addUtilities }) => {
+    plugin(({ addComponents, addUtilities, theme }) => {
+      const ringWidth = theme('ringWidth.DEFAULT');
+
       addUtilities({
         // Tailwind does not provide hyphens-related utility classes.
         '.hyphens-none': {
@@ -229,6 +231,20 @@ export default {
         '.break-anywhere': {
           'overflow-wrap': 'anywhere',
         },
+
+        // This acts like focus-visible-ring utility, but designed to mimic focus
+        // on elements which are not focusable and need to be to highlighted when
+        // children elements are focused.
+        '.focus-within-ring': {
+          '&:focus-within': {
+            boxShadow: `var(--tw-ring-inset) 0 0 0 calc(${ringWidth} + var(--tw-ring-offset-width)) var(--tw-ring-color)`,
+            outline: 'none',
+          },
+          // Disable focus ring on children elements
+          '.focus-visible-ring': {
+            boxShadow: 'none !important'
+          }
+        }
       });
       addComponents({
         // Add a custom class to set all properties to initial values. Used


### PR DESCRIPTION
Improve accessibility on custom `FileInput` by improving how it behaves when interacting with the keyboard.

* Use `:focus-within` to make the `InputGroup` render a focus ring when any of its children are focused.
* Disable focus ring on children.
* Remove the proxy input from the tab sequence, so that only the proxy button can be focused on the FileInput. The button has keyboard capabilities out of the box.

[Grabación de pantalla desde 2023-08-23 15-32-14.webm](https://github.com/hypothesis/client/assets/2719332/5597dfbc-ceb7-47a2-a106-1212b1d09d58)

### Considerations

* I have created a new `focus-within-ring` tailwind utility to achieve the behavior above. It implicitly overrides the styles set by `.focus-visible-ring`, which couples it a bit with its implementation.
    * A possible mitigation to this would be to move this new utility to frontend-shared, and place it's definition next to `focus-visible-ring`.
* The only practical way I found to remove the text Input from the tab sequence without loosing the hability to click on it, was by setting `tabIndex="-1"`. This works, but can be semantically incorrect, as it suggests the input can be programmatically focused somehow.

### Testing steps

1. Check out this branch.
2. Open the import tab.
3. Try to navigate the components using the `Tab` key, and check the FileInput gets focused as a whole.
4. Pressing `Enter` or `Space` while the `FileInput` is "focused" should open the file dialog.