### PR TITLE
Add page number to every annotation when exported as text

### DIFF
--- a/src/shared/test/trim-and-dedent-test.js
+++ b/src/shared/test/trim-and-dedent-test.js
@@ -17,11 +17,13 @@ describe('trimAndDedent', () => {
       
         Hello, Jane!
           Indented line
+
         Goodbye, John!
       
       `,
       `Hello, Jane!
   Indented line
+
 Goodbye, John!`,
     ],
     [
@@ -50,8 +52,7 @@ Goodbye, John!
 
         multiple
 lines
-with no indentation
-        `,
+with no indentation`,
     ],
     [
       () => {

--- a/src/shared/trim-and-dedent.ts
+++ b/src/shared/trim-and-dedent.ts
@@ -1,9 +1,5 @@
-function trimLeadingEmptyLines(str: string): string {
-  return str.replace(/^\s*\n/g, '');
-}
-
-function trimTrailingEmptyLines(str: string): string {
-  return str.replace(/\n\s*$/g, '');
+function trimLeadingAndTrailingEmptyLines(str: string): string {
+  return str.replace(/^\s*\n|\n\s*$/g, '');
 }
 
 /**
@@ -71,24 +67,5 @@ export function trimAndDedent(
   strings: TemplateStringsArray,
   ...params: any[]
 ): string {
-  if (strings.length < 2) {
-    // Trim leading and trailing empty lines from first (and only) string
-    const trimmedLines = [
-      trimLeadingEmptyLines(trimTrailingEmptyLines(strings[0])),
-    ];
-    return dedent(trimmedLines, ...params);
-  }
-
-  const firstString = strings[0];
-  const lastString = strings[strings.length - 1];
-  const middle = strings.slice(1, strings.length - 1);
-
-  // Trim empty leading lines from first string, and empty trailing lines from last one
-  const trimmedLines = [
-    trimLeadingEmptyLines(firstString),
-    ...middle,
-    trimTrailingEmptyLines(lastString),
-  ];
-
-  return dedent(trimmedLines, ...params);
+  return trimLeadingAndTrailingEmptyLines(dedent([...strings], ...params));
 }

--- a/src/sidebar/services/annotations-exporter.ts
+++ b/src/sidebar/services/annotations-exporter.ts
@@ -3,6 +3,7 @@ import type { APIAnnotationData } from '../../types/api';
 import {
   documentMetadata,
   isReply,
+  pageLabel,
   quote,
 } from '../helpers/annotation-metadata';
 import { annotationDisplayName } from '../helpers/annotation-user';
@@ -80,16 +81,17 @@ export class AnnotationsExporter {
     ];
 
     const annotationsText = annotations
-      .map(
-        (annotation, index) =>
-          trimAndDedent`
+      .map((annotation, index) => {
+        const page = pageLabel(annotation);
+        return trimAndDedent`
           Annotation ${index + 1}:
           ${annotation.created}
           ${annotation.text}
           ${extractUsername(annotation)}
           "${quote(annotation)}"
-          Tags: ${annotation.tags.join(', ')}`,
-      )
+          Tags: ${annotation.tags.join(', ')}
+          ${page ? `Page: ${page}` : ''}`;
+      })
       .join('\n\n');
 
     return trimAndDedent`

--- a/src/sidebar/services/test/annotations-exporter-test.js
+++ b/src/sidebar/services/test/annotations-exporter-test.js
@@ -58,7 +58,7 @@ describe('AnnotationsExporter', () => {
 
     it('throws error when empty list of annotations is provided', () => {
       assert.throws(
-        () => exporter.buildTextExportContent([]),
+        () => exporter.buildTextExportContent([], {}),
         'No annotations to export',
       );
     });

--- a/src/sidebar/services/test/annotations-exporter-test.js
+++ b/src/sidebar/services/test/annotations-exporter-test.js
@@ -58,7 +58,7 @@ describe('AnnotationsExporter', () => {
 
     it('throws error when empty list of annotations is provided', () => {
       assert.throws(
-        () => exporter.buildTextExportContent([], {}),
+        () => exporter.buildTextExportContent([]),
         'No annotations to export',
       );
     });
@@ -76,6 +76,16 @@ describe('AnnotationsExporter', () => {
         {
           ...baseAnnotation,
           ...newReply(),
+          target: [
+            {
+              selector: [
+                {
+                  type: 'PageSelector',
+                  label: '23',
+                },
+              ],
+            },
+          ],
         },
       ];
       const groupName = 'My group';
@@ -122,7 +132,8 @@ ${isoDate}
 Annotation text
 bill
 "null"
-Tags: tag_1, tag_2`,
+Tags: tag_1, tag_2
+Page: 23`,
       );
     });
 


### PR DESCRIPTION
Part of https://github.com/hypothesis/client/issues/5784

Depends on https://github.com/hypothesis/client/pull/6049

Add a `Page` line to every annotation when exporting annotations as plain text.

If a page value cannot be resolved, we skip that line.