### PR TITLE
Remove dependency on rounded_corners feature flag

### DIFF
--- a/src/sidebar/components/HypothesisApp.tsx
+++ b/src/sidebar/components/HypothesisApp.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import { useEffect, useLayoutEffect, useMemo } from 'preact/hooks';
+import { useEffect, useMemo } from 'preact/hooks';
 
 import { confirm } from '../../shared/prompts';
 import type { SidebarSettings } from '../../types/config';
@@ -48,20 +48,6 @@ function HypothesisApp({
   const profile = store.profile();
   const route = store.route();
   const isModalRoute = route === 'notebook' || route === 'profile';
-
-  const roundedCornersEnabled = store.isFeatureEnabled('rounded_corners');
-  useLayoutEffect(() => {
-    const html = document.querySelector('html');
-
-    html?.style.setProperty(
-      '--h-border-radius',
-      roundedCornersEnabled ? '0.25rem' : null,
-    );
-    html?.style.setProperty(
-      '--h-border-radius-lg',
-      roundedCornersEnabled ? '0.5rem' : null,
-    );
-  }, [roundedCornersEnabled]);
 
   const backgroundStyle = useMemo(
     () => applyTheme(['appBackgroundColor'], settings),

--- a/src/sidebar/components/test/HypothesisApp-test.js
+++ b/src/sidebar/components/test/HypothesisApp-test.js
@@ -142,24 +142,6 @@ describe('HypothesisApp', () => {
     });
   });
 
-  [true, false].forEach(roundedCornersEnabled => {
-    it('defines border-radius CSS vars when the feature flag is enabled', () => {
-      fakeStore.isFeatureEnabled.returns(roundedCornersEnabled);
-      createComponent();
-
-      const styles = document.querySelector('html')?.style;
-
-      assert.equal(
-        styles.getPropertyValue('--h-border-radius'),
-        roundedCornersEnabled ? '0.25rem' : '',
-      );
-      assert.equal(
-        styles.getPropertyValue('--h-border-radius-lg'),
-        roundedCornersEnabled ? '0.5rem' : '',
-      );
-    });
-  });
-
   describe('auto-opening tutorial', () => {
     it('should open tutorial on profile load when criteria are met', () => {
       fakeShouldAutoDisplayTutorial.returns(true);

--- a/tailwind-annotator.config.mjs
+++ b/tailwind-annotator.config.mjs
@@ -9,14 +9,4 @@ export default {
     // This module references `sidebar-frame` and related classes
     './src/annotator/sidebar.{js,ts,tsx}',
   ],
-  theme: {
-    extend: {
-      borderRadius: {
-        // Equivalent to tailwind defaults, but overriding values from frontend-shared preset
-        // Once the preset stops defining borderRadius, we can remove this
-        DEFAULT: '0.25rem',
-        lg: '0.5rem',
-      },
-    }
-  }
 };

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -24,6 +24,12 @@ export default {
         'pulse-fade-out': 'pulse-fade-out 5s ease-in-out forwards',
         'slide-in-from-right': 'slide-in-from-right 0.3s forwards ease-in-out',
       },
+      borderRadius: {
+        // Equivalent to tailwind defaults, but overriding values from frontend-shared preset
+        // Once the preset stops defining borderRadius, we can remove this
+        DEFAULT: '0.25rem',
+        lg: '0.5rem',
+      },
       boxShadow: {
         // A more prominent shadow than the one used by tailwind, intended for
         // popovers and menus


### PR DESCRIPTION
Rounded corners have been rolled out, and there has been no complains so far.

Considering we cannot disable them everywhere, as only the client makes use of the feature flag we originally created, we discussed it would be ok to remove it already, and use rounded corners unconditionally.

This PR moves the definition of border radius sizes to base tailwind config, with what is becoming our new default.