### PR TITLE
Use SelectNext for import and export user selectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.16.7",
     "@hypothesis/frontend-build": "^2.0.0",
-    "@hypothesis/frontend-shared": "^6.5.0",
+    "@hypothesis/frontend-shared": "^6.8.1",
     "@hypothesis/frontend-testing": "^1.0.1",
     "@npmcli/arborist": "^7.0.0",
     "@octokit/rest": "^20.0.1",

--- a/src/sidebar/components/ShareDialog/UserAnnotationsListItem.tsx
+++ b/src/sidebar/components/ShareDialog/UserAnnotationsListItem.tsx
@@ -1,0 +1,21 @@
+import type { UserAnnotations } from '../../helpers/annotations-by-user';
+
+export type UserAnnotationsListItemProps = {
+  userAnnotations: Omit<UserAnnotations, 'userid'>;
+};
+
+/**
+ * UserAnnotations representation to use inside `SelectNext.Option`.
+ */
+export function UserAnnotationsListItem({
+  userAnnotations,
+}: UserAnnotationsListItemProps) {
+  return (
+    <div className="flex gap-x-2">
+      {userAnnotations.displayName}
+      <div className="rounded px-1 bg-grey-7 text-white">
+        {userAnnotations.annotations.length}
+      </div>
+    </div>
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2059,15 +2059,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^6.5.0":
-  version: 6.8.0
-  resolution: "@hypothesis/frontend-shared@npm:6.8.0"
+"@hypothesis/frontend-shared@npm:^6.8.1":
+  version: 6.8.1
+  resolution: "@hypothesis/frontend-shared@npm:6.8.1"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^2.10.0-alpha.1
   peerDependencies:
     preact: ^10.4.0
-  checksum: e2981d395929d9ddd5b6b78f35b4aebe5422ebbdaa48f6e65684cb1514534186e98559b2aadbaad77f3dc02652b73128c5bf3714d86b14f4104d5162d9d79466
+  checksum: d2f78b52c75930a9e4e337874835977b8569320ca64c2e75df125a9f45427fb4b93267d7b153ee3e2a7021ce9f49c54fcd0ad7a9cc44ad55cf531ddaaa184b7e
   languageName: node
   linkType: hard
 
@@ -7403,7 +7403,7 @@ __metadata:
     "@babel/preset-react": ^7.0.0
     "@babel/preset-typescript": ^7.16.7
     "@hypothesis/frontend-build": ^2.0.0
-    "@hypothesis/frontend-shared": ^6.5.0
+    "@hypothesis/frontend-shared": ^6.8.1
     "@hypothesis/frontend-testing": ^1.0.1
     "@npmcli/arborist": ^7.0.0
     "@octokit/rest": ^20.0.1


### PR DESCRIPTION
This PR makes import and export user selectors look closer to the [original design](https://github.com/hypothesis/client/issues/5775#issuecomment-1698491323) by replacing `Select` with `SelectNext`.

There's one difference though. The design shows the amount of annotations for a user only when it is selected. I think that's useful information to show for every option in the listbox, and in fact, we were already showing that in plain text, so I have kept it there.

![image](https://github.com/hypothesis/client/assets/2719332/cec3a9e5-a002-45b2-b5a9-83c208744a5c)

### Testing steps

If you check-out this branch, the user selection dropdown for inport and export annotations should now look like the one on the screenshot.

The overall behavior should be the same, importing or exporting annotations for selected user only.

Closes #5841 