### PR TITLE
Remove html_side_by_side feature flag

### DIFF
--- a/src/annotator/features.ts
+++ b/src/annotator/features.ts
@@ -6,7 +6,7 @@ import type { FeatureFlags as IFeatureFlags } from '../types/annotator';
 /**
  * List of feature flags that annotator code tests for.
  */
-const annotatorFlags = ['html_side_by_side', 'styled_highlight_clusters'];
+const annotatorFlags = ['styled_highlight_clusters'];
 
 /**
  * An observable container of feature flags.

--- a/src/annotator/integrations/html.ts
+++ b/src/annotator/integrations/html.ts
@@ -39,7 +39,7 @@ export class HTMLIntegration extends TinyEmitter implements Integration {
 
   /** Controls how we resize the document to fit alongside sidebar. */
   private _sideBySideOptions: SideBySideOptions;
-  private _sideBySideFlagEnabled: boolean;
+  private _sideBySideEnabled: boolean;
 
   /**
    * Whether the document is currently being resized to fit alongside an
@@ -69,8 +69,10 @@ export class HTMLIntegration extends TinyEmitter implements Integration {
     this._htmlMeta = new HTMLMetadata();
     this._prevURI = this._htmlMeta.uri();
 
-    this._sideBySideFlagEnabled =
-      this.features.flagEnabled('html_side_by_side');
+    // Side-by-side was originally behind a feature flag. This property
+    // remains in case it is useful to turn off for debugging etc.
+    this._sideBySideEnabled = true;
+
     this._sideBySideOptions = sideBySideOptions ?? { mode: 'auto' };
     this._sideBySideActive = false;
     this._lastLayout = null;
@@ -98,16 +100,7 @@ export class HTMLIntegration extends TinyEmitter implements Integration {
     });
 
     this._flagsChanged = () => {
-      const sideBySideEnabled = features.flagEnabled('html_side_by_side');
-      if (sideBySideEnabled !== this._sideBySideFlagEnabled) {
-        this._sideBySideFlagEnabled = sideBySideEnabled;
-
-        // `fitSideBySide` is normally called by Guest when the sidebar layout
-        // changes. When the feature flag changes, we need to re-run the method.
-        if (this._lastLayout) {
-          this.fitSideBySide(this._lastLayout);
-        }
-      }
+      // There are currently no feature flags that the integration responds to.
     };
     this.features.on('flagsChanged', this._flagsChanged);
   }
@@ -163,7 +156,7 @@ export class HTMLIntegration extends TinyEmitter implements Integration {
 
     const maximumWidthToFit = window.innerWidth - layout.width;
     const active =
-      this._sideBySideFlagEnabled &&
+      this._sideBySideEnabled &&
       this._sideBySideOptions.mode === 'auto' &&
       layout.expanded &&
       maximumWidthToFit >= MIN_HTML_WIDTH;

--- a/src/annotator/integrations/test/html-test.js
+++ b/src/annotator/integrations/test/html-test.js
@@ -160,7 +160,6 @@ describe('HTMLIntegration', () => {
     it('undoes side-by-side mode changes', () => {
       const padding = sideBySidePadding;
 
-      features.update({ html_side_by_side: true });
       fakeGuessMainContentArea.returns(fullWidthContentRect());
 
       const integration = createIntegration();
@@ -201,194 +200,179 @@ describe('HTMLIntegration', () => {
       document.body.style.marginRight = '';
     });
 
-    it('does nothing when disabled', () => {
+    it('sets left and right margins on body element when activated', () => {
       const integration = createIntegration();
-      integration.fitSideBySide({});
-      assert.isFalse(integration.sideBySideActive());
+
+      integration.fitSideBySide({ expanded: true, width: sidebarWidth });
+
+      assert.isTrue(integration.sideBySideActive());
+      assert.deepEqual(getMargins(), [
+        sideBySidePadding,
+        sidebarWidth + sideBySidePadding,
+      ]);
     });
 
-    context('when enabled', () => {
+    it('does not set left and right margins if there is not enough room to enable', () => {
+      const integration = createIntegration();
+
+      // Minimum available content width for side-by-side is 480
+      // window.innerWidth (800) - 321 = 479 --> too small
+      integration.fitSideBySide({ expanded: true, width: 321 });
+
+      assert.isFalse(integration.sideBySideActive());
+      assert.deepEqual(getMargins(), [null, null]);
+    });
+
+    it('allows sidebar to overlap non-main content on the side of the page', () => {
+      const integration = createIntegration();
+
+      const contentRect = fullWidthContentRect();
+
+      // Pretend there is some content to the right of the main content
+      // in the document (eg. related stories, ads).
+      contentRect.width -= 100;
+      fakeGuessMainContentArea.returns(contentRect);
+
+      integration.fitSideBySide({ expanded: true, width: sidebarWidth });
+
+      assert.deepEqual(getMargins(), [
+        sideBySidePadding,
+        sidebarWidth + sideBySidePadding - 100,
+      ]);
+    });
+
+    it('does nothing if the content area cannot be determined', () => {
+      const integration = createIntegration();
+      fakeGuessMainContentArea.returns(null);
+
+      integration.fitSideBySide({ expanded: true, width: sidebarWidth });
+
+      assert.deepEqual(getMargins(), [null, null]);
+    });
+
+    it('saves and restores the scroll position after adjusting margins', () => {
+      const integration = createIntegration();
+
+      integration.fitSideBySide({ expanded: true, width: sidebarWidth });
+
+      assert.calledOnce(fakePreserveScrollPosition);
+    });
+
+    it('removes margins on body element when side-by-side mode is deactivated', () => {
+      const integration = createIntegration();
+
+      integration.fitSideBySide({ expanded: true, width: sidebarWidth });
+      assert.notDeepEqual(getMargins(), [null, null]);
+
+      integration.fitSideBySide({ expanded: false });
+      assert.deepEqual(getMargins(), [null, null]);
+    });
+
+    context('main content area has margin:auto', () => {
+      const bodyWidth = 400;
+      const autoMargin = Math.floor((window.innerWidth - bodyWidth) / 2);
+
+      function getComputedMargins(element) {
+        const leftMargin = Math.floor(
+          parseInt(window.getComputedStyle(element).marginLeft, 10),
+        );
+        const rightMargin = Math.floor(
+          parseInt(window.getComputedStyle(element).marginRight, 10),
+        );
+        return [leftMargin, rightMargin];
+      }
+
+      // Add a style node to set a max-width and auto margins on the body
+      function appendBodyStyles(document_) {
+        const el = document_.createElement('style');
+        el.type = 'text/css';
+        el.textContent = `body { margin: 0 auto; max-width: ${bodyWidth}px }`;
+        el.classList.add('js-style-test');
+        document_.body.appendChild(el);
+      }
+
+      before(() => {
+        appendBodyStyles(document);
+      });
+
+      after(() => {
+        // Remove test styles
+        const elements = document.querySelectorAll('.js-style-test');
+        for (let i = 0; i < elements.length; i++) {
+          elements[i].remove();
+        }
+      });
+
       beforeEach(() => {
-        features.update({ html_side_by_side: true });
+        // In these tests, we're treating the body element as the
+        // main content area.
+        //
+        // `guessMainContent` area is called _after_ a right margin is set
+        // on the body, so we'll return here the updated computed left and
+        // right position of the body to emulate a real-life result
+        fakeGuessMainContentArea.callsFake(bodyEl => {
+          const margins = getComputedMargins(bodyEl);
+          return { left: margins[0], right: window.innerWidth - margins[1] };
+        });
       });
 
-      it('sets left and right margins on body element when activated', () => {
+      it('should not move the main content to the right', () => {
         const integration = createIntegration();
-
-        integration.fitSideBySide({ expanded: true, width: sidebarWidth });
-
-        assert.isTrue(integration.sideBySideActive());
-        assert.deepEqual(getMargins(), [
-          sideBySidePadding,
-          sidebarWidth + sideBySidePadding,
+        // Before enabling side-by-side, the horizontal margins on the body
+        // are derived based on `margin: auto` in the stylesheet
+        assert.deepEqual(getComputedMargins(document.body), [
+          autoMargin,
+          autoMargin,
         ]);
-      });
 
-      it('does not set left and right margins if there is not enough room to enable', () => {
-        const integration = createIntegration();
-
-        // Minimum available content width for side-by-side is 480
-        // window.innerWidth (800) - 321 = 479 --> too small
-        integration.fitSideBySide({ expanded: true, width: 321 });
-
-        assert.isFalse(integration.sideBySideActive());
-        assert.deepEqual(getMargins(), [null, null]);
-      });
-
-      it('allows sidebar to overlap non-main content on the side of the page', () => {
-        const integration = createIntegration();
-
-        const contentRect = fullWidthContentRect();
-
-        // Pretend there is some content to the right of the main content
-        // in the document (eg. related stories, ads).
-        contentRect.width -= 100;
-        fakeGuessMainContentArea.returns(contentRect);
-
-        integration.fitSideBySide({ expanded: true, width: sidebarWidth });
-
-        assert.deepEqual(getMargins(), [
-          sideBySidePadding,
-          sidebarWidth + sideBySidePadding - 100,
-        ]);
-      });
-
-      it('does nothing if the content area cannot be determined', () => {
-        const integration = createIntegration();
-        fakeGuessMainContentArea.returns(null);
-
-        integration.fitSideBySide({ expanded: true, width: sidebarWidth });
-
-        assert.deepEqual(getMargins(), [null, null]);
-      });
-
-      it('saves and restores the scroll position after adjusting margins', () => {
-        const integration = createIntegration();
-
-        integration.fitSideBySide({ expanded: true, width: sidebarWidth });
-
-        assert.calledOnce(fakePreserveScrollPosition);
-      });
-
-      it('removes margins on body element when side-by-side mode is deactivated', () => {
-        const integration = createIntegration();
-
-        integration.fitSideBySide({ expanded: true, width: sidebarWidth });
-        assert.notDeepEqual(getMargins(), [null, null]);
-
-        integration.fitSideBySide({ expanded: false });
-        assert.deepEqual(getMargins(), [null, null]);
-      });
-
-      context('main content area has margin:auto', () => {
-        const bodyWidth = 400;
-        const autoMargin = Math.floor((window.innerWidth - bodyWidth) / 2);
-
-        function getComputedMargins(element) {
-          const leftMargin = Math.floor(
-            parseInt(window.getComputedStyle(element).marginLeft, 10),
-          );
-          const rightMargin = Math.floor(
-            parseInt(window.getComputedStyle(element).marginRight, 10),
-          );
-          return [leftMargin, rightMargin];
-        }
-
-        // Add a style node to set a max-width and auto margins on the body
-        function appendBodyStyles(document_) {
-          const el = document_.createElement('style');
-          el.type = 'text/css';
-          el.textContent = `body { margin: 0 auto; max-width: ${bodyWidth}px }`;
-          el.classList.add('js-style-test');
-          document_.body.appendChild(el);
-        }
-
-        before(() => {
-          appendBodyStyles(document);
-        });
-
-        after(() => {
-          // Remove test styles
-          const elements = document.querySelectorAll('.js-style-test');
-          for (let i = 0; i < elements.length; i++) {
-            elements[i].remove();
-          }
-        });
-
-        beforeEach(() => {
-          // In these tests, we're treating the body element as the
-          // main content area.
-          //
-          // `guessMainContent` area is called _after_ a right margin is set
-          // on the body, so we'll return here the updated computed left and
-          // right position of the body to emulate a real-life result
-          fakeGuessMainContentArea.callsFake(bodyEl => {
-            const margins = getComputedMargins(bodyEl);
-            return { left: margins[0], right: window.innerWidth - margins[1] };
-          });
-        });
-
-        it('should not move the main content to the right', () => {
-          const integration = createIntegration();
-          // Before enabling side-by-side, the horizontal margins on the body
-          // are derived based on `margin: auto` in the stylesheet
-          assert.deepEqual(getComputedMargins(document.body), [
-            autoMargin,
-            autoMargin,
-          ]);
-
-          // Will result in a right margin of 112px (100 + 12 padding)
-          integration.fitSideBySide({ expanded: true, width: 100 });
-
-          // Without intervention, the left margin would have _increased_ to
-          // balance out the remaining space, that is:
-          // innerWidth - bodyWidth - 112 > 200
-          //
-          // To prevent content jumping to the right, implementation sets left
-          // margin to original auto margin
-          assert.deepEqual(getComputedMargins(document.body), [
-            autoMargin,
-            112,
-          ]);
-        });
-
-        it('may move the main content to the left to make room for sidebar', () => {
-          const integration = createIntegration();
-
-          // Will result in right margin of 262 (250 + 12 padding)
-          integration.fitSideBySide({ expanded: true, width: 250 });
-
-          // The amount of space available to the left of the body is now _less_
-          // than the original auto-left-margin. This is fine: let the auto
-          // margin re-adjust to the available amount of space (move to the left):
-          const updatedMargins = getComputedMargins(document.body);
-          const expectedLeftMargin = Math.floor(
-            window.innerWidth - bodyWidth - 262,
-          );
-          assert.equal(updatedMargins[0], expectedLeftMargin);
-          assert.isBelow(updatedMargins[0], autoMargin);
-        });
-      });
-
-      it('sets an html class on the element if side by side is activated', () => {
-        const integration = createIntegration();
-
+        // Will result in a right margin of 112px (100 + 12 padding)
         integration.fitSideBySide({ expanded: true, width: 100 });
 
-        assert.isTrue(
-          integration.container.classList.contains(
-            'hypothesis-sidebyside-active',
-          ),
-        );
-
-        integration.fitSideBySide({ expanded: false, width: 100 });
-
-        assert.isFalse(
-          integration.container.classList.contains(
-            'hypothesis-sidebyside-active',
-          ),
-        );
+        // Without intervention, the left margin would have _increased_ to
+        // balance out the remaining space, that is:
+        // innerWidth - bodyWidth - 112 > 200
+        //
+        // To prevent content jumping to the right, implementation sets left
+        // margin to original auto margin
+        assert.deepEqual(getComputedMargins(document.body), [autoMargin, 112]);
       });
+
+      it('may move the main content to the left to make room for sidebar', () => {
+        const integration = createIntegration();
+
+        // Will result in right margin of 262 (250 + 12 padding)
+        integration.fitSideBySide({ expanded: true, width: 250 });
+
+        // The amount of space available to the left of the body is now _less_
+        // than the original auto-left-margin. This is fine: let the auto
+        // margin re-adjust to the available amount of space (move to the left):
+        const updatedMargins = getComputedMargins(document.body);
+        const expectedLeftMargin = Math.floor(
+          window.innerWidth - bodyWidth - 262,
+        );
+        assert.equal(updatedMargins[0], expectedLeftMargin);
+        assert.isBelow(updatedMargins[0], autoMargin);
+      });
+    });
+
+    it('sets an html class on the element if side by side is activated', () => {
+      const integration = createIntegration();
+
+      integration.fitSideBySide({ expanded: true, width: 100 });
+
+      assert.isTrue(
+        integration.container.classList.contains(
+          'hypothesis-sidebyside-active',
+        ),
+      );
+
+      integration.fitSideBySide({ expanded: false, width: 100 });
+
+      assert.isFalse(
+        integration.container.classList.contains(
+          'hypothesis-sidebyside-active',
+        ),
+      );
     });
 
     const isSideBySideActive = () => {
@@ -396,28 +380,9 @@ describe('HTMLIntegration', () => {
       return left !== null || right !== null;
     };
 
-    it('side-by-side is enabled/disabled when feature flag changes', () => {
-      const integration = createIntegration();
-
-      integration.fitSideBySide({ expanded: true, width: sidebarWidth });
-      assert.isFalse(isSideBySideActive());
-
-      features.update({ html_side_by_side: true });
-      assert.isTrue(isSideBySideActive());
-
-      features.update({ html_side_by_side: false });
-      assert.isFalse(isSideBySideActive());
-    });
-
-    it('manual side-by-side is not changed by enabled feature flag', () => {
-      features.update({ html_side_by_side: true });
+    it('side-by-side does not activate in "manual" mode', () => {
       const integration = createIntegration({ mode: 'manual' });
-
       integration.fitSideBySide({ expanded: true, width: sidebarWidth });
-      assert.isFalse(isSideBySideActive());
-
-      // Even if the feature flag is enabled, side-by-side stays disabled/manual
-      features.update({ html_side_by_side: true });
       assert.isFalse(isSideBySideActive());
     });
   });

--- a/src/annotator/integrations/test/vitalsource-test.js
+++ b/src/annotator/integrations/test/vitalsource-test.js
@@ -331,8 +331,6 @@ describe('annotator/integrations/vitalsource', () => {
     it('delegates to HTMLIntegration for side-by-side mode', () => {
       const integration = createIntegration();
       assert.calledOnce(FakeHTMLIntegration);
-      const htmlOptions = FakeHTMLIntegration.args[0][0];
-      assert.isTrue(htmlOptions.features.flagEnabled('html_side_by_side'));
 
       fakeHTMLIntegration.fitSideBySide.returns(true);
       fakeHTMLIntegration.sideBySideActive.returns(true);

--- a/src/annotator/integrations/vitalsource.ts
+++ b/src/annotator/integrations/vitalsource.ts
@@ -258,11 +258,6 @@ export class VitalSourceContentIntegration
 
     const htmlFeatures = new FeatureFlags();
 
-    // Forcibly enable the side-by-side feature for VS books. This feature is
-    // only behind a flag for regular web pages, which are typically more
-    // complex and varied than EPUB books.
-    htmlFeatures.update({ html_side_by_side: true });
-
     this._htmlIntegration = new HTMLIntegration({
       container,
       features: htmlFeatures,


### PR DESCRIPTION
A boolean `HTMLIntegration._sideBySideEnabled` flag has been retained in case a developer wants an easy way to turn this off for debugging.

Fixes https://github.com/hypothesis/client/issues/5664