### PR TITLE
Forward import errors to Sentry

### DIFF
--- a/src/sidebar/services/import-annotations.ts
+++ b/src/sidebar/services/import-annotations.ts
@@ -7,6 +7,7 @@ import {
 } from '../helpers/permissions';
 import type { SidebarStore } from '../store';
 import type { Frame } from '../store/modules/frames';
+import { captureException } from '../util/sentry';
 import type { AnnotationsService } from './annotations';
 import type { ToastMessengerService } from './toast-messenger';
 
@@ -208,6 +209,7 @@ export class ImportAnnotationsService {
 
         return { type: 'import', annotation: saved };
       } catch (error) {
+        captureException(error, 'annotation-import');
         return { type: 'error', error };
       }
     };

--- a/src/sidebar/util/sentry.ts
+++ b/src/sidebar/util/sentry.ts
@@ -121,11 +121,25 @@ export function init(config: SentryConfig) {
 
   // Catch errors occuring in Hypothesis-related code in the host frame.
   removeFrameErrorHandler = handleErrorsInFrames((err, context) => {
-    Sentry.captureException(err, {
-      tags: {
-        context,
-      },
-    });
+    captureException(err, context);
+  });
+}
+
+/**
+ * Forward an error to Sentry.
+ *
+ * This can be used to report errors to Sentry even if they have been caught
+ * and handled by the application (eg. by presenting an error to the user).
+ *
+ * @param err - The error that occurred
+ * @param context - A string identifying the context in which the error
+ *   occurred. This is attached to the Sentry report as a tag.
+ */
+export function captureException(err: unknown, context: string) {
+  Sentry.captureException(err, {
+    tags: {
+      context,
+    },
   });
 }
 


### PR DESCRIPTION
Since we capture these errors and present a toast to the user, they won't get sent via the usual unhandled exception mechanisms, so forward them explicitly to Sentry.

Part of https://github.com/hypothesis/client/issues/5741