### PR TITLE
Add new focus filters for page and CFI range

### DIFF
--- a/src/sidebar/components/search/FilterAnnotationsStatus.tsx
+++ b/src/sidebar/components/search/FilterAnnotationsStatus.tsx
@@ -25,8 +25,14 @@ type FilterStatusMessageProps = {
   /** Plural unit of the items being shown */
   entityPlural: string;
 
+  /** Range of content currently focused (if not a page range). */
+  focusContentRange?: string | null;
+
   /** Display name for the user currently focused, if any */
   focusDisplayName?: string | null;
+
+  /** Page range that is currently focused, if any */
+  focusPageRange?: string | null;
 
   /**
    * The number of items that match the current filter(s). When focusing on a
@@ -44,9 +50,18 @@ function FilterStatusMessage({
   additionalCount,
   entitySingular,
   entityPlural,
+  focusContentRange,
   focusDisplayName,
+  focusPageRange,
   resultCount,
 }: FilterStatusMessageProps) {
+  let contentLabel;
+  if (focusContentRange) {
+    contentLabel = <span> in {focusContentRange}</span>;
+  } else if (focusPageRange) {
+    contentLabel = <span> in pages {focusPageRange}</span>;
+  }
+
   return (
     <>
       {resultCount > 0 && <span>Showing </span>}
@@ -63,6 +78,7 @@ function FilterStatusMessage({
           </span>
         </span>
       )}
+      {contentLabel}
       {additionalCount > 0 && (
         <span className="whitespace-nowrap italic text-color-text-light">
           {' '}
@@ -172,9 +188,16 @@ export default function FilterAnnotationsStatus() {
       if (forcedVisibleCount > 0) {
         return 'Reset filters';
       }
-      return focusState.active
-        ? 'Show all'
-        : `Show only ${focusState.displayName}`;
+
+      if (focusState.active) {
+        return 'Show all';
+      } else if (focusState.displayName) {
+        return `Show only ${focusState.displayName}`;
+      } else if (focusState.configured) {
+        // Generic label for button to re-enable focus mode, if we don't have
+        // a more specific one.
+        return 'Reset filter';
+      }
     }
     return 'Clear search';
   }, [
@@ -184,6 +207,8 @@ export default function FilterAnnotationsStatus() {
     filterMode,
     forcedVisibleCount,
   ]);
+
+  const showFocusHint = filterMode !== 'selection' && focusState.active;
 
   return (
     <div
@@ -212,11 +237,13 @@ export default function FilterAnnotationsStatus() {
                     additionalCount={additionalCount}
                     entitySingular="annotation"
                     entityPlural="annotations"
-                    focusDisplayName={
-                      filterMode !== 'selection' && focusState.active
-                        ? focusState.displayName
-                        : ''
+                    focusContentRange={
+                      showFocusHint ? focusState.contentRange : null
                     }
+                    focusDisplayName={
+                      showFocusHint ? focusState.displayName : null
+                    }
+                    focusPageRange={showFocusHint ? focusState.pageRange : null}
                     resultCount={resultCount}
                   />
                 )}

--- a/src/sidebar/components/search/test/FilterAnnotationsStatus-test.js
+++ b/src/sidebar/components/search/test/FilterAnnotationsStatus-test.js
@@ -257,4 +257,40 @@ describe('FilterAnnotationsStatus', () => {
       });
     });
   });
+
+  it('shows focused page range', () => {
+    fakeStore.focusState.returns({
+      active: true,
+      configured: true,
+      pageRange: '5-10',
+    });
+    fakeThreadUtil.countVisible.returns(7);
+    assertFilterText(createComponent(), 'Showing 7 annotations in pages 5-10');
+  });
+
+  it('shows focused content range', () => {
+    fakeStore.focusState.returns({
+      active: true,
+      configured: true,
+      contentRange: 'Chapter 2',
+    });
+    fakeThreadUtil.countVisible.returns(3);
+    assertFilterText(createComponent(), 'Showing 3 annotations in Chapter 2');
+  });
+
+  [{ pageRange: '5-10' }, { contentRange: 'Chapter 2' }].forEach(focusState => {
+    it('shows button to reset focus mode if content focus is configured but inactive', () => {
+      fakeStore.focusState.returns({
+        active: false,
+        configured: true,
+        ...focusState,
+      });
+      fakeThreadUtil.countVisible.returns(7);
+      assertButton(createComponent(), {
+        text: 'Reset filter',
+        icon: false,
+        callback: fakeStore.toggleFocusMode,
+      });
+    });
+  });
 });

--- a/src/sidebar/store/modules/filters.ts
+++ b/src/sidebar/store/modules/filters.ts
@@ -5,23 +5,6 @@ import type { FocusConfig, SidebarSettings } from '../../../types/config';
 import type { FocusUserInfo } from '../../../types/rpc';
 import { createStoreModule, makeAction } from '../create-store';
 
-/**
- * Manage state pertaining to the filtering of annotations in the UI.
- *
- * There are a few sources of filtering that gets applied to annotations:
- *
- * - focusFilters: Filters defined by config/settings. Currently, supports a
- *   user filter. Application of these filters may be toggled on/off by user
- *   interaction (`focusActive`), but the values of these filters are set by
- *   config/settings or RPC (not by user directly). The value(s) of
- *   focusFilters are retained even when focus is inactive such that they might
- *   be re-applied later.
- * - filters: Filters set by faceting/filtering UI. Any filter here is currently
- *   active (applied).
- * - query: String query that is either typed in by the user or provided in
- *   settings. A query string may contain supported facets.
- */
-
 export type FilterOption = {
   /** The machine-readable value of the option */
   value: string;
@@ -42,6 +25,22 @@ type FocusState = {
   displayName: string;
 };
 
+/**
+ * State pertaining to the filtering of annotations in the UI.
+ *
+ * There are a few sources of filtering that gets applied to annotations:
+ *
+ * - focusFilters: Filters defined by config/settings. Currently, supports a
+ *   user filter. Application of these filters may be toggled on/off by user
+ *   interaction (`focusActive`), but the values of these filters are set by
+ *   config/settings or RPC (not by user directly). The value(s) of
+ *   focusFilters are retained even when focus is inactive such that they might
+ *   be re-applied later.
+ * - filters: Filters set by faceting/filtering UI. Any filter here is currently
+ *   active (applied).
+ * - query: String query that is either typed in by the user or provided in
+ *   settings. A query string may contain supported facets.
+ */
 export type State = {
   filters: Filters;
   focusActive: boolean;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -82,9 +82,33 @@ export type ReportAnnotationActivityConfig = {
 };
 
 /**
- * Structure of focus-mode config, provided in settings (app config)
+ * Configure the client to focus on a specific subset of annotations.
+ *
+ * This hides annotations which do not match the filter when the client starts,
+ * and shows an option to toggle the filters on or off.
+ *
+ * This is used in the LMS for example when a teacher is grading a specific
+ * student's annotations or in an assignment where students are being directed
+ * to annotate a specific chapter.
  */
 export type FocusConfig = {
+  /** Specify a range of content in an ebook as a CFI range. */
+  cfi?: {
+    /**
+     * CFI range specified as `[startCFI]-[endCFI]`. The range is exclusive of
+     * the end point.
+     */
+    range: string;
+    /** Descriptive label for this CFI range. */
+    label: string;
+  };
+
+  /**
+   * Page range in the form `[start]-[end]`. The range is inclusive of the
+   * end page.
+   */
+  pages?: string;
+
   user?: FocusUserInfo;
 };
 


### PR DESCRIPTION
Add new "focus" modes which cause the client to filter annotations based on a page range or CFI range. These will be used in the LMS app when an assignment is configured to filter by page range.

The embedder sets configuration like so:

```diff
diff --git a/dev-server/templates/client-config.js.mustache b/dev-server/templates/client-config.js.mustache
index b258f6043..7bbaa5a95 100644
--- a/dev-server/templates/client-config.js.mustache
+++ b/dev-server/templates/client-config.js.mustache
@@ -37,6 +37,14 @@
       // Open the sidebar when the page loads
       openSidebar: true,
 
+      focus: {
+        pages: '5-15',
+        //cfi: { // For an EPUB-based book
+        //  range: '/2-/6',
+        //  label: 'Chapter 2 - Chapter 3',
+        //},
+      },
+
       {{#exampleConfig}}
       // Additional configuration for the current test document
       ...{{{exampleConfig}}},
```

And the client will then filter annotations similarly to how it filters users when grading. The UI currently looks the same as for user filtering, but I expect the presentation of focus modes to be changed significantly as part of https://github.com/hypothesis/client/issues/6006.


**Page range filter active:**

(Test on http://localhost:3000/document/vitalsource-pdf)

<img width="502" alt="Page range focus" src="https://github.com/hypothesis/client/assets/2458/9f62b1ae-2df3-4f06-b0f0-9bfe23fb1a55">

**CFI filter active:**

(Test on http://localhost:3000/document/vitalsource-epub)

<img width="463" alt="cfi-filter-active" src="https://github.com/hypothesis/client/assets/2458/9658cf60-1f25-4410-abde-bcccc7414657">

**Page range or CFI filter inactive. The generic button label is intentional at present:**

<img width="469" alt="content-filter-reset" src="https://github.com/hypothesis/client/assets/2458/d73e90a8-82f4-412b-b9b0-a7d276ed3257">



