### PR TITLE
Add missing wildcard in Dependabot grouped updates config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
       lint:
         patterns:
           - 'eslint*'
-          - '@typescript-eslint/'
+          - '@typescript-eslint/*'
       rollup:
         patterns:
           - '@rollup/*'


### PR DESCRIPTION
Without this the pattern doesn't match any packages.