### PR TITLE
Allow full dedenting on trimAndDedent

### DIFF
--- a/src/shared/test/trim-and-dedent-test.js
+++ b/src/shared/test/trim-and-dedent-test.js
@@ -24,9 +24,22 @@ describe('trimAndDedent', () => {
   Indented line
 Goodbye, John!`,
     ],
-  ].forEach(([str, expectedResult]) => {
+    [
+      `
+      
+        Hello, Jane!
+          Indented line
+        Goodbye, John!
+      
+      `,
+      `Hello, Jane!
+Indented line
+Goodbye, John!`,
+      { fullDedent: true },
+    ],
+  ].forEach(([str, expectedResult, options]) => {
     it('normalizes strings with multiple lines', () => {
-      const result = trimAndDedent(str);
+      const result = trimAndDedent(str, options);
       assert.equal(result, expectedResult);
     });
   });

--- a/src/shared/trim-and-dedent.ts
+++ b/src/shared/trim-and-dedent.ts
@@ -5,10 +5,25 @@ function trimEmptyLines(str: string): string {
   return str.replace(/^\s*\n|\n\s*$/g, '');
 }
 
+export type DedentOptions = {
+  /**
+   * When true, it will completely remove indentation from every line.
+   * When false, it will only remove the common indentation among lines.
+   * Defaults to false.
+   */
+  fullDedent?: boolean;
+};
+
 /**
- * Remove common indentation from each line of a string.
+ * Remove indentation from each line of a string.
  */
-function dedent(str: string) {
+function dedent(str: string, options?: DedentOptions) {
+  if (options?.fullDedent) {
+    // Remove all tabs or spaces at the beginning of every line
+    // (`m` regex modifier means multiline)
+    return str.replace(/^[ \t]+/gm, '');
+  }
+
   // Match the smallest indentation
   const match = str.match(/^[ \t]*(?=\S)/gm);
   const indent = match && Math.min(...match.map(el => el.length));
@@ -20,6 +35,8 @@ function dedent(str: string) {
 
   return str;
 }
+
+export type TrimAndDedentOptions = DedentOptions;
 
 /**
  * Remove leading and trailing empty lines from a string, then remove common
@@ -50,6 +67,9 @@ function dedent(str: string) {
  *     }
  *   }
  */
-export function trimAndDedent(str: string): string {
-  return dedent(trimEmptyLines(str));
+export function trimAndDedent(
+  str: string,
+  options?: TrimAndDedentOptions,
+): string {
+  return dedent(trimEmptyLines(str), options);
 }


### PR DESCRIPTION
While working on https://github.com/hypothesis/client/pull/5960, I realized the `trimAndDedent` function can produce unexpected results if the string template is injecting variables with multiple lines.

When that happens dedenting won't work, because at least one of those lines will have zero indentation.

Considering we actually want to remove all indentation there, this PR adds the ability to pass options to `trimAndDedent`, and introduces the first `fullDedent` option which will remove all indentation when `true`, instead of just the common part.