### PR TITLE
Restrict annotations export to JSON

### DIFF
--- a/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
+++ b/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
@@ -27,7 +27,8 @@ export type ExportAnnotationsProps = {
 };
 
 type ExportFormat = {
-  value: 'json' | 'csv' | 'text' | 'html';
+  /** Unique format identifier used also as file extension */
+  value: 'json' | 'csv' | 'txt' | 'html';
   name: string;
 };
 
@@ -36,18 +37,20 @@ const exportFormats: ExportFormat[] = [
     value: 'json',
     name: 'JSON',
   },
-  {
-    value: 'csv',
-    name: 'CSV',
-  },
-  {
-    value: 'text',
-    name: 'Text',
-  },
-  {
-    value: 'html',
-    name: 'HTML',
-  },
+
+  // TODO Enable these formats when implemented
+  // {
+  //   value: 'csv',
+  //   name: 'CSV',
+  // },
+  // {
+  //   value: 'txt',
+  //   name: 'Text',
+  // },
+  // {
+  //   value: 'html',
+  //   name: 'HTML',
+  // },
 ];
 
 /**
@@ -118,12 +121,16 @@ function ExportAnnotations({
     e.preventDefault();
 
     try {
+      const format = exportFormat.value;
       const annotationsToExport =
         selectedUser?.annotations ?? exportableAnnotations;
-      const filename = `${customFilename ?? defaultFilename}.json`;
-      const exportData =
-        annotationsExporter.buildExportContent(annotationsToExport);
-      downloadJSONFile(exportData, filename);
+      const filename = `${customFilename ?? defaultFilename}.${format}`;
+
+      if (format === 'json') {
+        const exportData =
+          annotationsExporter.buildJSONExportContent(annotationsToExport);
+        downloadJSONFile(exportData, filename);
+      }
     } catch (e) {
       toastMessenger.error('Exporting annotations failed');
     }

--- a/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
+++ b/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
@@ -34,7 +34,7 @@ describe('ExportAnnotations', () => {
 
   beforeEach(() => {
     fakeAnnotationsExporter = {
-      buildExportContent: sinon.stub().returns({}),
+      buildJSONExportContent: sinon.stub().returns({}),
     };
     fakeToastMessenger = {
       error: sinon.stub(),
@@ -240,9 +240,9 @@ describe('ExportAnnotations', () => {
 
       submitExportForm(wrapper);
 
-      assert.calledOnce(fakeAnnotationsExporter.buildExportContent);
+      assert.calledOnce(fakeAnnotationsExporter.buildJSONExportContent);
       assert.calledWith(
-        fakeAnnotationsExporter.buildExportContent,
+        fakeAnnotationsExporter.buildJSONExportContent,
         annotationsToExport,
       );
       assert.notCalled(fakeToastMessenger.error);
@@ -298,9 +298,9 @@ describe('ExportAnnotations', () => {
 
       submitExportForm(wrapper);
 
-      assert.calledOnce(fakeAnnotationsExporter.buildExportContent);
+      assert.calledOnce(fakeAnnotationsExporter.buildJSONExportContent);
       assert.calledWith(
-        fakeAnnotationsExporter.buildExportContent,
+        fakeAnnotationsExporter.buildJSONExportContent,
         selectedUserAnnotations,
       );
     });
@@ -326,7 +326,7 @@ describe('ExportAnnotations', () => {
 
     context('when exporting annotations fails', () => {
       it('displays error toast message', () => {
-        fakeAnnotationsExporter.buildExportContent.throws(
+        fakeAnnotationsExporter.buildJSONExportContent.throws(
           new Error('Error exporting'),
         );
 
@@ -335,7 +335,7 @@ describe('ExportAnnotations', () => {
         submitExportForm(wrapper);
 
         assert.notCalled(fakeDownloadJSONFile);
-        assert.calledOnce(fakeAnnotationsExporter.buildExportContent);
+        assert.calledOnce(fakeAnnotationsExporter.buildJSONExportContent);
         assert.calledWith(
           fakeToastMessenger.error,
           'Exporting annotations failed',

--- a/src/sidebar/services/annotations-exporter.ts
+++ b/src/sidebar/services/annotations-exporter.ts
@@ -22,7 +22,7 @@ export class AnnotationsExporter {
     this._store = store;
   }
 
-  buildExportContent(
+  buildJSONExportContent(
     annotations: APIAnnotationData[],
     /* istanbul ignore next - test seam */
     now = new Date(),

--- a/src/sidebar/services/test/annotations-exporter-test.js
+++ b/src/sidebar/services/test/annotations-exporter-test.js
@@ -27,7 +27,7 @@ describe('AnnotationsExporter', () => {
       },
     ];
 
-    const result = exporter.buildExportContent(annotations, now);
+    const result = exporter.buildJSONExportContent(annotations, now);
 
     assert.deepEqual(result, {
       export_date: now.toISOString(),


### PR DESCRIPTION
This PR paves the road to add more annotations export formats, by disabling all options which are not JSON and refactoring a bit the logic to add the rest of the formats afterwards.

> Part of https://github.com/hypothesis/client/issues/5784

### Considerations

At first I thought it made sense to use `AnnotationsExporter.buildExportContent`, but then I have realized that is slightly coupled with the JSON export format.

Other formats, as described in https://docs.google.com/document/d/1Xn6AazKkpUy85VUaj9v_utasexk8lIqP_1zveILq1So/edit#heading=h.vi3pyroj4yi1 may need different information, or may not need some of the information `AnnotationsExporter.buildExportContent` returns.

Because of that I have decided to rename it to `buildJSONExportContent` and use it together with `downloadJSONFile`.

As we implement new formats, I think we will be adding new methods to `AnnotationsExporter`, together with new download file helpers.

### Testing steps

On this branch, check that you can still export annotations in JSON format, both when the [export_formats](http://localhost:5000/admin/features) feature flag is enabled and when it is not.