### PR TITLE
Add helper function to trim and dedent multiline strings

### DIFF
--- a/src/shared/test/trim-and-dedent-test.js
+++ b/src/shared/test/trim-and-dedent-test.js
@@ -1,0 +1,33 @@
+import { trimAndDedent } from '../trim-and-dedent';
+
+describe('trimAndDedent', () => {
+  [
+    ['Foo', 'Foo'],
+    ['   Foo', 'Foo'],
+    [
+      `First line
+  Second line
+    Third line`,
+      `First line
+  Second line
+    Third line`,
+    ],
+    [
+      `
+      
+        Hello, Jane!
+          Indented line
+        Goodbye, John!
+      
+      `,
+      `Hello, Jane!
+  Indented line
+Goodbye, John!`,
+    ],
+  ].forEach(([str, expectedResult]) => {
+    it('normalizes strings with multiple lines', () => {
+      const result = trimAndDedent(str);
+      assert.equal(result, expectedResult);
+    });
+  });
+});

--- a/src/shared/trim-and-dedent.ts
+++ b/src/shared/trim-and-dedent.ts
@@ -1,0 +1,55 @@
+/**
+ * Remove leading and trailing empty lines from a string.
+ */
+function trimEmptyLines(str: string): string {
+  return str.replace(/^\s*\n|\n\s*$/g, '');
+}
+
+/**
+ * Remove common indentation from each line of a string.
+ */
+function dedent(str: string) {
+  // Match the smallest indentation
+  const match = str.match(/^[ \t]*(?=\S)/gm);
+  const indent = match && Math.min(...match.map(el => el.length));
+
+  if (indent) {
+    const regexp = new RegExp(`^ {${indent}}`, 'gm');
+    return str.replace(regexp, '');
+  }
+
+  return str;
+}
+
+/**
+ * Remove leading and trailing empty lines from a string, then remove common
+ * indentation from each line.
+ *
+ * This is useful to improve readability for multi-line template literals,
+ * where you don't want to
+ *  1) start the first line right after the first backtick.
+ *  2) indent the string inconsistently with the rest of the code.
+ *
+ * This function allows to move from this:
+ *   function foo(arg) {
+ *     if (arg === 3) {
+ *       console.log(`First line
+ *   Second line
+ *   Third line`);
+ *     }
+ *   }
+ *
+ * to this:
+ *   function foo(arg) {
+ *     if (arg === 3) {
+ *       console.log(trimAndDedent(`
+ *         First line
+ *         Second line
+ *         Third line
+ *       `));
+ *     }
+ *   }
+ */
+export function trimAndDedent(str: string): string {
+  return dedent(trimEmptyLines(str));
+}


### PR DESCRIPTION
This PR is a follow-up on what was discussed in https://github.com/hypothesis/client/pull/5961

It brings the non-controversial parts of that PR (removing extra empty lines and extra indentation from a multi-line string), but leaves out the part about supporting handlebars-like placeholders.

This logic will come handy when rendering the annotations export for CSV, text and HTML, without adding any kind of variable filtering yet.

I tried to imagine how filtering would be plugged here, but then came to the conclusion that trying to abstract it would just make things harder.

The way I imagine it, we'll have separated tagged template literals for every format that needs it (CSV and HTML), which result will be passed to the function provided by this PR:

With that, every format could look something like this:

```ts
// Text
const result = normalizeMultiLine(`
  ${title}
  ${uri}
  Group: ${groupName}
  Total users: ${totalUsers}
  Users: ${users}
  Total annotations: ${totalAnnotations}
  Total replies: ${totalReplies}

  ${annotations}
`);

// CSV
const result = normalizeMultiLine(`
  title,uri,group
  ${annotations.map(annotation => filterCSV`${annotation.title},${annotation.uri},${groupName}`)}
`);

// HTML
const result = normalizeMultiLine(filterHTML`
  <div>Title</div>
  <div>${title}</div>
  ...
`);
```

But as said, let's figure those out once needed.