### PR TITLE
Fix error if `matchShortcut` is called with non-KeyboardEvent

### DIFF
--- a/src/shared/shortcut.ts
+++ b/src/shared/shortcut.ts
@@ -24,6 +24,14 @@ const modifiers = {
  * would be "!" instead. See also https://github.com/w3c/uievents/issues/247.
  */
 export function matchShortcut(event: KeyboardEvent, shortcut: string): boolean {
+  // Work around an issue where Chrome autofill can dispatch "keydown" events
+  // with an argument that is not a `KeyboardEvent`.
+  //
+  // See https://bugs.chromium.org/p/chromium/issues/detail?id=739792.
+  if (!(event instanceof KeyboardEvent)) {
+    return false;
+  }
+
   const parts = shortcut.split('+').map(p => p.toLowerCase());
 
   let requiredModifiers = 0;

--- a/src/shared/test/shortcut-test.js
+++ b/src/shared/test/shortcut-test.js
@@ -4,13 +4,13 @@ import { act } from 'preact/test-utils';
 import { matchShortcut, installShortcut, useShortcut } from '../shortcut';
 
 function createEvent(key, { ctrl, alt, shift, meta } = {}) {
-  return {
+  return new KeyboardEvent('keydown', {
     key,
     ctrlKey: !!ctrl,
     altKey: !!alt,
     shiftKey: !!shift,
     metaKey: !!meta,
-  };
+  });
 }
 
 describe('shared/shortcut', () => {
@@ -81,6 +81,10 @@ describe('shared/shortcut', () => {
       assert.throws(() => {
         matchShortcut(createEvent('a'), 'a+b');
       }, 'Multiple non-modifier keys specified');
+    });
+
+    it('should return false if event is not a `KeyboardEvent`', () => {
+      assert.isFalse(matchShortcut(new Event('keydown'), 'a'));
     });
   });
 


### PR DESCRIPTION
Work around an exception when testing for shortcuts in `keydown` event handlers, if the handler is called with an argument that is not a `KeyboardEvent`, and is missing the expected `key` property. The workaround has been added to `matchShortcut` because it is easier to do there than remember for each `keydown` event handler, although there is a risk that other code in these handlers could get caught out by the same issue.

I was able to reproduce this problem locally in Chrome 118 when using autofill to insert text into the search input field (see comments), though there might be other causes as well.

This should fix https://hypothesis.sentry.io/issues/3987386810/?project=69811