### PR TITLE
Convert `useStore` hook to TypeScript

### DIFF
--- a/src/sidebar/store/index.ts
+++ b/src/sidebar/store/index.ts
@@ -66,7 +66,7 @@ export function createSidebarStore(settings: SidebarSettings) {
  * and re-renders the component when relevant data in the store changes. See
  * {@link useStore}.
  */
-export function useSidebarStore() {
+export function useSidebarStore(): SidebarStore {
   const store = useService('store') as SidebarStore;
   return useStore(store);
 }


### PR DESCRIPTION
We're almost done with the conversion from JSDoc types to TypeScript, for non-test code. After this the remaining files are:

```
src/boot/boot.js
src/boot/browser-check.js
src/boot/index.js
src/boot/parse-json-config.js
src/boot/url-template.js
src/sidebar/store/modules/links.js
src/sidebar/store/modules/real-time-updates.js
src/sidebar/store/modules/route.js
src/sidebar/store/modules/selection.js
src/sidebar/store/modules/session.js
src/sidebar/store/modules/sidebar-panels.js
src/sidebar/store/modules/toast-messages.js
src/sidebar/store/modules/viewer.js
src/test-util/accessibility.js
src/test-util/assert-methods.js
src/test-util/compare-dom.js
src/test-util/mock-imported-components.js
src/types/config.js
src/types/rpc.js
src/types/sidebar.js
```

I have opened separate PRs for the remaining modules in `src/{boot, types}`.