### PR TITLE
Use display name if possible, when exporting annotations to text

### DIFF
--- a/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
+++ b/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
@@ -139,7 +139,11 @@ function ExportAnnotations({
         case 'txt': {
           const exportData = annotationsExporter.buildTextExportContent(
             annotationsToExport,
-            group?.name,
+            {
+              groupName: group?.name,
+              defaultAuthority,
+              displayNamesEnabled,
+            },
           );
           downloadTextFile(exportData, filename);
           break;

--- a/src/sidebar/helpers/test/annotation-user-test.js
+++ b/src/sidebar/helpers/test/annotation-user-test.js
@@ -21,6 +21,10 @@ describe('sidebar/helpers/annotation-user', () => {
     });
   });
 
+  afterEach(() => {
+    $imports.$restore();
+  });
+
   const fakeAnnotations = {
     withDisplayName: {
       user: 'acct:albert@victoriana.com',


### PR DESCRIPTION
Part of https://github.com/hypothesis/client/issues/5784

This PR improves the annotations export in text format, using the display name for third party users or if the feature flag has been enabled.

The logic is the same used to decide the value to display in annotation cards.

### Testing steps

1. Check out this branch.
2. Go to http://localhost:5000/admin/features and enable `client_display_names` for everyone.
3. Export annotations in text format. Check that display names are used.
4. Disable  `client_display_names` for everyone.
5. Repeat step 3, and check that usernames are used this time.