### PR TITLE
Display page numbers on annotation cards if feature enabled

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationHeader.tsx
+++ b/src/sidebar/components/Annotation/AnnotationHeader.tsx
@@ -12,6 +12,7 @@ import {
   isHighlight,
   isReply,
   hasBeenEdited,
+  pageLabel as getPageLabel,
 } from '../../helpers/annotation-metadata';
 import {
   annotationAuthorLink,
@@ -54,6 +55,7 @@ function AnnotationHeader({
   const defaultAuthority = store.defaultAuthority();
   const displayNamesEnabled = store.isFeatureEnabled('client_display_names');
   const userURL = store.getLink('user', { user: annotation.user });
+  const pageNumbersEnabled = store.isFeatureEnabled('page_numbers');
 
   const authorName = useMemo(
     () =>
@@ -101,7 +103,14 @@ function AnnotationHeader({
     // an ID.
     store.setExpanded(annotation.id!, true);
 
-  const group = store.getGroup(annotation.group);
+  // As part of the `page_numbers` feature, we are hiding the group on cards in
+  // contexts where it is the same for all cards and is shown elsewhere in the
+  // UI (eg. the top bar). This is to reduce visual clutter.
+  let group;
+  if (!pageNumbersEnabled || store.route() !== 'sidebar') {
+    group = store.getGroup(annotation.group);
+  }
+  const pageNumber = pageNumbersEnabled ? getPageLabel(annotation) : undefined;
 
   return (
     <header>
@@ -153,12 +162,21 @@ function AnnotationHeader({
               className="w-[10px] h-[10px] text-color-text-light"
             />
           )}
-          {showDocumentInfo && (
-            <AnnotationDocumentInfo
-              domain={documentInfo.domain}
-              link={documentLink}
-              title={documentInfo.titleText}
-            />
+          {(showDocumentInfo || pageNumber) && (
+            <span className="flex">
+              {showDocumentInfo && (
+                <AnnotationDocumentInfo
+                  domain={documentInfo.domain}
+                  link={documentLink}
+                  title={documentInfo.titleText}
+                />
+              )}
+              {pageNumber && (
+                <span className="text-grey-6" data-testid="page-number">
+                  {showDocumentInfo && ', '}p.{pageNumber}
+                </span>
+              )}
+            </span>
           )}
         </div>
       )}

--- a/src/sidebar/helpers/annotation-metadata.ts
+++ b/src/sidebar/helpers/annotation-metadata.ts
@@ -1,6 +1,7 @@
 import type {
   APIAnnotationData,
   Annotation,
+  PageSelector,
   SavedAnnotation,
   TextQuoteSelector,
 } from '../../types/api';
@@ -339,6 +340,18 @@ export function quote(annotation: APIAnnotationData): string | null {
     | TextQuoteSelector
     | undefined;
   return quoteSel ? quoteSel.exact : null;
+}
+
+/**
+ * Return the label of the page that an annotation comes from.
+ *
+ * This is usually a 1-based page number, but can also be roman numerals etc.
+ */
+export function pageLabel(annotation: APIAnnotationData): string | undefined {
+  const pageSel = annotation.target[0]?.selector?.find(
+    s => s.type === 'PageSelector',
+  ) as PageSelector | undefined;
+  return pageSel?.label;
 }
 
 /**

--- a/src/sidebar/helpers/test/annotation-metadata-test.js
+++ b/src/sidebar/helpers/test/annotation-metadata-test.js
@@ -4,6 +4,7 @@ import {
   documentMetadata,
   domainAndTitle,
   isSaved,
+  pageLabel,
 } from '../annotation-metadata';
 
 describe('sidebar/helpers/annotation-metadata', () => {
@@ -584,6 +585,27 @@ describe('sidebar/helpers/annotation-metadata', () => {
         ],
       };
       assert.equal(annotationMetadata.quote(ann), null);
+    });
+  });
+
+  describe('pageLabel', () => {
+    it('returns page label for annotation', () => {
+      const ann = {
+        target: [
+          {
+            source: 'https://publisher.org/article.pdf',
+            selector: [{ type: 'PageSelector', index: 10, label: '11' }],
+          },
+        ],
+      };
+      assert.equal(pageLabel(ann), '11');
+    });
+
+    it('returns undefined if annotation has no `PageSelector` selector', () => {
+      const anns = [fixtures.newPageNote(), fixtures.newAnnotation()];
+      for (const ann of anns) {
+        assert.isUndefined(pageLabel(ann));
+      }
     });
   });
 


### PR DESCRIPTION
Display page numbers on annotation cards when:

 - The `page_numbers` feature flag is enabled AND
 - The annotation has a `PageSelector` selector. This applies to VitalSource books and PDFs.

Part of https://github.com/hypothesis/client/issues/5986.

**Testing:**

1. Turn the `page_numbers` feature flag on
2. Create some annotations on a PDF

In the sidebar, the group name will be hidden and in its place, you will see the page number if available:

<img width="452" alt="sidebar-page-numbers" src="https://github.com/hypothesis/client/assets/2458/a2115fa6-61f0-471c-9d4e-41149eae5e24">

In the notebook, the group name and document info is shown as before, and the page number is shown at the end:

<img width="685" alt="notebook-page-numbers" src="https://github.com/hypothesis/client/assets/2458/47bc30ed-f92b-4adb-a452-a49cb002d149">
