### PR TITLE
Handle `document.documentElement` being null when installing shortcut

### DIFF
--- a/src/shared/shortcut.ts
+++ b/src/shared/shortcut.ts
@@ -103,6 +103,7 @@ export function installShortcut(
       onPress(event);
     }
   };
+  /* istanbul ignore next */
   if (!rootElement) {
     return () => {};
   }

--- a/src/shared/shortcut.ts
+++ b/src/shared/shortcut.ts
@@ -90,7 +90,12 @@ export function installShortcut(
     // which is used as a root element in some other places because the body
     // element is not keyboard-focusable in XHTML documents in Safari/Chrome.
     // See https://github.com/hypothesis/client/issues/4364.
-    rootElement = document.documentElement,
+    //
+    // nb. `documentElement` is non-null in TS types, but it can be null if
+    // the root element is explicitly removed. We don't know how this happens,
+    // but it has been observed on some ChromeOS devices. See
+    // https://hypothesis.sentry.io/issues/3987992034.
+    rootElement = (document.documentElement as HTMLElement | null) ?? undefined,
   }: ShortcutOptions = {},
 ) {
   const onKeydown = (event: KeyboardEvent) => {
@@ -98,6 +103,9 @@ export function installShortcut(
       onPress(event);
     }
   };
+  if (!rootElement) {
+    return () => {};
+  }
   rootElement.addEventListener('keydown', onKeydown);
   return () => rootElement.removeEventListener('keydown', onKeydown);
 }


### PR DESCRIPTION
`document.documentElement` is never null in "normal" circumstances, but it can be `null` if something explicitly removes the root element from the document, and this situation has apparently occurred in the wild on some ChromeOS devices [1].

One hypothesis I have is that maybe it happens when the document is unloaded if our scripts are somehow able to execute after the `<html>` element is removed? Or maybe a browser extension is removing the root element, although there is no direct evidence of extensions having created this situation.

[1] https://hypothesis.sentry.io/issues/3987992034