### PR TITLE
Export annotations improvements

### DIFF
--- a/src/sidebar/services/annotations-exporter.tsx
+++ b/src/sidebar/services/annotations-exporter.tsx
@@ -189,18 +189,30 @@ export class AnnotationsExporter {
               </a>
             </p>
 
-            <dl>
-              <dt>Group</dt>
-              <dd>{groupName}</dd>
-              <dt>Total users</dt>
-              <dd>{uniqueUsers.length}</dd>
-              <dt>Users</dt>
-              <dd>{uniqueUsers.join(', ')}</dd>
-              <dt>Total annotations</dt>
-              <dd>{annotations.length}</dd>
-              <dt>Total replies</dt>
-              <dd>{replies.length}</dd>
-            </dl>
+            <table>
+              <tbody>
+                <tr>
+                  <td>Group:</td>
+                  <td>{groupName}</td>
+                </tr>
+                <tr>
+                  <td>Total users:</td>
+                  <td>{uniqueUsers.length}</td>
+                </tr>
+                <tr>
+                  <td>Users:</td>
+                  <td>{uniqueUsers.join(', ')}</td>
+                </tr>
+                <tr>
+                  <td>Total annotations:</td>
+                  <td>{annotations.length}</td>
+                </tr>
+                <tr>
+                  <td>Total replies:</td>
+                  <td>{replies.length}</td>
+                </tr>
+              </tbody>
+            </table>
           </section>
           <hr />
           <section>

--- a/src/sidebar/services/annotations-exporter.tsx
+++ b/src/sidebar/services/annotations-exporter.tsx
@@ -171,7 +171,7 @@ export class AnnotationsExporter {
     return renderToString(
       <html lang="en">
         <head>
-          <title>Annotations export - Hypothesis</title>
+          <title>{`Annotations on "${title}"`}</title>
           <meta charSet="UTF-8" />
         </head>
         <body>

--- a/src/sidebar/services/annotations-exporter.tsx
+++ b/src/sidebar/services/annotations-exporter.tsx
@@ -78,7 +78,7 @@ export class AnnotationsExporter {
     const annotationsAsText = annotations.map((annotation, index) => {
       const page = pageLabel(annotation);
       const lines = [
-        formatDateTime(new Date(annotation.created)),
+        `Created at: ${formatDateTime(new Date(annotation.created))}`,
         `Comment: ${annotation.text}`,
         extractUsername(annotation),
         `Quote: "${quote(annotation)}"`,
@@ -135,7 +135,7 @@ export class AnnotationsExporter {
         .join(',');
 
     const headers = [
-      'Creation Date',
+      'Created at',
       'URL',
       'Group',
       'Annotation/Reply Type',
@@ -223,6 +223,7 @@ export class AnnotationsExporter {
                 <article key={annotation.id}>
                   <h2>Annotation {index + 1}:</h2>
                   <p>
+                    Created at:
                     <time dateTime={annotation.created}>
                       {formatDateTime(new Date(annotation.created))}
                     </time>

--- a/src/sidebar/services/annotations-exporter.tsx
+++ b/src/sidebar/services/annotations-exporter.tsx
@@ -141,7 +141,7 @@ export class AnnotationsExporter {
       'Annotation/Reply Type',
       'Quote',
       'User',
-      'Body',
+      'Comment',
       'Tags',
       'Page',
     ].join(',');

--- a/src/sidebar/services/test/annotations-exporter-test.js
+++ b/src/sidebar/services/test/annotations-exporter-test.js
@@ -120,28 +120,28 @@ Total annotations: 5
 Total replies: 1
 
 Annotation 1:
-${formattedNow}
+Created at: ${formattedNow}
 Comment: Annotation text
 bill
 Quote: "this is the quote"
 Tags: tag_1, tag_2
 
 Annotation 2:
-${formattedNow}
+Created at: ${formattedNow}
 Comment: Annotation text
 bill
 Quote: "null"
 Tags: tag_1, tag_2
 
 Annotation 3:
-${formattedNow}
+Created at: ${formattedNow}
 Comment: Annotation text
 jane
 Quote: "null"
 Tags: foo, bar
 
 Annotation 4:
-${formattedNow}
+Created at: ${formattedNow}
 Comment: Annotation text
 bill
 Quote: "null"
@@ -149,7 +149,7 @@ Tags: tag_1, tag_2
 Page: 23
 
 Annotation 5:
-${formattedNow}
+Created at: ${formattedNow}
 Comment: Annotation text
 bill
 Quote: "null"
@@ -183,7 +183,7 @@ Total annotations: 1
 Total replies: 0
 
 Annotation 1:
-${formattedNow}
+Created at: ${formattedNow}
 Comment: Annotation text
 John Doe
 Quote: "null"
@@ -229,7 +229,7 @@ Tags: tag_1, tag_2`,
 
       assert.equal(
         result,
-        `Creation Date,URL,Group,Annotation/Reply Type,Quote,User,Comment,Tags,Page
+        `Created at,URL,Group,Annotation/Reply Type,Quote,User,Comment,Tags,Page
 ${formattedNow},http://example.com,My group,Annotation,,jane,Annotation text,"foo,bar",
 ${formattedNow},http://example.com,My group,Reply,"includes ""double quotes"", and commas",bill,Annotation text,"tag_1,tag_2",23
 ${formattedNow},http://example.com,My group,Annotation,,bill,Annotation text,,iii`,
@@ -252,7 +252,7 @@ ${formattedNow},http://example.com,My group,Annotation,,bill,Annotation text,,ii
 
       assert.equal(
         result,
-        `Creation Date,URL,Group,Annotation/Reply Type,Quote,User,Comment,Tags,Page
+        `Created at,URL,Group,Annotation/Reply Type,Quote,User,Comment,Tags,Page
 ${formattedNow},http://example.com,My group,Annotation,,John Doe,Annotation text,"tag_1,tag_2",`,
       );
     });
@@ -356,6 +356,7 @@ ${formattedNow},http://example.com,My group,Annotation,,John Doe,Annotation text
       <article>
         <h2>Annotation 1:</h2>
         <p>
+          Created at:
           <time datetime="${isoDate}">${formattedNow}</time>
         </p>
         <p>Comment: Annotation text</p>
@@ -369,6 +370,7 @@ ${formattedNow},http://example.com,My group,Annotation,,John Doe,Annotation text
       <article>
         <h2>Annotation 2:</h2>
         <p>
+          Created at:
           <time datetime="${isoDate}">${formattedNow}</time>
         </p>
         <p>Comment: Annotation text</p>
@@ -383,6 +385,7 @@ ${formattedNow},http://example.com,My group,Annotation,,John Doe,Annotation text
       <article>
         <h2>Annotation 3:</h2>
         <p>
+          Created at:
           <time datetime="${isoDate}">${formattedNow}</time>
         </p>
         <p>Comment: Annotation text</p>

--- a/src/sidebar/services/test/annotations-exporter-test.js
+++ b/src/sidebar/services/test/annotations-exporter-test.js
@@ -302,7 +302,9 @@ ${formattedNow},http://example.com,My group,Annotation,,John Doe,Annotation text
         removeAllIndentation(result),
         removeAllIndentation(`<html lang="en">
   <head>
-    <title>Annotations export - Hypothesis</title>
+    <title>
+      Annotations on &quot;A special document&quot;
+    </title>
     <meta charset="UTF-8" />
   </head>
   <body>

--- a/src/sidebar/services/test/annotations-exporter-test.js
+++ b/src/sidebar/services/test/annotations-exporter-test.js
@@ -229,7 +229,7 @@ Tags: tag_1, tag_2`,
 
       assert.equal(
         result,
-        `Creation Date,URL,Group,Annotation/Reply Type,Quote,User,Body,Tags,Page
+        `Creation Date,URL,Group,Annotation/Reply Type,Quote,User,Comment,Tags,Page
 ${formattedNow},http://example.com,My group,Annotation,,jane,Annotation text,"foo,bar",
 ${formattedNow},http://example.com,My group,Reply,"includes ""double quotes"", and commas",bill,Annotation text,"tag_1,tag_2",23
 ${formattedNow},http://example.com,My group,Annotation,,bill,Annotation text,,iii`,
@@ -252,7 +252,7 @@ ${formattedNow},http://example.com,My group,Annotation,,bill,Annotation text,,ii
 
       assert.equal(
         result,
-        `Creation Date,URL,Group,Annotation/Reply Type,Quote,User,Body,Tags,Page
+        `Creation Date,URL,Group,Annotation/Reply Type,Quote,User,Comment,Tags,Page
 ${formattedNow},http://example.com,My group,Annotation,,John Doe,Annotation text,"tag_1,tag_2",`,
       );
     });

--- a/src/sidebar/services/test/annotations-exporter-test.js
+++ b/src/sidebar/services/test/annotations-exporter-test.js
@@ -323,18 +323,30 @@ ${formattedNow},http://example.com,My group,Annotation,,John Doe,Annotation text
           http://example.com
         </a>
       </p>
-      <dl>
-        <dt>Group</dt>
-        <dd>My group</dd>
-        <dt>Total users</dt>
-        <dd>2</dd>
-        <dt>Users</dt>
-        <dd>jane, bill</dd>
-        <dt>Total annotations</dt>
-        <dd>3</dd>
-        <dt>Total replies</dt>
-        <dd>1</dd>
-      </dl>
+      <table>
+        <tbody>
+          <tr>
+            <td>Group:</td>
+            <td>My group</td>
+          </tr>
+          <tr>
+            <td>Total users:</td>
+            <td>2</td>
+          </tr>
+          <tr>
+            <td>Users:</td>
+            <td>jane, bill</td>
+          </tr>
+          <tr>
+            <td>Total annotations:</td>
+            <td>3</td>
+          </tr>
+          <tr>
+            <td>Total replies:</td>
+            <td>1</td>
+          </tr>
+        </tbody>
+      </table>
     </section>
     <hr />
     <section>


### PR DESCRIPTION
Part of #5784 

This PR applies various small improvements that have been highlighted during other PR reviews:

* [Use table for annotations export in HTML format](https://github.com/hypothesis/client/commit/c0d26318b4afe7ac68013e48938e26a9e3bf0c4d)
* [Add document title as part of annotations export HTML title](https://github.com/hypothesis/client/commit/ba3f541863349392fc72243a1ef359573ab3f18f)
* [Use Comment as column name for annotation text when exporting as CSV](https://github.com/hypothesis/client/commit/9dccfa2172167816de25dde47c2b99bb44f7f987)
* [Label annotation creation date with 'Created at:' in HTML and text formats](https://github.com/hypothesis/client/pull/6082/commits/229a14fd5aa38db42947d58590caf43bb2b2afd4)