### PR TITLE
Initialize `target` property of new page notes to a single-item array

### DIFF
--- a/src/sidebar/services/annotations.ts
+++ b/src/sidebar/services/annotations.ts
@@ -166,7 +166,11 @@ export class AnnotationsService {
       return;
     }
     const pageNoteAnnotation = {
-      target: [],
+      target: [
+        {
+          source: topLevelFrame.uri,
+        },
+      ],
       uri: topLevelFrame.uri,
     };
     this.create(pageNoteAnnotation);

--- a/src/sidebar/services/test/annotations-test.js
+++ b/src/sidebar/services/test/annotations-test.js
@@ -279,7 +279,11 @@ describe('AnnotationsService', () => {
       const annotation = getLastAddedAnnotation();
 
       assert.equal(annotation.uri, 'http://www.example.com');
-      assert.deepEqual(annotation.target, []);
+      assert.deepEqual(annotation.target, [
+        {
+          source: 'http://www.example.com',
+        },
+      ]);
     });
   });
 


### PR DESCRIPTION
Annotations received from the API always have a non-empty `target` array, as do annotations and replies created locally that have not yet been saved. Locally created and unsaved Page Notes were an exception. This led to an error [1] when hovering a new unsaved page note in a VitalSource book, due to code not handling an empty `target` array.  Resolve this by initializing the `target` field of new page notes in the same way as replies and annotations (minus the `selector` property that annotations have).

[1] https://hypothesis.sentry.io/issues/3745569320/