### PR TITLE
Enable grouped updates for some npm packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,22 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: weekly
-    time: "10:00"
-  open-pull-requests-limit: 10
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+      time: '10:00'
+    open-pull-requests-limit: 10
+    groups:
+      babel:
+        patterns:
+          - '@babel/*'
+      lint:
+        patterns:
+          - 'eslint*'
+          - '@typescript-eslint/'
+      rollup:
+        patterns:
+          - '@rollup/*'
+      sentry:
+        patterns:
+          - '@sentry/*'

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
-.*/**
+.tox/
+.yalc/
 build/
 coverage/
 docs/


### PR DESCRIPTION
Attempt to reduce the noise from Dependabot PRs and conflicts between PRs by grouping updates from related packages.

I also changed the Prettier config to explicitly list hidden directories to ignore, rather than all hidden directories. This allows using Prettier to format files in `.github` for example.