### PR TITLE
Prevent confusing error if action payload has a field called `type`

### DIFF
--- a/src/sidebar/store/create-store.ts
+++ b/src/sidebar/store/create-store.ts
@@ -216,6 +216,9 @@ export function makeAction<
   Reducers extends ReducerMap<any>,
   Type extends keyof Reducers,
 >(reducers: Reducers, type: Type, payload: Parameters<Reducers[Type]>[1]) {
+  if (payload && 'type' in payload) {
+    throw new Error('Payload cannot contain a `type` field');
+  }
   // nb. `reducers` is not used here. It exists purely for type inference.
   return { type, ...payload };
 }

--- a/src/sidebar/store/test/create-store-test.js
+++ b/src/sidebar/store/test/create-store-test.js
@@ -1,5 +1,5 @@
 /* global process */
-import { createStore, createStoreModule } from '../create-store';
+import { createStore, createStoreModule, makeAction } from '../create-store';
 
 function initialState(value = 0) {
   return { count: value };
@@ -297,4 +297,20 @@ describe('createStore', () => {
       }, /Cannot assign to read only property/);
     });
   }
+});
+
+describe('makeAction', () => {
+  // Dummy reducers map.
+  const reducers = {};
+
+  it('merges type and payload', () => {
+    const action = makeAction(reducers, 'SET_SEARCH', { query: 'foo' });
+    assert.deepEqual(action, { type: 'SET_SEARCH', query: 'foo' });
+  });
+
+  it('does not allow payload to contain a `type` field', () => {
+    assert.throws(() => {
+      makeAction(reducers, 'SET_SEARCH', { query: 'foo', type: 'bar' });
+    }, 'Payload cannot contain a `type` field');
+  });
 });


### PR DESCRIPTION
Previously if a payload had a field called `type`, it would override the value passed in the `type` argument to `makeAction`, causing confusing errors.