### PR TITLE
Support filtering annotations by CFI

### DIFF
--- a/src/shared/cfi.ts
+++ b/src/shared/cfi.ts
@@ -116,6 +116,13 @@ export function compareCFIs(a: string, b: string): number {
 }
 
 /**
+ * Return true if the CFI `cfi` lies in the range [start, end).
+ */
+export function cfiInRange(cfi: string, start: string, end: string): boolean {
+  return compareCFIs(cfi, start) >= 0 && compareCFIs(cfi, end) < 0;
+}
+
+/**
  * Return a slice of `cfi` up to the first step indirection [1], with assertions
  * removed.
  *

--- a/src/shared/test/cfi-test.js
+++ b/src/shared/test/cfi-test.js
@@ -1,4 +1,9 @@
-import { compareCFIs, documentCFI, stripCFIAssertions } from '../cfi';
+import {
+  cfiInRange,
+  compareCFIs,
+  documentCFI,
+  stripCFIAssertions,
+} from '../cfi';
 
 describe('sidebar/util/cfi', () => {
   describe('stripCFIAssertions', () => {
@@ -117,6 +122,50 @@ describe('sidebar/util/cfi', () => {
         documentCFI('/6/152[;vnd.vst.idref=ch13_01]!/4/2[ch13_sec_1]'),
         '/6/152',
       );
+    });
+  });
+
+  describe('cfiInRange', () => {
+    [
+      // CFI before start of range
+      {
+        cfi: '/2',
+        start: '/4',
+        end: '/6',
+        expected: false,
+      },
+      // CFI at start of range
+      {
+        cfi: '/2',
+        start: '/2',
+        end: '/3',
+        expected: true,
+      },
+      // CFI in middle of range
+      {
+        cfi: '/4',
+        start: '/2',
+        end: '/6',
+        expected: true,
+      },
+      // CFI at start and end of empty range
+      {
+        cfi: '/2',
+        start: '/2',
+        end: '/2',
+        expected: false,
+      },
+      // CFI after end of range
+      {
+        cfi: '/6',
+        start: '/2',
+        end: '/4',
+        expected: false,
+      },
+    ].forEach(({ cfi, start, end, expected }) => {
+      it('should return true if the cfi is in the range [start, end)', () => {
+        assert.equal(cfiInRange(cfi, start, end), expected);
+      });
     });
   });
 });

--- a/src/sidebar/helpers/annotation-metadata.ts
+++ b/src/sidebar/helpers/annotation-metadata.ts
@@ -1,6 +1,7 @@
 import type {
   APIAnnotationData,
   Annotation,
+  EPUBContentSelector,
   PageSelector,
   SavedAnnotation,
   TextQuoteSelector,
@@ -340,6 +341,20 @@ export function quote(annotation: APIAnnotationData): string | null {
     | TextQuoteSelector
     | undefined;
   return quoteSel ? quoteSel.exact : null;
+}
+
+/**
+ * Return the EPUB Canonical Fragment Identifier for the table of contents entry
+ * associated with the part of the book / document that an annotation was made
+ * on.
+ *
+ * See {@link EPUBContentSelector}.
+ */
+export function cfi(annotation: APIAnnotationData): string | undefined {
+  const epubSel = annotation.target[0]?.selector?.find(
+    s => s.type === 'EPUBContentSelector',
+  ) as EPUBContentSelector | undefined;
+  return epubSel?.cfi;
 }
 
 /**

--- a/src/sidebar/helpers/test/annotation-metadata-test.js
+++ b/src/sidebar/helpers/test/annotation-metadata-test.js
@@ -1,6 +1,7 @@
 import * as fixtures from '../../test/annotation-fixtures';
 import * as annotationMetadata from '../annotation-metadata';
 import {
+  cfi,
   documentMetadata,
   domainAndTitle,
   isSaved,
@@ -602,6 +603,27 @@ describe('sidebar/helpers/annotation-metadata', () => {
     });
 
     it('returns undefined if annotation has no `PageSelector` selector', () => {
+      const anns = [fixtures.newPageNote(), fixtures.newAnnotation()];
+      for (const ann of anns) {
+        assert.isUndefined(pageLabel(ann));
+      }
+    });
+  });
+
+  describe('cfi', () => {
+    it('returns CFI for annotation', () => {
+      const ann = {
+        target: [
+          {
+            source: 'https://publisher.org/article.pdf',
+            selector: [{ type: 'EPUBContentSelector', cfi: '/2/4' }],
+          },
+        ],
+      };
+      assert.equal(cfi(ann), '/2/4');
+    });
+
+    it('returns undefined if annotation has no `EPUBContentSelector` selector', () => {
       const anns = [fixtures.newPageNote(), fixtures.newAnnotation()];
       for (const ann of anns) {
         assert.isUndefined(pageLabel(ann));

--- a/src/sidebar/helpers/test/view-filter-test.js
+++ b/src/sidebar/helpers/test/view-filter-test.js
@@ -267,6 +267,49 @@ describe('sidebar/helpers/view-filter', () => {
     });
   });
 
+  describe('"cfi" field', () => {
+    const annotation = {
+      id: 1,
+      target: [
+        {
+          selector: [
+            {
+              type: 'EPUBContentSelector',
+              cfi: '/2/4',
+            },
+          ],
+        },
+      ],
+    };
+
+    [
+      '/2/2-/2/6',
+      // CFI containing assertions in square brackets. Hyphens inside assertions
+      // should be ignored.
+      '/2/2[-/2/2]-/2/6',
+    ].forEach(range => {
+      it('matches if annotation is in range', () => {
+        const filters = { cfi: { terms: [range], operator: 'or' } };
+        const result = filterAnnotations([annotation], filters);
+        assert.deepEqual(result, [1]);
+      });
+    });
+
+    it('does not match if annotation is outside of range', () => {
+      const filters = { cfi: { terms: ['/2/6-/2/8'], operator: 'or' } };
+      const result = filterAnnotations([annotation], filters);
+      assert.deepEqual(result, []);
+    });
+
+    ['/2/2', '/2/2[-/2/6]'].forEach(range => {
+      it('does not match if term is not a range', () => {
+        const filters = { cfi: { terms: [range], operator: 'or' } };
+        const result = filterAnnotations([annotation], filters);
+        assert.deepEqual(result, []);
+      });
+    });
+  });
+
   it('ignores filters with no terms in the query', () => {
     const annotation = {
       id: 1,

--- a/src/sidebar/util/search-filter.ts
+++ b/src/sidebar/util/search-filter.ts
@@ -6,6 +6,18 @@
  * filter annotations displayed to the user or fetched from the API.
  */
 
+const filterFields = [
+  'cfi',
+  'group',
+  'quote',
+  'page',
+  'since',
+  'tag',
+  'text',
+  'uri',
+  'user',
+];
+
 /**
  * Splits a search term into filter and data.
  *
@@ -19,11 +31,7 @@ function splitTerm(term: string): [null | string, string] {
     return [null, term];
   }
 
-  if (
-    ['group', 'quote', 'page', 'since', 'tag', 'text', 'uri', 'user'].includes(
-      filter,
-    )
-  ) {
+  if (filterFields.includes(filter)) {
     const data = term.slice(filter.length + 1);
     return [filter, data];
   } else {
@@ -130,6 +138,7 @@ export function generateFacetedFilter(
   focusFilters: FocusFilter = {},
 ): Record<string, Facet> {
   const any = [];
+  const cfi = [];
   const page = [];
   const quote = [];
   const since = [];
@@ -145,6 +154,9 @@ export function generateFacetedFilter(
     const fieldValue = term.slice(filter.length + 1);
 
     switch (filter) {
+      case 'cfi':
+        cfi.push(fieldValue);
+        break;
       case 'quote':
         quote.push(fieldValue);
         break;
@@ -191,10 +203,18 @@ export function generateFacetedFilter(
     }
   }
 
+  // Filter terms use an "AND" operator if it is possible for an annotation to
+  // match more than one term (eg. an annotation can have multiple tags) or "OR"
+  // otherwise (eg. an annotation cannot match two distinct user terms).
+
   return {
     any: {
       terms: any,
       operator: 'and',
+    },
+    cfi: {
+      terms: cfi,
+      operator: 'or',
     },
     quote: {
       terms: quote,

--- a/src/sidebar/util/test/search-filter-test.js
+++ b/src/sidebar/util/test/search-filter-test.js
@@ -171,6 +171,15 @@ describe('sidebar/util/search-filter', () => {
           },
         },
       },
+      {
+        query: 'cfi:/2-/4',
+        expectedFilter: {
+          cfi: {
+            operator: 'or',
+            terms: ['/2-/4'],
+          },
+        },
+      },
     ].forEach(({ query, expectedFilter }) => {
       it('parses a search query', () => {
         const filter = searchFilter.generateFacetedFilter(query);


### PR DESCRIPTION
Support `cfi:{start}-{end}` queries which filter annotations based on whether they have an associated EPUB CFI which lies in `[start, end)`.

This query can be entered manually by the user in the search box, which is useful for testing, but the intent is that this filter would be used in contexts where the query is generated automatically (eg. as a result of the LMS app passing a CFI range from the assignment's configuration to the client).

Note that within a CFI, "-" can occur, but only inside a square-bracketed assertion (eg. `/6/14[chap05ref]!/4[body01]/10/2/1:3[2^[1^]]`). We strip these assertions before splitting a range into start and end parts.

**Testing:**

Go to http://localhost:3000/document/vitalsource-epub and make annotations on each of the three chapters. The chapters have CFIs of `/2`, `/4` and `/6` respectively. In the search bar you can enter a query such as `/2-/3` to show only annotations from the first chapter, or `/4-/7` to show annotations only from the last chapter.

Part of https://github.com/hypothesis/client/issues/5937.