### PR TITLE
Allow selecting which user's annotations to export

### DIFF
--- a/src/sidebar/helpers/annotations-by-user.ts
+++ b/src/sidebar/helpers/annotations-by-user.ts
@@ -1,0 +1,49 @@
+import type { APIAnnotationData } from '../../types/api';
+import { isReply } from './annotation-metadata';
+
+/**
+ * Details of a user and their annotations that are available to import or export.
+ */
+export type UserAnnotations = {
+  userid: string;
+  displayName: string;
+  annotations: APIAnnotationData[];
+};
+
+export type AnnotationsByUserOptions = {
+  annotations: APIAnnotationData[];
+  getDisplayName: (ann: APIAnnotationData) => string;
+
+  /** If true, replies will be excluded from returned annotations */
+  excludeReplies?: boolean;
+};
+
+/**
+ * Generate an alphabetized list of authors and their importable/exportable
+ * annotations.
+ */
+export function annotationsByUser({
+  annotations,
+  getDisplayName,
+  excludeReplies = false,
+}: AnnotationsByUserOptions): UserAnnotations[] {
+  const userInfo = new Map<string, UserAnnotations>();
+  for (const ann of annotations) {
+    if (excludeReplies && isReply(ann)) {
+      continue;
+    }
+    let info = userInfo.get(ann.user);
+    if (!info) {
+      info = {
+        userid: ann.user,
+        displayName: getDisplayName(ann),
+        annotations: [],
+      };
+      userInfo.set(ann.user, info);
+    }
+    info.annotations.push(ann);
+  }
+  const userInfos = [...userInfo.values()];
+  userInfos.sort((a, b) => a.displayName.localeCompare(b.displayName));
+  return userInfos;
+}

--- a/src/sidebar/helpers/test/annotations-by-user-test.js
+++ b/src/sidebar/helpers/test/annotations-by-user-test.js
@@ -1,0 +1,97 @@
+import { annotationsByUser } from '../annotations-by-user';
+
+describe('annotationsByUser', () => {
+  const annotations = [
+    {
+      id: 'abc',
+      user: 'acct:john@example.com',
+      text: 'Test annotation',
+    },
+    {
+      id: 'def',
+      user: 'acct:brian@example.com',
+      text: 'Test annotation',
+    },
+    {
+      id: 'xyz',
+      user: 'acct:brian@example.com',
+      text: 'Test annotation',
+      references: ['abc'],
+    },
+  ];
+
+  it('groups annotations by user and result is sorted', () => {
+    const getDisplayName = ann => ann.user;
+    const [first, second, ...rest] = annotationsByUser({
+      annotations,
+      getDisplayName,
+    });
+
+    // It should only return the first two users
+    assert.equal(rest.length, 0);
+
+    assert.deepEqual(first, {
+      userid: 'acct:brian@example.com',
+      displayName: 'acct:brian@example.com',
+      annotations: [
+        {
+          id: 'def',
+          user: 'acct:brian@example.com',
+          text: 'Test annotation',
+        },
+        {
+          id: 'xyz',
+          user: 'acct:brian@example.com',
+          text: 'Test annotation',
+          references: ['abc'],
+        },
+      ],
+    });
+    assert.deepEqual(second, {
+      userid: 'acct:john@example.com',
+      displayName: 'acct:john@example.com',
+      annotations: [
+        {
+          id: 'abc',
+          user: 'acct:john@example.com',
+          text: 'Test annotation',
+        },
+      ],
+    });
+  });
+
+  it('allows replies to be excluded', () => {
+    const getDisplayName = ann => ann.user;
+    const [first, second, ...rest] = annotationsByUser({
+      annotations,
+      getDisplayName,
+      excludeReplies: true,
+    });
+
+    // It should only return the first two users
+    assert.equal(rest.length, 0);
+
+    assert.deepEqual(first, {
+      userid: 'acct:brian@example.com',
+      displayName: 'acct:brian@example.com',
+      annotations: [
+        {
+          id: 'def',
+          user: 'acct:brian@example.com',
+          text: 'Test annotation',
+        },
+      ],
+    });
+    assert.deepEqual(second, {
+      userid: 'acct:john@example.com',
+      displayName: 'acct:john@example.com',
+      annotations: [
+        {
+          id: 'abc',
+          user: 'acct:john@example.com',
+          text: 'Test annotation',
+        },
+      ],
+    });
+  });
+});

--- a/src/sidebar/services/annotations-exporter.ts
+++ b/src/sidebar/services/annotations-exporter.ts
@@ -1,4 +1,4 @@
-import type { Annotation, APIAnnotationData } from '../../types/api';
+import type { APIAnnotationData } from '../../types/api';
 import { stripInternalProperties } from '../helpers/strip-internal-properties';
 import { VersionData } from '../helpers/version-data';
 import type { SidebarStore } from '../store';
@@ -23,7 +23,7 @@ export class AnnotationsExporter {
   }
 
   buildExportContent(
-    annotations: Annotation[],
+    annotations: APIAnnotationData[],
     /* istanbul ignore next - test seam */
     now = new Date(),
   ): ExportContent {


### PR DESCRIPTION
> This PR is part of #5775 (AKA phase 1)

Add a user selection dropdown to the `Export` tab, so that it is possible to export only the annotations for one user, instead of all annotations.

By default we will preselect current user, if the document has annotations he/she owns. Otherwise the "All annotations" option will be selected.

The logic reuses the `annotationsByUser` function that was created for the import dropdown.

![image](https://github.com/hypothesis/client/assets/2719332/4a772b62-50d1-4b85-ad78-1ae9a7eaf63c)

### TODO

- [x] Add/Fix tests

### Testing steps

1. Open the export tab. See that it now shows a select control with the list of users who have annotated current document.
2. The control should pre-select current user, if there are annotations owned by him/her.
3. "All annotations" should be the default option instead.
4. Clicking export will generate a file containing only the annotations of selected user.

### Considerations

* ~Due to reusing `annotationsByUser`, we are no longer exporting replies. Should we?~ As per [Rob's comment](https://github.com/hypothesis/client/pull/5779#issuecomment-1700676857) we do export replies in the end. However, we have lost the hint where we separated amount of regular annotations and replies. Potentially worth addressing on a follow-up PR.
* Current user appears pre-selected, but it's not the first in the dropdown due to the alphabetical order. Should we make sure is the first one?
* There is now some duplicated code in `ExportAnnotations` and `ImportAnnotations`, in terms of users dropdown and some pieces of state it needs. We could try to improve this on a follow-up PR.