### PR TITLE
Handle sidebar iframe reloads more gracefully

### DIFF
--- a/src/shared/messaging/test/port-provider-test.js
+++ b/src/shared/messaging/test/port-provider-test.js
@@ -173,6 +173,33 @@ describe('PortProvider', () => {
       );
     });
 
+    it('ignores a second request from sidebar frame for sidebar <-> host connection', async () => {
+      const warnStub = sinon.stub(console, 'warn');
+      try {
+        const data = {
+          frame1: 'sidebar',
+          frame2: 'host',
+          type: 'request',
+          sourceId: undefined,
+        };
+        await sendPortFinderRequest({
+          data: { ...data, requestId: 'first' },
+        });
+        window.postMessage.resetHistory();
+
+        await sendPortFinderRequest({
+          data: { ...data, requestId: 'second' },
+        });
+        assert.notCalled(window.postMessage);
+        assert.calledWith(
+          warnStub,
+          'Ignoring second request from Hypothesis sidebar to connect to host frame',
+        );
+      } finally {
+        warnStub.restore();
+      }
+    });
+
     it('responds to a valid port request from a source with an opaque origin', async () => {
       const data = {
         frame1: 'guest',

--- a/src/sidebar/index.tsx
+++ b/src/sidebar/index.tsx
@@ -103,11 +103,24 @@ function initServices(
 }
 
 /**
+ * Setup connection between sidebar and host page.
+ *
  * @inject
  */
-function setupFrameSync(frameSync: FrameSyncService, store: SidebarStore) {
+function setupFrameSync(
+  frameSync: FrameSyncService,
+  store: SidebarStore,
+  toastMessenger: ToastMessengerService,
+) {
   if (store.route() === 'sidebar') {
-    frameSync.connect();
+    frameSync.connect().catch(() => {
+      toastMessenger.error(
+        'Hypothesis failed to connect to the web page. Try reloading the page.',
+        {
+          autoDismiss: false,
+        },
+      );
+    });
   }
 }
 


### PR DESCRIPTION
If the `<hypothesis-sidebar>` element is moved around in the DOM, this can cause the sidebar to reload. There may also be other causes of the sidebar reloading (eg. process crash for out-of-process iframe?). If the sidebar loads a second time, it will fail to connect to the host frame since `PortProvider` will try to re-use the `MessageChannel` it has already allocated, but sending that channels ports will fail since they have already been transferred.

Recovering from this scenario fully involves a lot of changes since all the places that have a connection to the sidebar would need to support replacing that channel. Also various state in host/guest frames (eg. currently loaded annotations) will be out of sync and need resetting.

What this commit does is just to handle the situation more gracefully, by logging a meaningful error in the console and, after a delay, showing an error message in the sidebar telling the user to reload the page. This also avoids spamming Sentry [1] with errors about a situation that is out of our control. We get a lot of error reports about this each month, mainly from certain high-traffic pages that embed the client, but so far no actual complaints from users about Hypothesis not working. Therefore it doesn't yet seem valuable enough to do all the work to recover from a sidebar frame reload automatically.

[1] https://hypothesis.sentry.io/issues/2975780063/

Part of https://github.com/hypothesis/client/issues/4095. Also relates to https://github.com/hypothesis/client/issues/3986.

----

**Testing:**

1. Go to http://localhost:3000
2. Using developer tools, drag and drop the `<hypothesis-sidebar>` element to a different location in the DOM (simply moving it to a different index in the body's children will do). This will cause the sidebar to reload.

On main, an error will be logged and the reloaded sidebar will be stuck in a loading state indefinitely. On this branch, the sidebar will eventually (after 20 seconds currently) show an error:

<img width="502" alt="Reload error" src="https://github.com/hypothesis/client/assets/2458/fd9b5a38-ecde-4ddb-9993-46a33e8cf2c4">

The 20 second delay is because the protocol used by the sidebar to connect to the host frame does not currently have a way for the host frame to immediately respond with an error. If this is fixed, we could show the notice immediately.
