### PR TITLE
Add missing null check for content frame in `ExportAnnotations`

### DIFF
--- a/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
+++ b/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
@@ -60,7 +60,7 @@ function ExportAnnotations({
   const defaultFilename = useMemo(
     () =>
       suggestedFilename({
-        documentMetadata: contentFrame.metadata,
+        documentMetadata: contentFrame?.metadata,
         groupName: group?.name,
       }),
     [contentFrame, group],

--- a/src/sidebar/store/modules/frames.ts
+++ b/src/sidebar/store/modules/frames.ts
@@ -163,7 +163,16 @@ const mainFrame = createSelector(
  */
 const defaultContentFrame = createSelector(
   (state: State) => state.frames,
-  frames => firstFrameWithoutId(frames) ?? frames[0] ?? null,
+  frames => {
+    const mainFrame = firstFrameWithoutId(frames);
+    if (mainFrame) {
+      return mainFrame;
+    } else if (frames.length > 0) {
+      return frames[0];
+    } else {
+      return null;
+    }
+  },
 );
 
 function searchUrisForFrame(frame: Frame): string[] {


### PR DESCRIPTION
The `store.defaultContentFrame` selector had an incorrect return type, `Frame` instead of `Frame|null`, because `frames[0]` has the static type `Frame`, even though this can actually return undefined at runtime. As a result, TypeScript didn't catch a missing null check when generating the default filename for the export.

Fixes https://github.com/hypothesis/client/issues/5818

---

**Testing notes:**

To simulate a slow-loading PDF, you can apply this diff and then access eg. http://localhost:3000/pdf/nils-olav. The PDF will still load quickly in the viewer, but the client will behave as if it is still loading until the timeout expires.

On `main`, if you click the "share" icon in the toolbar during this time you'll get an exception. On this branch the Share / Export / Import tabs will appear but be in various loading states (Share / Export tabs will show a loading spinner, Import tab won't let you actually import until the document loads).

```diff
diff --git a/src/annotator/integrations/pdf-metadata.ts b/src/annotator/integrations/pdf-metadata.ts
index 3d4cc2c61..0cc48eedb 100644
--- a/src/annotator/integrations/pdf-metadata.ts
+++ b/src/annotator/integrations/pdf-metadata.ts
@@ -113,7 +113,8 @@ export class PDFMetadata {
    * If the PDF is currently loading, the returned promise resolves once loading
    * is complete.
    */
-  getUri(): Promise<string> {
+  async getUri(): Promise<string> {
+    await new Promise(r => setTimeout(r, 20_000));
     return this._loaded.then(app => {
       let uri = getPDFURL(app);
       if (!uri) {
```