### PR TITLE
Allow whitespace-only <span>s during highlight

### DIFF
--- a/dev-server/documents/html/whitespace.mustache
+++ b/dev-server/documents/html/whitespace.mustache
@@ -140,6 +140,23 @@
       ullamcorper commodo. Nunc at nisi ut arcu euismod venenatis quis in nisl.
     </p>
     </div>
+
+    <h3>Syntaxhighlighting Codeblocks</h3>
+
+    <h4>Highlight js - whitespace &lt;span&gt;s</h4>
+    <div class="testcase">
+      <div class="highlight-bash notranslate">
+        <div class="highlight">
+          <pre><span></span>tox<span class="w"> </span>-qe<span class="w"> </span>dev<span class="w"> </span>--<span class="w"> </span>sh<span class="w"> </span>bin/hypothesis<span class="w"> </span>--dev<span class="w"> </span>user<span class="w"> </span>admin<span class="w"> </span>&lt;username&gt;
+          </pre>
+        </div>
+      </div>
+    </div>
+
+    <h4>Codemirror - whitespace between &lt;span&gt;s</h4>
+    <div class="testcase">
+      <pre><code type="javascript"><span class="tok-keyword">import</span> <span class="tok-punctuation">{</span><span class="tok-variableName tok-definition">EditorView</span><span class="tok-punctuation">,</span> <span class="tok-variableName tok-definition">keymap</span><span class="tok-punctuation">}</span> <span class="tok-keyword">from</span> <span class="tok-string">"@codemirror/view"</span></code></pre>
+    </div>
     {{{ hypothesisScript }}}
   </body>
 </html>

--- a/src/annotator/highlighter.ts
+++ b/src/annotator/highlighter.ts
@@ -234,10 +234,16 @@ export function highlightRange(
   // inserting highlight elements in places that can only contain a restricted
   // subset of nodes such as table rows and lists.
   const whitespace = /^\s*$/;
-  textNodeSpans = textNodeSpans.filter(span =>
-    // Check for at least one text node with non-space content.
-    span.some(node => !whitespace.test(node.data)),
-  );
+  textNodeSpans = textNodeSpans.filter(span => {
+    const parentElement = span[0].parentElement;
+    return (
+      // Whitespace <span>s should be highlighted since they affect layout
+      (parentElement?.childNodes.length === 1 &&
+        parentElement?.tagName.match(/^SPAN$/i)) ||
+      // Otherwise ignore white-space only Text node spans
+      span.some(node => !whitespace.test(node.data))
+    );
+  });
 
   // Wrap each text node span with a `<hypothesis-highlight>` element.
   const highlights: HighlightElement[] = [];

--- a/src/annotator/highlighter.ts
+++ b/src/annotator/highlighter.ts
@@ -237,9 +237,10 @@ export function highlightRange(
   textNodeSpans = textNodeSpans.filter(span => {
     const parentElement = span[0].parentElement;
     return (
-      // Whitespace <span>s should be highlighted since they affect layout
+      // Whitespace <span>s should be highlighted since they affect layout in
+      // some code editors
       (parentElement?.childNodes.length === 1 &&
-        parentElement?.tagName.match(/^SPAN$/i)) ||
+        parentElement?.tagName === 'SPAN') ||
       // Otherwise ignore white-space only Text node spans
       span.some(node => !whitespace.test(node.data))
     );

--- a/src/annotator/test/highlighter-test.js
+++ b/src/annotator/test/highlighter-test.js
@@ -235,7 +235,7 @@ describe('annotator/highlighter', () => {
       assert.equal(result[0].textContent, 'one two');
     });
 
-    it('skips non-<span> text node spans which consist only of spaces', () => {
+    it('skips whitespace-only text node spans, except inside <span>s', () => {
       const el = document.createElement('div');
       el.appendChild(document.createTextNode(' '));
       el.appendChild(document.createTextNode(''));
@@ -249,7 +249,7 @@ describe('annotator/highlighter', () => {
       assert.equal(result.length, 0);
     });
 
-    it('includes whitespace elements if <span> parent', () => {
+    it('wraps whitespace-only text if <span> parent', () => {
       // Real-world examples:
       // - Codeblocks on https://h.readthedocs.io/en/latest/developing/install
       // - Text layer on https://archive.org/details/goodytwoshoes00newyiala


### PR DESCRIPTION
Closes #5711 

This will fix archive.org 's BookReader, and some highlightjs code snippets (like those on https://h.readthedocs.io/en/latest/developing/administration/ ). These have HTML like:

```html
<span class="word">The</span><span class="space">[WHITESPACE]</span><span class="word">quick</span>
```

Note it will not fix other code syntax highlighters, like Codemirror, or what's on GitHub, since those use whitespaces _between_ spans. (eg `<span class="keyword">if</span>[WHITESPACE]<span class="paren">(</span>...`).