### PR TITLE
Make ShareDialog receive the list of tabs to render

### DIFF
--- a/src/sidebar/components/HypothesisApp.tsx
+++ b/src/sidebar/components/HypothesisApp.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo } from 'preact/hooks';
 import { confirm } from '../../shared/prompts';
 import type { SidebarSettings } from '../../types/config';
 import { serviceConfig } from '../config/service-config';
+import { isThirdPartyService } from '../helpers/is-third-party-service';
 import { shouldAutoDisplayTutorial } from '../helpers/session';
 import { applyTheme } from '../helpers/theme';
 import { withServices } from '../service-context';
@@ -61,6 +62,12 @@ function HypothesisApp({
       store.openSidebarPanel('help');
     }
   }, [isSidebar, profile, settings, store]);
+
+  const isThirdParty = isThirdPartyService(settings);
+  const exportAnnotations = store.isFeatureEnabled('export_annotations');
+  const importAnnotations = store.isFeatureEnabled('import_annotations');
+  const showShareButton =
+    !isThirdParty || exportAnnotations || importAnnotations;
 
   const login = async () => {
     if (serviceConfig(settings)) {
@@ -155,12 +162,19 @@ function HypothesisApp({
           onSignUp={signUp}
           onLogout={logout}
           isSidebar={isSidebar}
+          showShareButton={showShareButton}
         />
       )}
       <div className="container">
         <ToastMessages />
         <HelpPanel />
-        <ShareDialog />
+        {showShareButton && (
+          <ShareDialog
+            shareTab={!isThirdParty}
+            exportTab={exportAnnotations}
+            importTab={importAnnotations}
+          />
+        )}
 
         {route && (
           <main>

--- a/src/sidebar/components/ShareDialog/ShareDialog.tsx
+++ b/src/sidebar/components/ShareDialog/ShareDialog.tsx
@@ -9,23 +9,34 @@ import ShareAnnotations from './ShareAnnotations';
 import TabHeader from './TabHeader';
 import TabPanel from './TabPanel';
 
+export type ShareDialogProps = {
+  /** If true, the share tab will be rendered. Defaults to false */
+  shareTab?: boolean;
+  /** If true, the export tab will be rendered. Defaults to false */
+  exportTab?: boolean;
+  /** If true, the import tab will be rendered. Defaults to false */
+  importTab?: boolean;
+};
+
 /**
  * Panel with sharing options.
- * - If export feature flag is enabled, will show a tabbed interface with
- *   share and export tabs
+ * - If provided tabs include `export` or `import`, will show a tabbed interface
  * - Else, shows a single "Share annotations" interface
  */
-export default function ShareDialog() {
+export default function ShareDialog({
+  shareTab,
+  exportTab,
+  importTab,
+}: ShareDialogProps) {
   const store = useSidebarStore();
   const focusedGroup = store.focusedGroup();
   const groupName = (focusedGroup && focusedGroup.name) || '...';
   const panelTitle = `Share Annotations in ${groupName}`;
 
-  const showExportTab = store.isFeatureEnabled('export_annotations');
-  const showImportTab = store.isFeatureEnabled('import_annotations');
-  const tabbedDialog = showExportTab || showImportTab;
+  const tabbedDialog = exportTab || importTab;
   const [selectedTab, setSelectedTab] = useState<'share' | 'export' | 'import'>(
-    'share',
+    // Determine initial selected tab, based on the first tab that will be displayed
+    shareTab ? 'share' : exportTab ? 'export' : 'import',
   );
 
   return (
@@ -37,17 +48,19 @@ export default function ShareDialog() {
       {tabbedDialog && (
         <>
           <TabHeader>
-            <Tab
-              id="share-panel-tab"
-              aria-controls="share-panel"
-              variant="tab"
-              selected={selectedTab === 'share'}
-              onClick={() => setSelectedTab('share')}
-              textContent={'Share'}
-            >
-              Share
-            </Tab>
-            {showExportTab && (
+            {shareTab && (
+              <Tab
+                id="share-panel-tab"
+                aria-controls="share-panel"
+                variant="tab"
+                selected={selectedTab === 'share'}
+                onClick={() => setSelectedTab('share')}
+                textContent="Share"
+              >
+                Share
+              </Tab>
+            )}
+            {exportTab && (
               <Tab
                 id="export-panel-tab"
                 aria-controls="export-panel"
@@ -59,7 +72,7 @@ export default function ShareDialog() {
                 Export
               </Tab>
             )}
-            {showImportTab && (
+            {importTab && (
               <Tab
                 id="import-panel-tab"
                 aria-controls="import-panel"
@@ -85,7 +98,7 @@ export default function ShareDialog() {
               id="export-panel"
               active={selectedTab === 'export'}
               aria-labelledby="export-panel-tab"
-              title={`Export from ${focusedGroup?.name ?? '...'}`}
+              title={`Export from ${groupName}`}
             >
               <ExportAnnotations />
             </TabPanel>
@@ -93,14 +106,14 @@ export default function ShareDialog() {
               id="import-panel"
               active={selectedTab === 'import'}
               aria-labelledby="import-panel-tab"
-              title={`Import into ${focusedGroup?.name ?? '...'}`}
+              title={`Import into ${groupName}`}
             >
               <ImportAnnotations />
             </TabPanel>
           </Card>
         </>
       )}
-      {!tabbedDialog && <ShareAnnotations />}
+      {shareTab && !tabbedDialog && <ShareAnnotations />}
     </SidebarPanel>
   );
 }

--- a/src/sidebar/components/TopBar.tsx
+++ b/src/sidebar/components/TopBar.tsx
@@ -8,7 +8,6 @@ import classnames from 'classnames';
 
 import type { SidebarSettings } from '../../types/config';
 import { serviceConfig } from '../config/service-config';
-import { isThirdPartyService } from '../helpers/is-third-party-service';
 import { applyTheme } from '../helpers/theme';
 import { withServices } from '../service-context';
 import type { FrameSyncService } from '../services/frame-sync';
@@ -21,6 +20,8 @@ import StreamSearchInput from './StreamSearchInput';
 import UserMenu from './UserMenu';
 
 export type TopBarProps = {
+  showShareButton: boolean;
+
   /** Flag indicating whether the app is in a sidebar context */
   isSidebar: boolean;
 
@@ -49,8 +50,8 @@ function TopBar({
   onSignUp,
   frameSync,
   settings,
+  showShareButton,
 }: TopBarProps) {
-  const showSharePageButton = !isThirdPartyService(settings);
   const loginLinkStyle = applyTheme(['accentColor'], settings);
 
   const store = useSidebarStore();
@@ -106,7 +107,7 @@ function TopBar({
                 onSearch={store.setFilterQuery}
               />
               <SortMenu />
-              {showSharePageButton && (
+              {showShareButton && (
                 <IconButton
                   icon={ShareIcon}
                   expanded={isAnnotationsPanelOpen}

--- a/src/sidebar/components/test/HypothesisApp-test.js
+++ b/src/sidebar/components/test/HypothesisApp-test.js
@@ -14,6 +14,7 @@ describe('HypothesisApp', () => {
   let fakeShouldAutoDisplayTutorial = null;
   let fakeSettings = null;
   let fakeToastMessenger = null;
+  let fakeIsThirdPartyService;
 
   const createComponent = (props = {}) => {
     return mount(
@@ -53,6 +54,7 @@ describe('HypothesisApp', () => {
       route: sinon.stub().returns('sidebar'),
 
       getLink: sinon.stub(),
+      isFeatureEnabled: sinon.stub().returns(true),
     };
 
     fakeAuth = {};
@@ -76,6 +78,8 @@ describe('HypothesisApp', () => {
 
     fakeConfirm = sinon.stub().resolves(false);
 
+    fakeIsThirdPartyService = sinon.stub().returns(false);
+
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       '../config/service-config': { serviceConfig: fakeServiceConfig },
@@ -85,6 +89,9 @@ describe('HypothesisApp', () => {
       },
       '../helpers/theme': { applyTheme: fakeApplyTheme },
       '../../shared/prompts': { confirm: fakeConfirm },
+      '../helpers/is-third-party-service': {
+        isThirdPartyService: fakeIsThirdPartyService,
+      },
     });
   });
 
@@ -398,6 +405,23 @@ describe('HypothesisApp', () => {
       const container = wrapper.find(appSelector);
 
       assert.isFalse(container.hasClass('theme-clean'));
+    });
+  });
+
+  context('when there are no sharing tabs to show', () => {
+    beforeEach(() => {
+      fakeStore.isFeatureEnabled.returns(false);
+      fakeIsThirdPartyService.returns(true);
+    });
+
+    it('does not render ShareDialog', () => {
+      const wrapper = createComponent();
+      assert.isFalse(wrapper.exists('ShareDialog'));
+    });
+
+    it('disables share button in TopBar', () => {
+      const wrapper = createComponent();
+      assert.isFalse(wrapper.find('TopBar').prop('showShareButton'));
     });
   });
 });

--- a/src/sidebar/components/test/TopBar-test.js
+++ b/src/sidebar/components/test/TopBar-test.js
@@ -9,12 +9,9 @@ describe('TopBar', () => {
   let fakeFrameSync;
   let fakeStore;
   let fakeStreamer;
-  let fakeIsThirdPartyService;
   let fakeServiceConfig;
 
   beforeEach(() => {
-    fakeIsThirdPartyService = sinon.stub().returns(false);
-
     fakeStore = {
       filterQuery: sinon.stub().returns(null),
       hasFetchedProfile: sinon.stub().returns(false),
@@ -38,9 +35,6 @@ describe('TopBar', () => {
 
     $imports.$mock({
       '../store': { useSidebarStore: () => fakeStore },
-      '../helpers/is-third-party-service': {
-        isThirdPartyService: fakeIsThirdPartyService,
-      },
       '../config/service-config': { serviceConfig: fakeServiceConfig },
     });
   });
@@ -63,6 +57,7 @@ describe('TopBar', () => {
         isSidebar={true}
         settings={fakeSettings}
         streamer={fakeStreamer}
+        showShareButton
         {...props}
       />,
     );
@@ -149,13 +144,6 @@ describe('TopBar', () => {
     });
   });
 
-  it("checks whether we're using a third-party service", () => {
-    createTopBar();
-
-    assert.called(fakeIsThirdPartyService);
-    assert.alwaysCalledWithExactly(fakeIsThirdPartyService, fakeSettings);
-  });
-
   context('when using a first-party service', () => {
     it('shows the share annotations button', () => {
       const wrapper = createTopBar();
@@ -163,13 +151,9 @@ describe('TopBar', () => {
     });
   });
 
-  context('when using a third-party service', () => {
-    beforeEach(() => {
-      fakeIsThirdPartyService.returns(true);
-    });
-
+  context('when showShareButton is false', () => {
     it("doesn't show the share annotations button", () => {
-      const wrapper = createTopBar();
+      const wrapper = createTopBar({ showShareButton: false });
       assert.isFalse(
         wrapper.exists('[title="Share annotations on this page"]'),
       );


### PR DESCRIPTION
While trying to test import/export feature in the LMS context, I realized we were not displaying the "share" button in the `TopBar`, because in the past, this button would only display the share section, which is not relevant for LMS.

This PR refactors the logic to determine when to display that button, and what tabs to render when it is clicked, so that we can show Import/Export tabs in LMS.

### Context

Before the changes in this PR, the component hierarchy looked like this:

```
HypothesisApp
    TopBar
    ShareDialog
```

* The `TopBar` had an internal logic to determine if the context was the LMS, and not render the share button in that case.
* The `ShareDialog` is opened when the share button is clicked, and contains either the share panel, or a tabbed structure including the share panel, and the import and/or export tabs based on feature flags.

In order to be able to show the relevant tabs depending on the context, and the share button only if at least one tab needs to be displayed, I have decided to refactor the three components above, as now they have cross-dependent logic.

Now, the `ShareDialog` no longer checks feature flags, as on top of that, now it would also need to check if it's rendered in the LMS context.

Instead, it now receives the tabs to render ~, enforcing the list to not be empty, and "just" iterating over whatever was provided and rendering those tabs blindly~.

Regarding the `TopBar`, the logic to dynamically render the share button is also removed from it, and instead, it now expects a boolean prop to be provided to render the button or not.

The logic to determine which tabs to render is now moved to the `HypothesisApp` component, which wraps the other two:

* It is now responsible of checking all needed conditions (are feature flags enabled? are we running in the LMS context?) and based on that determine the tabs.
* If no tabs should be displayed, we pass `showShareButton={false}` to the `TopBar`, and don't render the `ShareDialog` at all.
* If there's at least one tab, we pass `showShareButton={true}` to the `TopBar`, and render the `ShareDialog` with the appropriate tabs.

### Testing steps

You need to check that:

* While both import and export feature flags are disabled:
  * We show no share button in LMS.
  * In the public instance, the share panel shows no tabs, only the public sharing panel.
* If any of those feature flags is enabled
  * We show the button in LMS, which will show 1 or 2 tabs, depending on which features are enabled.
  * The public instance will display up to three tabs when clicking the share button.

Closes #5750 