### PR TITLE
Create function to format dates in a standard sortable format

### DIFF
--- a/src/sidebar/util/test/time-test.js
+++ b/src/sidebar/util/test/time-test.js
@@ -2,6 +2,7 @@ import {
   clearFormatters,
   decayingInterval,
   formatDate,
+  formatDateTime,
   formatRelativeDate,
   nextFuzzyUpdate,
 } from '../time';
@@ -253,6 +254,18 @@ describe('sidebar/util/time', () => {
         normalizeSpaces(formatDate(date, fakeIntl('de-DE'))),
         'Montag, 04. Mai 2020, 23:02',
       );
+    });
+  });
+
+  describe('formatDateTime', () => {
+    [
+      new Date(Date.UTC(2023, 11, 20, 3, 5, 38)),
+      new Date('2020-05-04T23:02:01+05:00'),
+    ].forEach(date => {
+      it('returns right format for provided date', () => {
+        const expectedDateRegex = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/;
+        assert.match(formatDateTime(date), expectedDateRegex);
+      });
     });
   });
 });

--- a/src/sidebar/util/time.ts
+++ b/src/sidebar/util/time.ts
@@ -262,3 +262,16 @@ export function formatDate(date: Date, Intl?: IntlType): string {
     Intl,
   );
 }
+
+/**
+ * Formats a date as `YYYY-MM-DD hh:mm`, using 24h and system timezone.
+ */
+export function formatDateTime(date: Date): string {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  const hours = `${date.getHours()}`.padStart(2, '0');
+  const minutes = `${date.getMinutes()}`.padStart(2, '0');
+
+  return `${year}-${month}-${day} ${hours}:${minutes}`;
+}


### PR DESCRIPTION
This PR creates a utility function that can be used to format a date as `YYYY-MM-DD hh:mm`, which is a standard format, that can be used to sort a list chronologically, and is also detected as date by common spreadsheet apps.

This function will then be used to format dates when exporting annotations in formats other than JSON.