### PR TITLE
Support toggling different filter states independently

### DIFF
--- a/src/sidebar/components/SidebarView.tsx
+++ b/src/sidebar/components/SidebarView.tsx
@@ -96,7 +96,7 @@ function SidebarView({
 
         store.clearSelection();
         if (restoreFocus) {
-          store.toggleFocusMode(true);
+          store.toggleFocusMode({ active: true });
         }
       }
       prevGroupId.current = focusedGroupId;

--- a/src/sidebar/components/test/SidebarView-test.js
+++ b/src/sidebar/components/test/SidebarView-test.js
@@ -114,7 +114,7 @@ describe('SidebarView', () => {
       wrapper.setProps({});
 
       assert.calledOnce(fakeStore.clearSelection);
-      assert.calledWith(fakeStore.toggleFocusMode, true);
+      assert.calledWith(fakeStore.toggleFocusMode, { active: true });
     });
 
     it('does not clear selected annotations when group ID is first set on startup', () => {

--- a/src/sidebar/helpers/thread-annotations.ts
+++ b/src/sidebar/helpers/thread-annotations.ts
@@ -4,6 +4,7 @@ import { buildThread } from './build-thread';
 import type { Thread, BuildThreadOptions } from './build-thread';
 import { filterAnnotations } from './filter-annotations';
 import { parseFilterQuery } from './query-parser';
+import type { FilterField } from './query-parser';
 import { shouldShowInTab } from './tabs';
 import { sorters } from './thread-sorters';
 
@@ -13,7 +14,7 @@ export type ThreadState = {
   selection: {
     expanded: Record<string, boolean>;
     filterQuery: string | null;
-    filters: Record<string, string>;
+    filters: Partial<Record<FilterField, string>>;
     forcedVisible: string[];
     selected: string[];
     sortKey: keyof typeof sorters;

--- a/src/sidebar/store/modules/filters.ts
+++ b/src/sidebar/store/modules/filters.ts
@@ -43,26 +43,32 @@ export type FocusState = {
 };
 
 /**
- * State pertaining to the filtering of annotations in the UI.
+ * State related to filtering of annotations in the UI.
  *
- * There are a few sources of filtering that gets applied to annotations:
+ * There are several layers of filters:
  *
- * - focusFilters: Filters defined by config/settings. Currently, supports a
- *   user filter. Application of these filters may be toggled on/off by user
- *   interaction (`focusActive`), but the values of these filters are set by
- *   config/settings or RPC (not by user directly). The value(s) of
- *   focusFilters are retained even when focus is inactive such that they might
- *   be re-applied later.
- * - filters: Filters set by faceting/filtering UI. Any filter here is currently
- *   active (applied).
- * - query: String query that is either typed in by the user or provided in
- *   settings. A query string may contain supported facets.
+ * - Filter/search queries entered by the user via the search UI
+ *
+ * - Focus filters which are filters supplied in the Hypothesis configuration.
+ *   This is for contexts where there is some default filter that should be
+ *   applied when the client loads. For example when grading a student's work,
+ *   the client can be configured to start up showing only that user's annotations.
+ *
+ * - Filters/facets set via UI controls other than the search box.
+ *   For example the Notebook has a user selection dropdown.
  */
 export type State = {
+  /** Facet filters (eg. selected user) */
   filters: Filters;
-  focusActive: Set<FilterKey>;
-  focusFilters: Filters;
+
+  /** Active filter/search query. */
   query: string | null;
+
+  /** Configuration for focus filters imported from client configuration. */
+  focusFilters: Filters;
+
+  /** Which filters from `focusFilters` are currently active. */
+  focusActive: Set<FilterKey>;
 };
 
 function initialState(settings: SidebarSettings): State {


### PR DESCRIPTION
In order to support a UI like the one shown in https://github.com/hypothesis/client/issues/6006#issuecomment-1878461964 it needs to be possible to toggle different filter modes independently. For example, if a teacher is grading an assignment with a page range specified, there will be filters for both the student being graded and the page range, and it should be possible to toggle them independently. This PR refactors the `focusActive` state in the `filters` store module to support this.

- The first commit changes the `focusActive` state from a boolean to a set of enabled states and extends the `toggleFocusMode` store action API
- The second commit revises the documentation for the filter states

There should be no functional changes , as the new capabilities are not used by the UI yet.