### PR TITLE
Ignore port requests from frames that have been removed

### DIFF
--- a/src/shared/messaging/port-provider.ts
+++ b/src/shared/messaging/port-provider.ts
@@ -147,8 +147,13 @@ export class PortProvider implements Destroyable {
     const handleRequest = (event: MessageEvent) => {
       const { data, origin, source } = event;
 
+      // Ignore messages where the sender went away before we can send a response.
+      if (!source) {
+        return;
+      }
+
+      // Ignore messages that don't look like port requests.
       if (!isMessage(data) || data.type !== 'request') {
-        // If this does not look like a message intended for us, ignore it.
         return;
       }
 

--- a/src/shared/messaging/test/port-provider-test.js
+++ b/src/shared/messaging/test/port-provider-test.js
@@ -128,7 +128,20 @@ describe('PortProvider', () => {
           requestId: 'abcdef',
         },
         source: null,
-        reason: 'comes from invalid source',
+        reason: 'source frame went away',
+      },
+      {
+        data: {
+          frame1: 'sidebar',
+          frame2: 'host',
+          type: 'request',
+          requestId: 'abcdef',
+        },
+        // In reality a non-Window sender of a message to a window is most
+        // likely to be a worker of some kind, but a MessagePort is easier to
+        // construct.
+        source: new MessageChannel().port1,
+        reason: 'source is not a window',
       },
       {
         data: {


### PR DESCRIPTION
Ignore port requests in `PortProvider` where the `MessageEvent.source` property is null. This can happen if the source was removed before our message event handler was called.

This attempts to resolve https://hypothesis.sentry.io/issues/3987392274.