### PR TITLE
Adjust grouped updates config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,13 +10,17 @@ updates:
       babel:
         patterns:
           - '@babel/*'
-      lint:
+      eslint:
         patterns:
           - 'eslint*'
           - '@typescript-eslint/*'
       rollup:
         patterns:
+          - 'rollup'
           - '@rollup/*'
       sentry:
         patterns:
           - '@sentry/*'
+      typescript-types:
+        patterns:
+          - '@types/*'

--- a/yarn.lock
+++ b/yarn.lock
@@ -6716,14 +6716,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-func-name@npm:^2.0.0":
-  version: 2.0.2
-  resolution: "get-func-name@npm:2.0.2"
-  checksum: 3f62f4c23647de9d46e6f76d2b3eafe58933a9b3830c60669e4180d6c601ce1b4aa310ba8366143f55e52b139f992087a9f0647274e8745621fa2af7e0acf13b
-  languageName: node
-  linkType: hard
-
-"get-func-name@npm:^2.0.2":
+"get-func-name@npm:^2.0.0, get-func-name@npm:^2.0.2":
   version: 2.0.2
   resolution: "get-func-name@npm:2.0.2"
   checksum: 3f62f4c23647de9d46e6f76d2b3eafe58933a9b3830c60669e4180d6c601ce1b4aa310ba8366143f55e52b139f992087a9f0647274e8745621fa2af7e0acf13b


### PR DESCRIPTION
 - Add the core `rollup` dep to the "rollup" group. It is maintained by the same GitHub org, but doesn't start with `@rollup/`

 - Add groups for `@types/` package. These are all sourced from the same organization.

 - Rename `lint` => `eslint`. This avoids ambiguity if copying this config into other repos that also use Python linters. Also plays nicely with dependabot-batch-review's grouping. See https://github.com/hypothesis/dependabot-batch-review#grouped-updates.