### PR TITLE
Overwrite imported annotations URI with target document one

### DIFF
--- a/src/sidebar/services/import-annotations.ts
+++ b/src/sidebar/services/import-annotations.ts
@@ -19,12 +19,12 @@ type ImportData = Pick<
  * Return a copy of `ann` that contains only fields which can be preserved by
  * an import performed on the client.
  */
-function getImportData(ann: APIAnnotationData): ImportData {
+function getImportData(ann: APIAnnotationData, uri?: string): ImportData {
   return {
     target: ann.target,
     tags: ann.tags,
     text: ann.text,
-    uri: ann.uri,
+    uri: uri ?? ann.uri,
     document: ann.document,
   };
 }
@@ -128,6 +128,7 @@ export class ImportAnnotationsService {
     this._store.beginImport(anns.length);
 
     const existingAnns = this._store.allAnnotations();
+    const currentUri = this._store.mainFrame()?.uri;
 
     const importAnn = async (ann: APIAnnotationData): Promise<ImportResult> => {
       const existingAnn = existingAnns.find(ex => duplicateMatch(ann, ex));
@@ -136,8 +137,9 @@ export class ImportAnnotationsService {
       }
 
       try {
-        // Strip out all the fields that are ignored in an import.
-        const importData = getImportData(ann);
+        // Strip out all the fields that are ignored in an import, and overwrite
+        // the URI with current document's URI.
+        const importData = getImportData(ann, currentUri);
 
         // Fill out the annotation with default values for the current user and
         // group.

--- a/src/sidebar/services/test/import-annotations-test.js
+++ b/src/sidebar/services/test/import-annotations-test.js
@@ -13,6 +13,7 @@ describe('ImportAnnotationsService', () => {
       allAnnotations: sinon.stub().returns([]),
       beginImport: sinon.stub(),
       completeImport: sinon.stub(),
+      mainFrame: sinon.stub(),
     };
 
     fakeToastMessenger = {
@@ -81,6 +82,22 @@ describe('ImportAnnotationsService', () => {
       assert.calledWith(fakeAnnotationsService.save, {
         $tag: 'dummy',
         ...ann,
+      });
+    });
+
+    it('overwrites annotation URI with current document one', async () => {
+      const newUri = 'new_document_uri';
+      fakeStore.mainFrame.returns({ uri: newUri });
+
+      const svc = createService();
+      const ann = generateAnnotation();
+
+      await svc.import([ann]);
+
+      assert.calledWith(fakeAnnotationsService.save, {
+        $tag: 'dummy',
+        ...ann,
+        uri: newUri,
       });
     });
 


### PR DESCRIPTION
> This PR is part of #5743 

Fulfill the happy path on import annotations, making sure the annotations URI is the one of the document in which annotations are being imported, rather than the original document.

In most of the cases, and specially in the LMS context, instructors will export annotations from one assignment, and import them on a different one, where the document is effectively the same, but the URI may differ due to temporal LMS URLs and such.

This change ensures the annotations are still loaded after refreshing the page.

In future, we should enhance this, allowing instructors avoid mistakes if they in fact import annotations from a completely different document.

### Testing steps

1. Export annotations from one age or document.
2. Import them on a completely different one.
3. If the page is refreshed, imported annotations should still be loaded in the sidebar (notice not all of them will anchor, depending on how different original and new documents are).