### PR TITLE
Test improvements

### DIFF
--- a/src/sidebar/components/ShareDialog/test/ImportAnnotations-test.js
+++ b/src/sidebar/components/ShareDialog/test/ImportAnnotations-test.js
@@ -339,16 +339,13 @@ describe('ImportAnnotations', () => {
   it(
     'should pass a11y checks',
     checkAccessibility({
-      content: () =>
-        mount(
-          // re. outer div, see https://github.com/hypothesis/client/issues/5690
-          <div>
-            <ImportAnnotations
-              store={fakeStore}
-              importAnnotationsService={fakeImportAnnotationsService}
-            />
-          </div>,
-        ),
+      // re. not using `mount`, see https://github.com/hypothesis/client/issues/5690
+      content: () => (
+        <ImportAnnotations
+          store={fakeStore}
+          importAnnotationsService={fakeImportAnnotationsService}
+        />
+      ),
     }),
   );
 });

--- a/src/sidebar/components/ShareDialog/test/ImportAnnotations-test.js
+++ b/src/sidebar/components/ShareDialog/test/ImportAnnotations-test.js
@@ -339,7 +339,6 @@ describe('ImportAnnotations', () => {
   it(
     'should pass a11y checks',
     checkAccessibility({
-      // re. not using `mount`, see https://github.com/hypothesis/client/issues/5690
       content: () => (
         <ImportAnnotations
           store={fakeStore}

--- a/src/sidebar/components/ShareDialog/test/ShareDialog-test.js
+++ b/src/sidebar/components/ShareDialog/test/ShareDialog-test.js
@@ -126,10 +126,6 @@ describe('ShareDialog', () => {
     it(
       'should pass a11y checks',
       checkAccessibility({
-        // ShareDialog renders a Fragment as its top-level component when
-        // it has import and/or export tabs.
-        // Returning the VNode verbatim ensures no children are discarded.
-        // See https://github.com/hypothesis/client/issues/5671
         content: () => <ShareDialog shareTab exportTab importTab />,
       }),
     );

--- a/src/sidebar/components/ShareDialog/test/ShareDialog-test.js
+++ b/src/sidebar/components/ShareDialog/test/ShareDialog-test.js
@@ -126,17 +126,11 @@ describe('ShareDialog', () => {
     it(
       'should pass a11y checks',
       checkAccessibility({
-        content: () =>
-          // ShareDialog renders a Fragment as its top-level component when
-          // it has import and/or export tabs.
-          // Wrapping it in a `div` ensures `checkAccessibility` internal logic
-          // does not discard all the Fragment children but the first one.
-          // See https://github.com/hypothesis/client/issues/5671
-          mount(
-            <div>
-              <ShareDialog shareTab exportTab importTab />
-            </div>,
-          ),
+        // ShareDialog renders a Fragment as its top-level component when
+        // it has import and/or export tabs.
+        // Returning the VNode verbatim ensures no children are discarded.
+        // See https://github.com/hypothesis/client/issues/5671
+        content: () => <ShareDialog shareTab exportTab importTab />,
       }),
     );
   });

--- a/src/sidebar/components/test/ThreadList-test.js
+++ b/src/sidebar/components/test/ThreadList-test.js
@@ -418,10 +418,7 @@ describe('ThreadList', () => {
   it(
     'should pass a11y checks',
     checkAccessibility({
-      content: () => {
-        const wrapper = createComponent();
-        return wrapper;
-      },
+      content: () => createComponent(),
     }),
   );
 });

--- a/src/sidebar/components/test/ToastMessages-test.js
+++ b/src/sidebar/components/test/ToastMessages-test.js
@@ -7,10 +7,10 @@ describe('ToastMessages', () => {
   let fakeStore;
   let fakeToastMessenger;
 
-  const fakeMessage = () => ({
+  const fakeMessage = (id = 'someId') => ({
+    id,
     type: 'notice',
     message: 'you should know...',
-    id: 'someId',
     isDismissed: false,
     moreInfoURL: 'http://www.example.com',
   });
@@ -42,9 +42,9 @@ describe('ToastMessages', () => {
 
   it('should render all messages returned by the store', () => {
     fakeStore.getToastMessages.returns([
-      fakeMessage(),
-      fakeMessage(),
-      fakeMessage(),
+      fakeMessage('someId1'),
+      fakeMessage('someId2'),
+      fakeMessage('someId3'),
     ]);
 
     const wrapper = createComponent();


### PR DESCRIPTION
This PR introduces these improvements in tests:

* Use `content: () => <MyComponent />` over `content: () => mount(<div><MyComponent /></div>)` in accessibility tests for components with a top-level Fragment, where the wrapping div was a workaround to prevent some children from being "lost" (see https://github.com/hypothesis/client/issues/5690)
* Fix a warning printed in ToastMessages test that could make debugging other issues harder.
  ![image](https://github.com/hypothesis/client/assets/2719332/2e78a6c8-c9a6-4f10-9c88-4c432baf0f0b)
