### PR TITLE
Avoid showing scrollbars in sidebar, codeblocks when not needed

### DIFF
--- a/src/sidebar/components/HypothesisApp.tsx
+++ b/src/sidebar/components/HypothesisApp.tsx
@@ -154,7 +154,7 @@ function HypothesisApp({
   return (
     <div
       className={classnames(
-        'h-full min-h-full overflow-scroll',
+        'h-full min-h-full overflow-auto',
         // Precise padding to align with annotation cards in content
         // Larger padding on bottom for wide screens
         'lg:pb-16 bg-grey-2',

--- a/src/styles/sidebar/components/StyledText.scss
+++ b/src/styles/sidebar/components/StyledText.scss
@@ -89,7 +89,7 @@
     }
 
     pre code {
-      @apply block p-3 bg-grey-1 rounded overflow-scroll;
+      @apply block p-3 bg-grey-1 rounded overflow-auto;
     }
 
     a {


### PR DESCRIPTION
Currently the horizontal/vertical scrollbars appear on the hypothesis sidebar and in codeblocks even when they're not needed. Switch to `overflow: auto` to only display them when necessary.

Before:
<img src="https://github.com/hypothesis/client/assets/6251786/dc894ccf-db0b-4081-a97c-a24b00341d52" width=300>

After:
<img src="https://github.com/hypothesis/client/assets/6251786/255986b2-abe7-43d9-bf5f-75e72f9d52d2" width=300>
