### PR TITLE
Use regular SelectNext.Option children when possible

### DIFF
--- a/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
+++ b/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
@@ -156,15 +156,11 @@ function ExportAnnotations({
             }
           >
             <SelectNext.Option value={allAnnotationsOption}>
-              {() => (
-                <UserAnnotationsListItem
-                  userAnnotations={allAnnotationsOption}
-                />
-              )}
+              <UserAnnotationsListItem userAnnotations={allAnnotationsOption} />
             </SelectNext.Option>
             {userList.map(userInfo => (
               <SelectNext.Option key={userInfo.userid} value={userInfo}>
-                {() => <UserAnnotationsListItem userAnnotations={userInfo} />}
+                <UserAnnotationsListItem userAnnotations={userInfo} />
               </SelectNext.Option>
             ))}
           </SelectNext>

--- a/src/sidebar/components/ShareDialog/ImportAnnotations.tsx
+++ b/src/sidebar/components/ShareDialog/ImportAnnotations.tsx
@@ -177,7 +177,7 @@ function ImportAnnotations({
           >
             {userList.map(userInfo => (
               <SelectNext.Option key={userInfo.userid} value={userInfo}>
-                {() => <UserAnnotationsListItem userAnnotations={userInfo} />}
+                <UserAnnotationsListItem userAnnotations={userInfo} />
               </SelectNext.Option>
             ))}
           </SelectNext>


### PR DESCRIPTION
Initial `SelectNext` versions required `SelectNext.Option` children to be a callback that would receive some state props that can be used to customize the children based on that.

After using it in a few places we realized most of the time we didn't want to customize anything, and just keep default styles. Because of this, we enhanced `SelectNext.Option` to also accept regular children.

This PR refactors all usages of `SelectNext.Option` away from the callback notation when the callback arguments are not used. 