### PR TITLE
Fix trim-and-dedent for interpolated vars with text after

### DIFF
--- a/src/shared/test/trim-and-dedent-test.js
+++ b/src/shared/test/trim-and-dedent-test.js
@@ -53,6 +53,33 @@ lines
 with no indentation
         `,
     ],
+    [
+      () => {
+        const name = `Jane`;
+        const secondVar = `
+        multiple
+lines
+with no indentation
+        `;
+
+        return trimAndDedent`
+      
+            Hello, ${name}!
+              Indented line
+            Goodbye, John!
+            text${secondVar}more text
+        
+        `;
+      },
+      `Hello, Jane!
+  Indented line
+Goodbye, John!
+text
+        multiple
+lines
+with no indentation
+        more text`,
+    ],
   ].forEach(([getResult, expectedResult]) => {
     it('normalizes strings with multiple lines', () => {
       assert.equal(getResult(), expectedResult);

--- a/src/shared/trim-and-dedent.ts
+++ b/src/shared/trim-and-dedent.ts
@@ -19,16 +19,14 @@ function dedentStr(str: string, indent: number) {
  * params verbatim.
  */
 function dedent(strings: string[], ...params: any[]) {
-  // Match the smallest indentation among all strings
-  const indents = strings
-    .map(str => {
-      const match = str.match(/^[ \t]*(?=\S)/gm);
-      return match ? Math.min(...match.map(el => el.length)) : -1;
-    })
-    // Exclude lines where indentation could not be matched
-    .filter(num => num > -1);
-  const smallestIndent = indents.length > 0 ? Math.min(...indents) : 0;
+  // Match the smallest indentation among all lines of the full string before
+  // interpolating params
+  const match = strings.join('').match(/^[ \t]*(?=\S)/gm);
+  const smallestIndent = match ? Math.min(...match.map(el => el.length)) : 0;
 
+  // Dedent every individual string while interpolating params
+  // Those strings which are not the beginning of a line will have zero-indent
+  // and dedenting will have no effect
   let result = '';
   for (const [i, param] of params.entries()) {
     result += dedentStr(strings[i], smallestIndent);


### PR DESCRIPTION
Part of https://github.com/hypothesis/client/issues/5784

In https://github.com/hypothesis/client/pull/6009, we refactored `trimAndDedent` to ignore interpolated params when calculating the common indentation to strip from all lines.

However, it was done incorrectly, calculating it for every string instead of every line. That caused the common indentation to be incorrectly calculated for template strings including text after some param.

This PR fixes it by calculating the common indent over all lines of the result of joining all strings of the template without params.

I have tested these changes against https://github.com/hypothesis/client/pull/6026, and now it produces expected results.