### PR TITLE
Use rounded_corners feature flag to enable CSS vars

### DIFF
--- a/src/sidebar/components/HypothesisApp.tsx
+++ b/src/sidebar/components/HypothesisApp.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import { useEffect, useMemo } from 'preact/hooks';
+import { useEffect, useLayoutEffect, useMemo } from 'preact/hooks';
 
 import { confirm } from '../../shared/prompts';
 import type { SidebarSettings } from '../../types/config';
@@ -48,6 +48,20 @@ function HypothesisApp({
   const profile = store.profile();
   const route = store.route();
   const isModalRoute = route === 'notebook' || route === 'profile';
+
+  const roundedCornersEnabled = store.isFeatureEnabled('rounded_corners');
+  useLayoutEffect(() => {
+    const html = document.querySelector('html');
+
+    html?.style.setProperty(
+      '--h-border-radius',
+      roundedCornersEnabled ? '0.25rem' : null,
+    );
+    html?.style.setProperty(
+      '--h-border-radius-lg',
+      roundedCornersEnabled ? '0.5rem' : null,
+    );
+  }, [roundedCornersEnabled]);
 
   const backgroundStyle = useMemo(
     () => applyTheme(['appBackgroundColor'], settings),

--- a/src/sidebar/components/test/HypothesisApp-test.js
+++ b/src/sidebar/components/test/HypothesisApp-test.js
@@ -142,6 +142,24 @@ describe('HypothesisApp', () => {
     });
   });
 
+  [true, false].forEach(roundedCornersEnabled => {
+    it('defines border-radius CSS vars when the feature flag is enabled', () => {
+      fakeStore.isFeatureEnabled.returns(roundedCornersEnabled);
+      createComponent();
+
+      const styles = document.querySelector('html')?.style;
+
+      assert.equal(
+        styles.getPropertyValue('--h-border-radius'),
+        roundedCornersEnabled ? '0.25rem' : '',
+      );
+      assert.equal(
+        styles.getPropertyValue('--h-border-radius-lg'),
+        roundedCornersEnabled ? '0.5rem' : '',
+      );
+    });
+  });
+
   describe('auto-opening tutorial', () => {
     it('should open tutorial on profile load when criteria are met', () => {
       fakeShouldAutoDisplayTutorial.returns(true);


### PR DESCRIPTION
Requires https://github.com/hypothesis/h/pull/8307

Part of https://github.com/hypothesis/client/issues/5602

This PR ensures the [appropriate CSS variables](https://github.com/hypothesis/frontend-shared/blob/main/src/tailwind.preset.js#L26-L27) are defined when the `rounded_corners` feature flag introduced in https://github.com/hypothesis/h/pull/8307 is enabled.

This PR does not introduce any visual changes yet, but it prepares the project for the next steps.