### PR TITLE
Add space between "p." and page number

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationHeader.tsx
+++ b/src/sidebar/components/Annotation/AnnotationHeader.tsx
@@ -173,7 +173,7 @@ function AnnotationHeader({
               )}
               {pageNumber && (
                 <span className="text-grey-6" data-testid="page-number">
-                  {showDocumentInfo && ', '}p.{pageNumber}
+                  {showDocumentInfo && ', '}p. {pageNumber}
                 </span>
               )}
             </span>

--- a/src/sidebar/components/Annotation/test/AnnotationHeader-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationHeader-test.js
@@ -478,7 +478,7 @@ describe('AnnotationHeader', () => {
       const wrapper = createAnnotationHeader({ annotation });
       const pageNumber = wrapper.find('[data-testid="page-number"]');
       assert.isTrue(pageNumber.exists());
-      assert.equal(pageNumber.text(), 'p.11');
+      assert.equal(pageNumber.text(), 'p. 11');
     });
 
     it('should hide group name in sidebar', () => {


### PR DESCRIPTION
This matches how page numbers are more typically written in e.g. citations.

Before:

<img width="430" alt="Page number no space" src="https://github.com/hypothesis/client/assets/2458/f86cef55-a6c5-4e22-b716-ee0d72def4ca">

After:

<img width="434" alt="Page number space" src="https://github.com/hypothesis/client/assets/2458/08ff5381-3ba5-4364-8060-f9ccbd868620">
