### PR TITLE
Add dependabot group for redux packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,8 @@ updates:
       typescript-types:
         patterns:
           - '@types/*'
+      redux:
+        patterns:
+          - 'redux'
+          - 'redux-thunk'
+          - 'reselect'


### PR DESCRIPTION
With new major versions of main redux packages released, this makes sure dependabot will group updates for the ones we depend on in the same PR.

Single PRs updating every individual package would require human attention, as they need to be updated at the same time.