### PR TITLE
Add comments which help understand Annotation vs APIAnnotationData types

### DIFF
--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -158,6 +158,10 @@ export type UserInfo = {
   display_name: string | null;
 };
 
+/**
+ * Represents an annotation as returned by the h API.
+ * API docs: https://h.readthedocs.io/en/latest/api-reference/#tag/annotations
+ */
 export type APIAnnotationData = {
   /**
    * The server-assigned ID for the annotation. This is only set once the
@@ -211,6 +215,10 @@ export type APIAnnotationData = {
   user_info?: UserInfo;
 };
 
+/**
+ * Augmented annotation including what's returned by `h` API + client-internal
+ * properties
+ */
 export type Annotation = ClientAnnotationData & APIAnnotationData;
 
 /**


### PR DESCRIPTION
This aims to reduce future confusion on the difference of `Annotation` and `APIAnnotationData` type definitions, as suggested in [this comment](https://github.com/hypothesis/client/pull/5779#discussion_r1311601575), by adding a simple comment.