### PR TITLE
Add annotations export format select

### DIFF
--- a/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
+++ b/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
@@ -26,6 +26,30 @@ export type ExportAnnotationsProps = {
   toastMessenger: ToastMessengerService;
 };
 
+type ExportFormat = {
+  value: 'json' | 'csv' | 'text' | 'html';
+  name: string;
+};
+
+const exportFormats: ExportFormat[] = [
+  {
+    value: 'json',
+    name: 'JSON',
+  },
+  {
+    value: 'csv',
+    name: 'CSV',
+  },
+  {
+    value: 'text',
+    name: 'Text',
+  },
+  {
+    value: 'html',
+    name: 'HTML',
+  },
+];
+
 /**
  * Render content for "export" tab panel: allow user to export annotations
  * with a specified filename.
@@ -67,6 +91,9 @@ function ExportAnnotations({
     userList.find(userInfo => userInfo.userid === currentUser) ??
       allAnnotationsOption,
   );
+
+  const exportFormatsEnabled = store.isFeatureEnabled('export_formats');
+  const [exportFormat, setExportFormat] = useState(exportFormats[0]);
 
   const fileInputId = useId();
   const userSelectId = useId();
@@ -133,17 +160,39 @@ function ExportAnnotations({
           >
             Name of export file:
           </label>
-          <Input
-            data-testid="export-filename"
-            id={fileInputId}
-            defaultValue={defaultFilename}
-            value={customFilename}
-            onChange={e =>
-              setCustomFilename((e.target as HTMLInputElement).value)
-            }
-            required
-            maxLength={250}
-          />
+          <div className="flex">
+            <Input
+              classes="grow"
+              data-testid="export-filename"
+              id={fileInputId}
+              defaultValue={defaultFilename}
+              value={customFilename}
+              onChange={e =>
+                setCustomFilename((e.target as HTMLInputElement).value)
+              }
+              required
+              maxLength={250}
+            />
+            {exportFormatsEnabled && (
+              <div className="grow-0 ml-2 min-w-[5rem]">
+                <SelectNext
+                  value={exportFormat}
+                  onChange={setExportFormat}
+                  buttonContent={exportFormat.name}
+                  data-testid="export-format-select"
+                >
+                  {exportFormats.map(exportFormat => (
+                    <SelectNext.Option
+                      key={exportFormat.value}
+                      value={exportFormat}
+                    >
+                      {exportFormat.name}
+                    </SelectNext.Option>
+                  ))}
+                </SelectNext>
+              </div>
+            )}
+          </div>
           <label htmlFor={userSelectId} className="block font-medium">
             Select which user{"'"}s annotations to export:
           </label>
@@ -154,6 +203,7 @@ function ExportAnnotations({
             buttonContent={
               <UserAnnotationsListItem userAnnotations={selectedUser} />
             }
+            data-testid="user-select"
           >
             <SelectNext.Option value={allAnnotationsOption}>
               <UserAnnotationsListItem userAnnotations={allAnnotationsOption} />

--- a/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
+++ b/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
@@ -81,6 +81,9 @@ describe('ExportAnnotations', () => {
     $imports.$restore();
   });
 
+  const waitForTestId = async (wrapper, testId) =>
+    waitForElement(wrapper, `[data-testid="${testId}"]`);
+
   context('export annotations not ready (loading)', () => {
     it('renders a loading spinner if there is no focused group', () => {
       fakeStore.focusedGroup.returns(null);
@@ -181,7 +184,7 @@ describe('ExportAnnotations', () => {
 
       const wrapper = createComponent();
 
-      const userList = await waitForElement(wrapper, SelectNext);
+      const userList = await waitForTestId(wrapper, 'user-select');
       const users = userList.find(SelectNext.Option);
       assert.equal(users.length, userEntries.length);
 
@@ -205,6 +208,22 @@ describe('ExportAnnotations', () => {
       documentMetadata: fakeStore.defaultContentFrame().metadata,
     });
     assert.equal(input.prop('defaultValue'), 'suggested-filename');
+  });
+
+  [
+    { exportFormatsEnabled: true, expectedAmountOfSelects: 2 },
+    { exportFormatsEnabled: false, expectedAmountOfSelects: 1 },
+  ].forEach(({ exportFormatsEnabled, expectedAmountOfSelects }) => {
+    it('displays format selector when feature is enabled', async () => {
+      fakeStore.isFeatureEnabled.callsFake(
+        ff => exportFormatsEnabled || ff !== 'export_formats',
+      );
+
+      const wrapper = createComponent();
+      const selects = await waitForElement(wrapper, SelectNext);
+
+      assert.equal(selects.length, expectedAmountOfSelects);
+    });
   });
 
   describe('export form submitted', () => {
@@ -265,7 +284,7 @@ describe('ExportAnnotations', () => {
       const wrapper = createComponent();
 
       // Select the user whose annotations we want to export
-      const userList = await waitForElement(wrapper, SelectNext);
+      const userList = await waitForTestId(wrapper, 'user-select');
       const option = userList
         .find(SelectNext.Option)
         .filterWhere(
@@ -376,7 +395,7 @@ describe('ExportAnnotations', () => {
 
   it('should pass a11y checks', async () => {
     const wrapper = createComponent();
-    const select = await waitForElement(wrapper, SelectNext);
+    const select = await waitForTestId(wrapper, 'user-select');
 
     await checkAccessibility({
       content: () => wrapper,


### PR DESCRIPTION
This PR adds an annotation export format select which is displayed only if the `export_formats` feature flag is enabled.

This component is dummy for now. You can change its value, but the export will always be in JSON. The logic for additional formats will come in follow-up pull requests.

The changes also don't include swapping user select and filename input as designed here https://github.com/hypothesis/client/issues/5784#issuecomment-1712072564. Let's discuss that later.

![image](https://github.com/hypothesis/client/assets/2719332/bca4e90a-4667-43e4-a5cf-8820f6edc619)

### Testing steps

1. Check out this branch.
2. Go to "Share annotations" and then select the "Export" tab. You should see all components as before.
3. Go to http://localhost:5000/admin/features and enable the `export_formats` feature flag.
4. Repeat step 2. Now you should also see the format dropdown like in the screenshot above.