### PR TITLE
Import multiple annotations concurrently

### DIFF
--- a/src/sidebar/services/test/import-annotations-test.js
+++ b/src/sidebar/services/test/import-annotations-test.js
@@ -84,6 +84,25 @@ describe('ImportAnnotationsService', () => {
       });
     });
 
+    it('can save many annotations', async () => {
+      const svc = createService();
+      const anns = [];
+      const totalAnns = 23; // A total that exceeds the max number of concurrent imports.
+      while (anns.length < totalAnns) {
+        anns.push(generateAnnotation());
+      }
+
+      await svc.import(anns);
+
+      assert.equal(fakeAnnotationsService.save.callCount, anns.length);
+      for (const ann of anns) {
+        assert.calledWith(fakeAnnotationsService.save, {
+          $tag: 'dummy',
+          ...ann,
+        });
+      }
+    });
+
     it('does not skip annotation if existing annotations in store differ', async () => {
       const svc = createService();
       const ann = generateAnnotation();


### PR DESCRIPTION
Speed up large imports by allowing up to 5 imports to be in-flight concurrently.

The simplest approach to this would be to divide the annotations into batches and save one at a time. However due to the variability in the time that an individual import can take, this can lead to sub-optimal concurrency. Instead structure the code so that we try to always keep `MAX_CONCURRENT_IMPORTS` imports in flight at once, as long as there are that many remaining.

In some tests with the production h service, this speed up an import of 81 annotations from around 60s (!) to ~30s. Figuring out why the gain is much smaller than the concurrency factor is something I'm going to look into, but I think this initial implementation is worth landing in the meantime.

Fixes https://github.com/hypothesis/client/issues/5739