### PR TITLE
Record page number selectors for EPUB-based VitalSource books

### DIFF
--- a/dev-server/static/scripts/vitalsource-mosaic-book-element.js
+++ b/dev-server/static/scripts/vitalsource-mosaic-book-element.js
@@ -61,21 +61,21 @@ export class MosaicBookElement extends HTMLElement {
           absoluteURL: '/document/little-women-1',
           chapterTitle: 'Chapter One',
           cfi: '/2',
-          index: 0,
+          index: undefined,
           page: '10',
         },
         {
           absoluteURL: '/document/little-women-2',
           chapterTitle: 'Chapter Two',
           cfi: '/4',
-          index: 1,
+          index: undefined,
           page: '20',
         },
         {
           absoluteURL: '/document/little-women-3',
           chapterTitle: 'Chapter Three',
           cfi: '/6',
-          index: 2,
+          index: undefined,
           page: '30',
         },
       ];
@@ -168,6 +168,10 @@ export class MosaicBookElement extends HTMLElement {
 
   async getCurrentPage() {
     return this.pageData[this.pageIndex];
+  }
+
+  async getPages() {
+    return { ok: true, data: [...this.pageData], status: 200 };
   }
 
   async getTOC() {

--- a/src/annotator/integrations/test/vitalsource-test.js
+++ b/src/annotator/integrations/test/vitalsource-test.js
@@ -236,7 +236,7 @@ describe('annotator/integrations/vitalsource', () => {
           absoluteURL: '/pages/chapter_02.xhtml',
           cfi: '/2',
           chapterTitle: 'Chapter two',
-          index: 1,
+          index: undefined,
           page: '20',
         };
       } else if (this._format === 'pbk') {
@@ -250,6 +250,12 @@ describe('annotator/integrations/vitalsource', () => {
       } else {
         throw new Error('Unknown book');
       }
+    }
+
+    async getPages() {
+      const pageData = await this.getCurrentPage();
+      const data = [pageData];
+      return { ok: true, data };
     }
 
     async getTOC() {
@@ -394,7 +400,7 @@ describe('annotator/integrations/vitalsource', () => {
       const pageSelector = selectors.find(s => s.type === 'PageSelector');
       assert.deepEqual(pageSelector, {
         type: 'PageSelector',
-        index: 1,
+        index: 0,
         label: '20',
       });
     });

--- a/src/annotator/integrations/test/vitalsource-test.js
+++ b/src/annotator/integrations/test/vitalsource-test.js
@@ -392,7 +392,11 @@ describe('annotator/integrations/vitalsource', () => {
       });
 
       const pageSelector = selectors.find(s => s.type === 'PageSelector');
-      assert.notOk(pageSelector);
+      assert.deepEqual(pageSelector, {
+        type: 'PageSelector',
+        index: 1,
+        label: '20',
+      });
     });
 
     it('adds selector for current PDF book page', async () => {

--- a/src/annotator/integrations/vitalsource.ts
+++ b/src/annotator/integrations/vitalsource.ts
@@ -352,13 +352,13 @@ export class VitalSourceContentIntegration
       },
     ];
 
-    // If this is a PDF-based book, add a page selector. PDFs always have page
-    // numbers available. EPUB-based books _may_ have information about how
-    // content maps to page numbers in a printed edition of the book. We
-    // currently limit page number selectors to PDFs until more is understood
-    // about when EPUB page numbers are reliable/likely to remain stable.
-    const bookInfo = this._bookElement.getBookInfo();
-    if (bookInfo.format === 'pbk' && typeof pageIndex === 'number') {
+    // Add page number if available. PDF-based books always have them.
+    // Publishers are encouraged to provide page numbers for EPUB-based books,
+    // but not all do. See mentions of page numbers in the "VitalSource ePub3
+    // Submission Guide" [1].
+    //
+    // [1] https://www.vitalsource.com/en-uk/products/vitalsource-epub3-implementation-guide-vitalsource-vvstdocsepub3implementguide?term=VST-DOCS-EPUB3IMPLEMENTGUIDE
+    if (typeof pageIndex === 'number') {
       extraSelectors.push({
         type: 'PageSelector',
         index: pageIndex,

--- a/src/types/vitalsource.ts
+++ b/src/types/vitalsource.ts
@@ -164,6 +164,9 @@ export type MosaicBookElement = HTMLElement & {
    */
   getCurrentPage(): Promise<PageInfo>;
 
+  /** Get the list of pages in the book. */
+  getPages(): Promise<DataResponse<PageInfo[]>>;
+
   /** Retrieve the book's table of contents. */
   getTOC(): Promise<DataResponse<TableOfContentsEntry[]>>;
 


### PR DESCRIPTION
Previously annotations in EPUB-based VitalSource books had CFI selectors (`type: "EPUBContentSelector"`) but not page number selectors (`type: "PageSelector"`). In order to be able to filter annotations based on page range, even if they came from a book that is EPUB-based, we need to store page numbers with annotations as well.

There are two parts to this:
- Remove the guard that prevented page numbers from being saved with EPUB-based books (first commit)
- Add an alternative method to get the index of the page, which is one of the fields of `PageSelector`, as the previous data source is not available for EPUB-based books (second commit)

Addresses https://github.com/hypothesis/client/issues/5937#issuecomment-1833430417.

**Testing:**

1. Build this branch locally and create a browser extension from it
2. Open an EPUB-based book in bookshelf (eg. https://www.vitalsource.com/en-uk/products/vitalsource-epub3-implementation-guide-vitalsource-vvstdocsepub3implementguide?term=VST-DOCS-EPUB3IMPLEMENTGUIDE)
3. Create an annotation and inspect the JSON payload

The newly created annotation should have a `PageSelector` selector with a `label` field that matches the page number displayed in the lower-right corner of the book viewer, and a correct `index` value.