### PR TITLE
Improve menu items focus ring styles

### DIFF
--- a/src/sidebar/components/MenuItem.tsx
+++ b/src/sidebar/components/MenuItem.tsx
@@ -239,7 +239,11 @@ export default function MenuItem({
   const wrapperClasses = classnames(
     'focus-visible-ring ring-inset',
     'w-full min-w-[150px] flex items-center select-none',
-    'border-b rounded-none cursor-pointer',
+    'rounded-none cursor-pointer',
+    {
+      'focus-visible:rounded-lg': !isSelected,
+      'focus-visible:rounded-r-lg': isSelected,
+    },
     // Set this container as a "group" so that children may style based on its
     // layout state.
     // See https://tailwindcss.com/docs/hover-focus-and-other-states#styling-based-on-parent-state
@@ -260,8 +264,6 @@ export default function MenuItem({
       // of a transparent left border to make focus ring cover the full
       // menu item. Otherwise the focus ring will be inset on the left too far.
       'pl-[4px]': !isSelected,
-      'border-b-grey-3': isExpanded,
-      'border-b-transparent': !isExpanded,
       'text-color-text-light': isDisabled,
       'text-color-text hover:text-color-text': !isDisabled,
     },
@@ -312,7 +314,7 @@ export default function MenuItem({
           <MenuKeyboardNavigation
             closeMenu={onCloseSubmenu}
             visible={isSubmenuVisible}
-            className="border-b"
+            className="border-y border-grey-3"
           >
             {submenu}
           </MenuKeyboardNavigation>


### PR DESCRIPTION
This PR changes the styles for focused menu items so that the focus ring does not overlap with the rounded corners of the menu.

This has been done by applying the same size of rounded corners on menu items, but only when focused, to avoid other side effects like rounded background color on hover and such.

The change takes into consideration that active items have a brand-color left border. When this happens, the left side is left "unrounded".

This PR also removes the bottom border set on menu items, which is only relevant when there's an uncollapsed submenu, and is transparent otherwise, causing the left border to have a less sharper bottom edge, and it also renders a 1px separation between the focus ring and the bottom of the menu, when the last item is focused.

The above has been replaced by top and bottom borders in the submenu container itself, making it look the same when the submenu is open.

This is how menus look now:

[Grabación de pantalla desde 2023-11-13 14-45-18.webm](https://github.com/hypothesis/client/assets/2719332/3435d122-1241-4e15-92f5-c97d01f47868)
