### PR TITLE
Make AnnotationsExporter not depend on SidebarStore

### DIFF
--- a/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
+++ b/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
@@ -84,7 +84,8 @@ function ExportAnnotations({
   );
 
   // User whose annotations are going to be exported.
-  const currentUser = store.profile().userid;
+  const profile = store.profile();
+  const currentUser = profile.userid;
   const allAnnotationsOption: Omit<UserAnnotations, 'userid'> = useMemo(
     () => ({
       annotations: exportableAnnotations,
@@ -131,8 +132,10 @@ function ExportAnnotations({
 
       switch (format) {
         case 'json': {
-          const exportData =
-            annotationsExporter.buildJSONExportContent(annotationsToExport);
+          const exportData = annotationsExporter.buildJSONExportContent(
+            annotationsToExport,
+            { profile },
+          );
           downloadJSONFile(exportData, filename);
           break;
         }

--- a/src/sidebar/services/annotations-exporter.ts
+++ b/src/sidebar/services/annotations-exporter.ts
@@ -1,5 +1,5 @@
 import { trimAndDedent } from '../../shared/trim-and-dedent';
-import type { APIAnnotationData } from '../../types/api';
+import type { APIAnnotationData, Profile } from '../../types/api';
 import {
   documentMetadata,
   isReply,
@@ -9,13 +9,17 @@ import {
 import { annotationDisplayName } from '../helpers/annotation-user';
 import { stripInternalProperties } from '../helpers/strip-internal-properties';
 import { VersionData } from '../helpers/version-data';
-import type { SidebarStore } from '../store';
 
 export type JSONExportContent = {
   export_date: string;
   export_userid: string;
   client_version: string;
   annotations: APIAnnotationData[];
+};
+
+export type JSONExportOptions = {
+  profile: Profile;
+  now?: Date;
 };
 
 export type TextExportOptions = {
@@ -31,18 +35,14 @@ export type TextExportOptions = {
  * @inject
  */
 export class AnnotationsExporter {
-  private _store: SidebarStore;
-
-  constructor(store: SidebarStore) {
-    this._store = store;
-  }
-
   buildJSONExportContent(
     annotations: APIAnnotationData[],
-    /* istanbul ignore next - test seam */
-    now = new Date(),
+    {
+      profile,
+      /* istanbul ignore next - test seam */
+      now = new Date(),
+    }: JSONExportOptions,
   ): JSONExportContent {
-    const profile = this._store.profile();
     const versionData = new VersionData(profile, []);
 
     return {

--- a/src/sidebar/services/test/annotations-exporter-test.js
+++ b/src/sidebar/services/test/annotations-exporter-test.js
@@ -6,40 +6,41 @@ import {
 import { AnnotationsExporter } from '../annotations-exporter';
 
 describe('AnnotationsExporter', () => {
-  let fakeStore;
   let now;
   let exporter;
 
   beforeEach(() => {
-    fakeStore = {
-      profile: sinon.stub().returns({ userid: 'userId' }),
-    };
     now = new Date();
-
-    exporter = new AnnotationsExporter(fakeStore);
+    exporter = new AnnotationsExporter();
   });
 
-  it('generates JSON content with provided annotations', () => {
-    const firstBaseAnnotation = publicAnnotation();
-    const secondBaseAnnotation = publicAnnotation();
-    const annotations = [
-      {
-        ...firstBaseAnnotation,
-        $tag: '',
-      },
-      {
-        ...secondBaseAnnotation,
-        $highlight: true,
-      },
-    ];
+  describe('buildJSONExportContent', () => {
+    it('generates JSON content with provided annotations', () => {
+      const profile = { userid: 'userId' };
+      const firstBaseAnnotation = publicAnnotation();
+      const secondBaseAnnotation = publicAnnotation();
+      const annotations = [
+        {
+          ...firstBaseAnnotation,
+          $tag: '',
+        },
+        {
+          ...secondBaseAnnotation,
+          $highlight: true,
+        },
+      ];
 
-    const result = exporter.buildJSONExportContent(annotations, now);
+      const result = exporter.buildJSONExportContent(annotations, {
+        now,
+        profile,
+      });
 
-    assert.deepEqual(result, {
-      export_date: now.toISOString(),
-      export_userid: 'userId',
-      client_version: '__VERSION__',
-      annotations: [firstBaseAnnotation, secondBaseAnnotation],
+      assert.deepEqual(result, {
+        export_date: now.toISOString(),
+        export_userid: 'userId',
+        client_version: '__VERSION__',
+        annotations: [firstBaseAnnotation, secondBaseAnnotation],
+      });
     });
   });
 


### PR DESCRIPTION
Refactor the `AnnotationsExporter` so that it does not depend on `SidebarStore`. The only reason it used to is for the JSON export to have access to current user via `store.profile()`.

This PR changes the JSON export method signature so that it expects an options object as its second argument, which includes the `profile`, and makes it more consistent with how other formats work.

> [!TIP]
> It's easier to review this PR [ignoring whitespaces](https://github.com/hypothesis/client/pull/6058/files?w=1)