### PR TITLE
Add logic to export annotations in CSV format

### DIFF
--- a/src/shared/download-file.ts
+++ b/src/shared/download-file.ts
@@ -39,7 +39,7 @@ export function downloadJSONFile(
 }
 
 /**
- * Download a text file containing data
+ * Download a text file containing text
  */
 export function downloadTextFile(
   text: string,
@@ -48,4 +48,13 @@ export function downloadTextFile(
   _document = document,
 ) {
   downloadFile(text, 'text/plain', filename, _document);
+}
+
+export function downloadCSVFile(
+  text: string,
+  filename: string,
+  /* istanbul ignore next - test seam */
+  _document = document,
+) {
+  downloadFile(text, 'text/csv', filename, _document);
 }

--- a/src/shared/test/download-file-test.js
+++ b/src/shared/test/download-file-test.js
@@ -1,4 +1,8 @@
-import { downloadJSONFile, downloadTextFile } from '../download-file';
+import {
+  downloadCSVFile,
+  downloadJSONFile,
+  downloadTextFile,
+} from '../download-file';
 
 describe('download-file', () => {
   let fakeLink;
@@ -59,5 +63,14 @@ describe('download-file', () => {
     downloadTextFile(data, filename, fakeDocument);
 
     assertDownloadHappened(filename, data, 'text/plain');
+  });
+
+  it('downloadCSVFile generates csv file with provided data', () => {
+    const data = 'foo,bar,baz';
+    const filename = 'my-file.csv';
+
+    downloadCSVFile(data, filename, fakeDocument);
+
+    assertDownloadHappened(filename, data, 'text/csv');
   });
 });

--- a/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
+++ b/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
@@ -8,6 +8,7 @@ import {
 import { useCallback, useId, useMemo, useState } from 'preact/hooks';
 
 import {
+  downloadCSVFile,
   downloadJSONFile,
   downloadTextFile,
 } from '../../../shared/download-file';
@@ -44,12 +45,12 @@ const exportFormats: ExportFormat[] = [
     value: 'txt',
     name: 'Text',
   },
+  {
+    value: 'csv',
+    name: 'CSV',
+  },
 
   // TODO Enable these formats when implemented
-  // {
-  //   value: 'csv',
-  //   name: 'CSV',
-  // },
   // {
   //   value: 'html',
   //   name: 'HTML',
@@ -149,6 +150,18 @@ function ExportAnnotations({
             },
           );
           downloadTextFile(exportData, filename);
+          break;
+        }
+        case 'csv': {
+          const exportData = annotationsExporter.buildCSVExportContent(
+            annotationsToExport,
+            {
+              groupName: group?.name,
+              defaultAuthority,
+              displayNamesEnabled,
+            },
+          );
+          downloadCSVFile(exportData, filename);
           break;
         }
       }

--- a/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
+++ b/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
@@ -16,6 +16,7 @@ describe('ExportAnnotations', () => {
   let fakeToastMessenger;
   let fakeDownloadJSONFile;
   let fakeDownloadTextFile;
+  let fakeDownloadCSVFile;
   let fakeSuggestedFilename;
 
   const fakePrivateGroup = {
@@ -37,12 +38,14 @@ describe('ExportAnnotations', () => {
     fakeAnnotationsExporter = {
       buildJSONExportContent: sinon.stub().returns({}),
       buildTextExportContent: sinon.stub().returns(''),
+      buildCSVExportContent: sinon.stub().returns(''),
     };
     fakeToastMessenger = {
       error: sinon.stub(),
     };
     fakeDownloadJSONFile = sinon.stub();
     fakeDownloadTextFile = sinon.stub();
+    fakeDownloadCSVFile = sinon.stub();
     fakeStore = {
       defaultAuthority: sinon.stub().returns('example.com'),
       isFeatureEnabled: sinon.stub().returns(true),
@@ -65,6 +68,7 @@ describe('ExportAnnotations', () => {
       '../../../shared/download-file': {
         downloadJSONFile: fakeDownloadJSONFile,
         downloadTextFile: fakeDownloadTextFile,
+        downloadCSVFile: fakeDownloadCSVFile,
       },
       '../../helpers/export-annotations': {
         suggestedFilename: fakeSuggestedFilename,
@@ -238,9 +242,10 @@ describe('ExportAnnotations', () => {
     );
     const options = select.find(SelectNext.Option);
 
-    assert.equal(options.length, 2);
+    assert.equal(options.length, 3);
     assert.equal(options.at(0).text(), 'JSON');
     assert.equal(options.at(1).text(), 'Text');
+    assert.equal(options.at(2).text(), 'CSV');
   });
 
   describe('export form submitted', () => {
@@ -265,6 +270,11 @@ describe('ExportAnnotations', () => {
         format: 'txt',
         getExpectedInvokedContentBuilder: () =>
           fakeAnnotationsExporter.buildTextExportContent,
+      },
+      {
+        format: 'csv',
+        getExpectedInvokedContentBuilder: () =>
+          fakeAnnotationsExporter.buildCSVExportContent,
       },
     ].forEach(({ format, getExpectedInvokedContentBuilder }) => {
       it('builds an export file from all non-draft annotations', async () => {
@@ -351,6 +361,10 @@ describe('ExportAnnotations', () => {
       {
         format: 'txt',
         getExpectedInvokedDownloader: () => fakeDownloadTextFile,
+      },
+      {
+        format: 'csv',
+        getExpectedInvokedDownloader: () => fakeDownloadCSVFile,
       },
     ].forEach(({ format, getExpectedInvokedDownloader }) => {
       it('downloads a file using user-entered filename appended with proper extension', async () => {


### PR DESCRIPTION
Part of https://github.com/hypothesis/client/issues/5784

This PR adds a new option to the export annotations dropdown, to generate a CSV file.

Some of the columns in the CSV contain generic values that are duplicated on every row (total annotations, total replies, current date, etc). These values are placed in a header in other formats, but that's not possible in CSV.

The rest of the format is described in https://docs.google.com/document/d/1Xn6AazKkpUy85VUaj9v_utasexk8lIqP_1zveILq1So/edit

### Testing steps

1. Check out this branch
2. Go to http://localhost:5000/admin/features and enable `export_formats`.
3. Go to http://localhost:3000, share annotations, and select CSV from the format dropdown.
4. You should get a properly formatted CSV, where values are escaped when needed.

### Considerations

* I have not included information about "to" and "from", even though it is defined in https://docs.google.com/document/d/1Xn6AazKkpUy85VUaj9v_utasexk8lIqP_1zveILq1So/edit
  The reasons are that "from" is the same as "user", so it's redundant. And "to", I have decided to address it separately, as I realized I also missed it in text format.
* I have also skipped "Event" filed, as it is pending clarification of what is it.
* I have added "Page", even though it is not defined in the document, because this field was added after that document was created.
* The order of fields is subject to changing, as we discussed in text format. I will address that separately as well, once all formats are implemented, so that we can make sure they are consistent.
* I have left the aggregate fields as defined in the document (total annotations, total replies, etc), but as [noted by Rob](https://github.com/hypothesis/client/pull/6057#issuecomment-1878842160), these could be calculated in whatever spreadsheet software is used to read the export file.