### PR TITLE
Extract escapeCSVValue util to its own module

### DIFF
--- a/src/shared/csv.ts
+++ b/src/shared/csv.ts
@@ -1,0 +1,13 @@
+/**
+ * Escape a CSV field value (see https://www.ietf.org/rfc/rfc4180.txt)
+ *
+ * - foo -> foo
+ * - foo,bar -> "foo,bar"
+ * - with "quoted" text -> "with ""quoted"" text"
+ */
+export function escapeCSVValue(value: string): string {
+  if (/[",\n\r]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}

--- a/src/shared/test/csv-test.js
+++ b/src/shared/test/csv-test.js
@@ -1,0 +1,20 @@
+import { escapeCSVValue } from '../csv';
+
+describe('escapeCSVValue', () => {
+  [
+    { value: 'foo', expected: 'foo' },
+    { value: 'foo,bar', expected: '"foo,bar"' },
+    { value: 'with \r carriage return', expected: '"with \r carriage return"' },
+    {
+      value: `multiple
+    lines`,
+      expected: `"multiple
+    lines"`,
+    },
+    { value: 'with "quotes"', expected: '"with ""quotes"""' },
+  ].forEach(({ value, expected }) => {
+    it('escapes values', () => {
+      assert.equal(escapeCSVValue(value), expected);
+    });
+  });
+});

--- a/src/sidebar/services/annotations-exporter.ts
+++ b/src/sidebar/services/annotations-exporter.ts
@@ -1,3 +1,4 @@
+import { escapeCSVValue } from '../../shared/csv';
 import { trimAndDedent } from '../../shared/trim-and-dedent';
 import type { APIAnnotationData, Profile } from '../../types/api';
 import {
@@ -117,14 +118,6 @@ export class AnnotationsExporter {
       defaultAuthority,
     });
 
-    const escapeCSVValue = (value: string): string => {
-      // If the value contains a comma, newline or double quote, then wrap it in
-      // double quotes and escape any existing double quotes.
-      if (/[",\n]/.test(value)) {
-        return `"${value.replace(/"/g, '""')}"`;
-      }
-      return value;
-    };
     const annotationToRow = (annotation: APIAnnotationData) =>
       [
         annotation.created,


### PR DESCRIPTION
The `escapeCSVValue` utility was implemented as part of the CSV export annotations.

This PR extracts it so that it's easier to test independently, and reuse if needed.