### PR TITLE
Include some error details in toast shown when an import fails

### DIFF
--- a/src/sidebar/services/test/import-annotations-test.js
+++ b/src/sidebar/services/test/import-annotations-test.js
@@ -178,7 +178,7 @@ describe('ImportAnnotationsService', () => {
 
       assert.calledWith(
         fakeToastMessenger.notice,
-        '1 annotations imported, 1 imports failed',
+        '1 annotations imported, 1 imports failed (Oh no)',
       );
     });
 
@@ -188,7 +188,10 @@ describe('ImportAnnotationsService', () => {
 
       await svc.import([generateAnnotation(), generateAnnotation()]);
 
-      assert.calledWith(fakeToastMessenger.error, '2 imports failed');
+      assert.calledWith(
+        fakeToastMessenger.error,
+        '2 imports failed (Something went wrong)',
+      );
     });
   });
 });


### PR DESCRIPTION
This will make triaging any user reports of issues easier. It would look better if we could present the details in a separate dialog, but this is a starting point.

Also disable auto-dismiss for non-success statuses so the user is less likely to miss them.

Part of https://github.com/hypothesis/client/issues/5741