### PR TITLE
Remove "Clear search" button from SearchStatus

### DIFF
--- a/src/sidebar/components/search/SearchStatus.tsx
+++ b/src/sidebar/components/search/SearchStatus.tsx
@@ -1,4 +1,3 @@
-import { Button, CancelIcon } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useMemo } from 'preact/hooks';
 
@@ -19,13 +18,11 @@ export default function SearchStatus() {
     [rootThread, forcedVisibleCount],
   );
 
-  const buttonText = 'Clear search';
-
   return (
     <div
       // This container element needs to be present at all times but
       // should only be visible when there are applied filters
-      className={classnames('mb-3 flex items-center justify-center space-x-1', {
+      className={classnames('mb-1 flex items-center justify-center space-x-1', {
         'sr-only': !filterQuery,
       })}
       data-testid="search-status-container"
@@ -53,19 +50,6 @@ export default function SearchStatus() {
           </>
         )}
       </div>
-      {filterQuery && (
-        <Button
-          onClick={() => store.clearSelection()}
-          size="sm"
-          title={buttonText}
-          variant="primary"
-          data-testid="clear-button"
-        >
-          {/** @TODO: Set `icon` prop in `Button` instead when https://github.com/hypothesis/frontend-shared/issues/675 is fixed */}
-          {filterQuery && <CancelIcon />}
-          {buttonText}
-        </Button>
-      )}
     </div>
   );
 }

--- a/src/sidebar/components/search/test/SearchStatus-test.js
+++ b/src/sidebar/components/search/test/SearchStatus-test.js
@@ -37,14 +37,6 @@ describe('SearchStatus', () => {
     assert.equal(filterText, text);
   }
 
-  function clickClearButton(wrapper) {
-    const button = wrapper.find('Button[data-testid="clear-button"]');
-    assert.equal(button.text(), 'Clear search');
-    assert.isTrue(button.find('CancelIcon').exists());
-    button.props().onClick();
-    assert.calledOnce(fakeStore.clearSelection);
-  }
-
   context('when no search filters are active', () => {
     it('should render hidden but available to screen readers', () => {
       const wrapper = createComponent();
@@ -61,10 +53,6 @@ describe('SearchStatus', () => {
     beforeEach(() => {
       fakeStore.filterQuery.returns('foobar');
       fakeThreadUtil.countVisible.returns(1);
-    });
-
-    it('should provide a "Clear search" button that clears the selection', () => {
-      clickClearButton(createComponent());
     });
 
     it('should show the count of matching results', () => {
@@ -91,10 +79,6 @@ describe('SearchStatus', () => {
 
     it('should show a separate count for results versus forced visible', () => {
       assertFilterText(createComponent(), "Showing 2 results for 'foobar'");
-    });
-
-    it('should provide a "Clear search" button that clears the selection', () => {
-      clickClearButton(createComponent());
     });
   });
 });


### PR DESCRIPTION
The `SearchPanel` component had two buttons that both had the effect of clearing the search when clicked. We decided that just the panel's "X" button was sufficient.

**Preview:**

<img width="480" alt="Search panel with one cancel button" src="https://github.com/hypothesis/client/assets/2458/938ea010-447d-41df-8e52-866e8ec0d9c5">
