### PR TITLE
Conditionally render tags in text exported annotations

### DIFF
--- a/src/sidebar/services/annotations-exporter.ts
+++ b/src/sidebar/services/annotations-exporter.ts
@@ -83,14 +83,20 @@ export class AnnotationsExporter {
     const annotationsText = annotations
       .map((annotation, index) => {
         const page = pageLabel(annotation);
+        const lines = [
+          annotation.created,
+          annotation.text,
+          extractUsername(annotation),
+          `"${quote(annotation)}"`,
+          annotation.tags.length > 0
+            ? `Tags: ${annotation.tags.join(', ')}`
+            : undefined,
+          page ? `Page: ${page}` : undefined,
+        ].filter(Boolean);
+
         return trimAndDedent`
           Annotation ${index + 1}:
-          ${annotation.created}
-          ${annotation.text}
-          ${extractUsername(annotation)}
-          "${quote(annotation)}"
-          Tags: ${annotation.tags.join(', ')}
-          ${page ? `Page: ${page}` : ''}`;
+          ${lines.join('\n')}`;
       })
       .join('\n\n');
 

--- a/src/sidebar/services/test/annotations-exporter-test.js
+++ b/src/sidebar/services/test/annotations-exporter-test.js
@@ -65,6 +65,16 @@ describe('AnnotationsExporter', () => {
 
     it('generates text content with provided annotations', () => {
       const isoDate = baseAnnotation.created;
+      const targetWithPageSelector = page => [
+        {
+          selector: [
+            {
+              type: 'PageSelector',
+              label: `${page}`,
+            },
+          ],
+        },
+      ];
       const annotations = [
         baseAnnotation,
         baseAnnotation,
@@ -76,16 +86,12 @@ describe('AnnotationsExporter', () => {
         {
           ...baseAnnotation,
           ...newReply(),
-          target: [
-            {
-              selector: [
-                {
-                  type: 'PageSelector',
-                  label: '23',
-                },
-              ],
-            },
-          ],
+          target: targetWithPageSelector(23),
+        },
+        {
+          ...baseAnnotation,
+          tags: [],
+          target: targetWithPageSelector('iii'),
         },
       ];
       const groupName = 'My group';
@@ -103,7 +109,7 @@ http://example.com
 Group: ${groupName}
 Total users: 2
 Users: bill, jane
-Total annotations: 4
+Total annotations: 5
 Total replies: 1
 
 Annotation 1:
@@ -133,7 +139,14 @@ Annotation text
 bill
 "null"
 Tags: tag_1, tag_2
-Page: 23`,
+Page: 23
+
+Annotation 5:
+${isoDate}
+Annotation text
+bill
+"null"
+Page: iii`,
       );
     });
 


### PR DESCRIPTION
Part of https://github.com/hypothesis/client/issues/5784

Make sure `Tags` line is not rendered for exported annotations when using text format, for annotations that don't have any tag 