### PR TITLE
Replace LinkButton's color prop usage with variant

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationHeader.tsx
+++ b/src/sidebar/components/Annotation/AnnotationHeader.tsx
@@ -115,7 +115,7 @@ function AnnotationHeader({
         <AnnotationUser authorLink={authorLink} displayName={authorName} />
         {replyCount > 0 && isCollapsedReply && (
           <LinkButton
-            color="text-light"
+            variant="text-light"
             onClick={onReplyCountClick}
             title="Expand replies"
             underline="hover"

--- a/src/sidebar/components/Excerpt.tsx
+++ b/src/sidebar/components/Excerpt.tsx
@@ -40,7 +40,7 @@ function InlineControls({
     >
       <div className="flex justify-end">
         <LinkButton
-          color="text"
+          variant="text"
           onClick={() => setCollapsed(!isCollapsed)}
           expanded={!isCollapsed}
           title="Toggle visibility of full excerpt text"

--- a/src/sidebar/components/HelpPanel.tsx
+++ b/src/sidebar/components/HelpPanel.tsx
@@ -25,7 +25,7 @@ function HelpPanelNavigationButton({
   onClick,
 }: HelpPanelNavigationButtonProps) {
   return (
-    <LinkButton color="brand" onClick={onClick} underline="hover">
+    <LinkButton variant="brand" onClick={onClick} underline="hover">
       <div className="flex items-center gap-x-1">
         {children}
         <ArrowRightIcon className="w-em h-em" />

--- a/src/sidebar/components/LoggedOutMessage.tsx
+++ b/src/sidebar/components/LoggedOutMessage.tsx
@@ -28,7 +28,7 @@ function LoggedOutMessage({ onLogin }: LoggedOutMessageProps) {
           create a free account
         </Link>{' '}
         or{' '}
-        <LinkButton inline color="text" onClick={onLogin} underline="always">
+        <LinkButton inline variant="text" onClick={onLogin} underline="always">
           log in
         </LinkButton>
         .

--- a/src/sidebar/components/SelectionTabs.tsx
+++ b/src/sidebar/components/SelectionTabs.tsx
@@ -58,7 +58,7 @@ function Tab({
       classes={classnames('bg-transparent min-w-[5.25rem]', {
         'font-bold': isSelected,
       })}
-      color="text"
+      variant="text"
       // Listen for `onMouseDown` so that the tab is selected when _pressed_
       // as this makes the UI feel faster. Also listen for `onClick` as a fallback
       // to enable selecting the tab via other input methods.


### PR DESCRIPTION
This removes the only remaining usages of deprecated frontend-shared symbols, in preparation for v7.0.0