### PR TITLE
Disable import button if group, document metadata of existing annotations not available

### DIFF
--- a/src/sidebar/components/ShareDialog/ImportAnnotations.tsx
+++ b/src/sidebar/components/ShareDialog/ImportAnnotations.tsx
@@ -87,8 +87,6 @@ function ImportAnnotations({
     [annotations, getDisplayName],
   );
 
-  const importsPending = store.importsPending();
-
   // Parse input file, extract annotations and update the user list.
   useEffect(() => {
     if (!currentUser || !file) {
@@ -135,11 +133,27 @@ function ImportAnnotations({
     );
   }
 
+  // In order to perform an import, we need:
+  //
+  //  1. A group to import into
+  //  2. A frame from which to get the document URI and metadata
+  //  3. Existing annotations for the group loaded so we can de-duplicate against
+  //     them
+  //  4. A file to import from and a selection of what to import
+  //     (`importAnnotations` will be falsey if this is not the case).
+  const importReady = Boolean(
+    store.focusedGroup() &&
+      store.mainFrame() &&
+      store.hasFetchedAnnotations() &&
+      !store.isFetchingAnnotations() &&
+      importAnnotations,
+  );
+
   // True if we're validating a JSON file after it has been selected.
   const parseInProgress = file && !annotations && !error;
 
   // True if we're validating or importing.
-  const busy = parseInProgress || importsPending > 0;
+  const busy = parseInProgress || store.importsPending() > 0;
 
   return (
     <>
@@ -183,7 +197,7 @@ function ImportAnnotations({
       <CardActions>
         <Button
           data-testid="import-button"
-          disabled={!importAnnotations || busy}
+          disabled={!importReady || busy}
           onClick={importAnnotations}
           variant="primary"
         >


### PR DESCRIPTION
Prevent the user from importing annotations until we have:

 - A group to import into
 - A set of existing annotations to match against
 - Document metadata to use for the new annotations

I considered replacing the whole dialog with a `LoadingSpinner` until these
conditions are met, like the Export dialog does, but it makes for a less jumpy
transition when eg. switching groups if we just disable the button.

On this branch, you can still select a file to import from if any of the above conditions are true, but the "Import" button will be disabled if:

- The initial client load is in progress
- The document is still loading. This is mainly relevant for large PDFs.
- You switched between groups and the newly selected group is still loading
