### PR TITLE
Disable group switch and logout during import

### DIFF
--- a/src/sidebar/components/GroupList/GroupList.tsx
+++ b/src/sidebar/components/GroupList/GroupList.tsx
@@ -40,6 +40,9 @@ function GroupList({ settings }: GroupListProps) {
   const focusedGroup = store.focusedGroup();
   const userid = store.profile().userid;
 
+  // Prevent changing groups during an import
+  const disabled = store.importsPending() > 0;
+
   const myGroupsSorted = useMemo(
     () => groupsByOrganization(myGroups),
     [myGroups],
@@ -117,6 +120,7 @@ function GroupList({ settings }: GroupListProps) {
     <Menu
       align="left"
       contentClass="min-w-[250px]"
+      disabled={disabled}
       label={label}
       onOpenChanged={() => setExpandedGroup(null)}
       title={menuTitle}

--- a/src/sidebar/components/GroupList/test/GroupList-test.js
+++ b/src/sidebar/components/GroupList/test/GroupList-test.js
@@ -50,6 +50,7 @@ describe('GroupList', () => {
       getLink: sinon.stub().returns(''),
       getMyGroups: sinon.stub().returns([]),
       focusedGroup: sinon.stub().returns(testGroup),
+      importsPending: sinon.stub().returns(0),
       profile: sinon.stub().returns({ userid: null }),
     };
     fakeServiceConfig = sinon.stub().returns(null);
@@ -70,6 +71,13 @@ describe('GroupList', () => {
     const menu = wrapper.find('Menu');
 
     assert.equal(menu.props().title, 'Select group (now viewing: Test group)');
+  });
+
+  it('disables menu if imports are in progress', () => {
+    fakeStore.importsPending.returns(1);
+    const wrapper = createGroupList();
+    const menu = wrapper.find('Menu');
+    assert.isTrue(menu.prop('disabled'));
   });
 
   it('adds descriptive label text if no currently-focused group', () => {

--- a/src/sidebar/components/Menu.tsx
+++ b/src/sidebar/components/Menu.tsx
@@ -51,6 +51,8 @@ export type MenuProps = {
    */
   defaultOpen?: boolean;
 
+  disabled?: boolean;
+
   /** Whether to render an (arrow) indicator next to the Menu label */
   menuIndicator?: boolean;
 
@@ -98,6 +100,7 @@ export default function Menu({
   containerPositioned = true,
   contentClass,
   defaultOpen = false,
+  disabled = false,
   label,
   open,
   onOpenChanged,
@@ -201,6 +204,7 @@ export default function Menu({
           },
         )}
         data-testid="menu-toggle-button"
+        disabled={disabled}
         onMouseDown={toggleMenu}
         onClick={toggleMenu}
         aria-label={title}

--- a/src/sidebar/components/UserMenu.tsx
+++ b/src/sidebar/components/UserMenu.tsx
@@ -42,8 +42,14 @@ function UserMenu({ frameSync, onLogout, settings }: UserMenuProps) {
 
   const isSelectableProfile =
     !isThirdParty || serviceSupports('onProfileRequestProvided');
-  const isLogoutEnabled =
+
+  // Is logging out generally possible for the current user?
+  const logoutAvailable =
     !isThirdParty || serviceSupports('onLogoutRequestProvided');
+
+  // Is logging out possible right now?
+  const logoutDisabled = store.importsPending() > 0;
+
   const isProfileEnabled = store.isFeatureEnabled('client_user_profile');
 
   const onSelectNotebook = () => {
@@ -104,9 +110,13 @@ function UserMenu({ frameSync, onLogout, settings }: UserMenuProps) {
           )}
           <MenuItem label="Open notebook" onClick={() => onSelectNotebook()} />
         </MenuSection>
-        {isLogoutEnabled && (
+        {logoutAvailable && (
           <MenuSection>
-            <MenuItem label="Log out" onClick={onLogout} />
+            <MenuItem
+              isDisabled={logoutDisabled}
+              label="Log out"
+              onClick={onLogout}
+            />
           </MenuSection>
         )}
       </Menu>

--- a/src/sidebar/components/test/Menu-test.js
+++ b/src/sidebar/components/test/Menu-test.js
@@ -52,6 +52,12 @@ describe('Menu', () => {
     assert.isFalse(isOpen(wrapper));
   });
 
+  it('disables menu if `disabled` prop is true', () => {
+    const wrapper = createMenu({ disabled: true });
+    const toggle = wrapper.find(toggleSelector);
+    assert.isTrue(toggle.prop('disabled'));
+  });
+
   it('leaves the management of open/closed state to parent component if `open` prop present', () => {
     // When `open` is present, `Menu` will invoke `onOpenChanged` on interactions
     // but will not modify the its open state directly.

--- a/src/sidebar/components/test/UserMenu-test.js
+++ b/src/sidebar/components/test/UserMenu-test.js
@@ -48,6 +48,7 @@ describe('UserMenu', () => {
       focusedGroupId: sinon.stub().returns('mygroup'),
       getLink: sinon.stub(),
       profile: sinon.stub().returns(fakeProfile),
+      importsPending: sinon.stub().returns(0),
       isFeatureEnabled: fakeIsFeatureEnabled,
     };
 
@@ -296,6 +297,20 @@ describe('UserMenu', () => {
   });
 
   describe('log out menu item', () => {
+    it('is disabled if an import is in progress', () => {
+      fakeStore.importsPending.returns(1);
+      const wrapper = createUserMenu();
+
+      let logOutMenuItem = findMenuItem(wrapper, 'Log out');
+      assert.isTrue(logOutMenuItem.prop('isDisabled'));
+
+      fakeStore.importsPending.returns(0);
+      wrapper.setProps({});
+
+      logOutMenuItem = findMenuItem(wrapper, 'Log out');
+      assert.isFalse(logOutMenuItem.prop('isDisabled'));
+    });
+
     const tests = [
       {
         it: 'should be present for first-party user if no service configured',


### PR DESCRIPTION
Disable the groups menu button during an import and also the "Log out" button in the user menu.

Fixes https://github.com/hypothesis/client/issues/5774

