### PR TITLE
Add ability for port discovery protocol to report errors

### DIFF
--- a/src/shared/messaging/port-finder.ts
+++ b/src/shared/messaging/port-finder.ts
@@ -49,20 +49,6 @@ export class PortFinder implements Destroyable {
    * @param target - the frame aiming to be discovered
    */
   async discover(target: Frame): Promise<MessagePort> {
-    let isValidRequest = false;
-    if (
-      (this._source === 'guest' && target === 'host') ||
-      (this._source === 'guest' && target === 'sidebar') ||
-      (this._source === 'sidebar' && target === 'host') ||
-      (this._source === 'notebook' && target === 'sidebar')
-    ) {
-      isValidRequest = true;
-    }
-
-    if (!isValidRequest) {
-      throw new Error('Invalid request of channel/port');
-    }
-
     const requestId = generateHexString(6);
 
     return new Promise((resolve, reject) => {

--- a/src/shared/messaging/port-util.ts
+++ b/src/shared/messaging/port-util.ts
@@ -19,6 +19,9 @@ export type Message = {
    */
   type: 'offer' | 'request';
 
+  /** If set on an `offer` message, indicates that the request was rejected. */
+  error?: string;
+
   /**
    * ID of the request. Used to associate "offer" messages with their
    * corresponding "request" messages.

--- a/src/shared/messaging/test/port-finder-test.js
+++ b/src/shared/messaging/test/port-finder-test.js
@@ -87,18 +87,6 @@ describe('PortFinder', () => {
   });
 
   describe('#discover', () => {
-    ['guest', 'invalid'].forEach(target =>
-      it('rejects if requesting an invalid port', async () => {
-        let error;
-        try {
-          await portFinder.discover(target);
-        } catch (e) {
-          error = e;
-        }
-        assert.equal(error.message, 'Invalid request of channel/port');
-      }),
-    );
-
     it('sends port request to host frame', async () => {
       const clock = sinon.useFakeTimers();
       try {
@@ -128,7 +116,7 @@ describe('PortFinder', () => {
       { source: 'sidebar', target: 'host' },
       { source: 'notebook', target: 'sidebar' },
     ].forEach(({ source, target }) =>
-      it('resolves if requesting a valid port', async () => {
+      it('resolves when port is returned', async () => {
         const { port1 } = new MessageChannel();
         let resolvedPort;
         portFinder = createPortFinder(source);

--- a/src/shared/messaging/test/port-provider-test.js
+++ b/src/shared/messaging/test/port-provider-test.js
@@ -190,7 +190,15 @@ describe('PortProvider', () => {
         await sendPortFinderRequest({
           data: { ...data, requestId: 'second' },
         });
-        assert.notCalled(window.postMessage);
+        assert.calledWith(
+          window.postMessage,
+          sinon.match({
+            ...data,
+            type: 'offer',
+            error: 'Received duplicate port request',
+          }),
+          window.location.origin,
+        );
         assert.calledWith(
           warnStub,
           'Ignoring second request from Hypothesis sidebar to connect to host frame',


### PR DESCRIPTION
This is a follow up to https://github.com/hypothesis/client/pull/5829 to which eliminates the delay before the error is presented in the sidebar.

It adds an `error` property to port discovery messages, so that the host frame can reject port requests it can't fulfill immediately (eg. because the port has already been sent), instead of the frame requesting the port having to wait until a timeout elapses.

The testing steps are the same as https://github.com/hypothesis/client/pull/5829, but the error message should appear immediately instead of after a 20-second delay.

Part of https://github.com/hypothesis/client/issues/4095.