### PR TITLE
Add staging deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
       run: |
         git fetch --tags --quiet
         LAST_COMMIT_HASH=$(git show HEAD --no-patch --format="%h")
-        STAGING_VERSION=$(git tag --list | sort --version-sort --reverse | head -n1 | tail -c +2)-$LAST_COMMIT_HASH
+        STAGING_VERSION=$(git tag --list | sort --version-sort --reverse | head -n1 | tail -c +2)-stg-$LAST_COMMIT_HASH
         echo "STAGING_VERSION=$STAGING_VERSION" >> $GITHUB_ENV
     - name: Build app
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,51 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
       run: scripts/deploy-to-s3.js --bucket ${{ env.S3_BUCKET }} --tag qa --no-cache-entry
 
+  release-staging:
+    needs: continuous-integration
+    runs-on: ubuntu-latest
+    # This presently uses the same AWS / Sentry auth as QA. We should eventually
+    # rename that environment or create a new one.
+    environment: qa
+    env:
+      NOTEBOOK_APP_URL: https://staging.hypothes.is/notebook
+      PROFILE_APP_URL: https://staging.hypothes.is/user-profile
+      SIDEBAR_APP_URL: https://staging.hypothes.is/app.html
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Cache the node_modules dir
+      uses: actions/cache@v3
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}
+    - name: Install
+      run: yarn install --immutable
+    - name: Get version
+      run: |
+        git fetch --tags --quiet
+        LAST_COMMIT_HASH=$(git show HEAD --no-patch --format="%h")
+        STAGING_VERSION=$(git tag --list | sort --version-sort --reverse | head -n1 | tail -c +2)-$LAST_COMMIT_HASH
+        echo "STAGING_VERSION=$STAGING_VERSION" >> $GITHUB_ENV
+    - name: Build app
+      run: |
+        yarn version "$STAGING_VERSION"
+        make clean build
+    - name: Upload files to Sentry
+      env:
+        SENTRY_AUTH_TOKEN: ${{ secrets.sentry_auth_token }}
+      run: |
+        SENTRY_CMD="yarn run sentry-cli releases --org hypothesis --project client"
+        $SENTRY_CMD new $STAGING_VERSION
+        $SENTRY_CMD files $STAGING_VERSION upload-sourcemaps --url-prefix $CDN_URL/$STAGING_VERSION/build/scripts/ build/scripts
+        $SENTRY_CMD finalize $STAGING_VERSION
+    - name: Deploy to S3
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
+      run: scripts/deploy-to-s3.js --bucket ${{ env.S3_BUCKET }} --tag staging --no-cache-entry
+
   release-prod:
     if: github.ref_name == 'main'
     needs: release-qa


### PR DESCRIPTION
This is a copy-and-paste of the `release-qa` job configuration, with "qa"
replaced by "staging". This is part of the new staging deployment of h.

It initially re-uses the AWS / Sentry auth from the existing GitHub "qa"
environment in the client repo.

See https://github.com/hypothesis/playbook/issues/1519.

