### PR TITLE
Export fields arrangement

### DIFF
--- a/src/sidebar/services/annotations-exporter.tsx
+++ b/src/sidebar/services/annotations-exporter.tsx
@@ -222,21 +222,46 @@ export class AnnotationsExporter {
               return (
                 <article key={annotation.id}>
                   <h2>Annotation {index + 1}:</h2>
-                  <p>
-                    Created at:
-                    <time dateTime={annotation.created}>
-                      {formatDateTime(new Date(annotation.created))}
-                    </time>
-                  </p>
-                  <p>Author: {extractUsername(annotation)}</p>
-                  {page && <p>Page: {page}</p>}
-                  <p>
-                    Quote: <blockquote>{quote(annotation)}</blockquote>
-                  </p>
-                  <p>Comment: {annotation.text}</p>
-                  {annotation.tags.length > 0 && (
-                    <p>Tags: {annotation.tags.join(', ')}</p>
-                  )}
+                  <table>
+                    <tbody>
+                      <tr>
+                        <td>Created at:</td>
+                        <td>
+                          <time dateTime={annotation.created}>
+                            {formatDateTime(new Date(annotation.created))}
+                          </time>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>Author:</td>
+                        <td>{extractUsername(annotation)}</td>
+                      </tr>
+                      {page && (
+                        <tr>
+                          <td>Page:</td>
+                          <td>{page}</td>
+                        </tr>
+                      )}
+                      <tr>
+                        <td>Quote:</td>
+                        <td>
+                          <blockquote style={{ margin: 0 }}>
+                            {quote(annotation)}
+                          </blockquote>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>Comment:</td>
+                        <td>{annotation.text}</td>
+                      </tr>
+                      {annotation.tags.length > 0 && (
+                        <tr>
+                          <td>Tags:</td>
+                          <td>{annotation.tags.join(', ')}</td>
+                        </tr>
+                      )}
+                    </tbody>
+                  </table>
                 </article>
               );
             })}

--- a/src/sidebar/services/annotations-exporter.tsx
+++ b/src/sidebar/services/annotations-exporter.tsx
@@ -79,13 +79,13 @@ export class AnnotationsExporter {
       const page = pageLabel(annotation);
       const lines = [
         `Created at: ${formatDateTime(new Date(annotation.created))}`,
-        `Comment: ${annotation.text}`,
-        extractUsername(annotation),
+        `Author: ${extractUsername(annotation)}`,
+        page ? `Page: ${page}` : undefined,
         `Quote: "${quote(annotation)}"`,
+        `Comment: ${annotation.text}`,
         annotation.tags.length > 0
           ? `Tags: ${annotation.tags.join(', ')}`
           : undefined,
-        page ? `Page: ${page}` : undefined,
       ].filter(Boolean);
 
       return trimAndDedent`
@@ -122,28 +122,28 @@ export class AnnotationsExporter {
     const annotationToRow = (annotation: APIAnnotationData) =>
       [
         formatDateTime(new Date(annotation.created)),
+        extractUsername(annotation),
+        pageLabel(annotation) ?? '',
         uri,
         groupName,
         isReply(annotation) ? 'Reply' : 'Annotation',
         quote(annotation) ?? '',
-        extractUsername(annotation),
         annotation.text,
         annotation.tags.join(','),
-        pageLabel(annotation) ?? '',
       ]
         .map(escapeCSVValue)
         .join(',');
 
     const headers = [
       'Created at',
+      'Author',
+      'Page',
       'URL',
       'Group',
       'Annotation/Reply Type',
       'Quote',
-      'User',
       'Comment',
       'Tags',
-      'Page',
     ].join(',');
     const annotationsContent = annotations
       .map(anno => annotationToRow(anno))
@@ -228,15 +228,15 @@ export class AnnotationsExporter {
                       {formatDateTime(new Date(annotation.created))}
                     </time>
                   </p>
-                  <p>Comment: {annotation.text}</p>
-                  <p>{extractUsername(annotation)}</p>
+                  <p>Author: {extractUsername(annotation)}</p>
+                  {page && <p>Page: {page}</p>}
                   <p>
                     Quote: <blockquote>{quote(annotation)}</blockquote>
                   </p>
+                  <p>Comment: {annotation.text}</p>
                   {annotation.tags.length > 0 && (
                     <p>Tags: {annotation.tags.join(', ')}</p>
                   )}
-                  {page && <p>Page: {page}</p>}
                 </article>
               );
             })}

--- a/src/sidebar/services/test/annotations-exporter-test.js
+++ b/src/sidebar/services/test/annotations-exporter-test.js
@@ -121,39 +121,39 @@ Total replies: 1
 
 Annotation 1:
 Created at: ${formattedNow}
-Comment: Annotation text
-bill
+Author: bill
 Quote: "this is the quote"
+Comment: Annotation text
 Tags: tag_1, tag_2
 
 Annotation 2:
 Created at: ${formattedNow}
-Comment: Annotation text
-bill
+Author: bill
 Quote: "null"
+Comment: Annotation text
 Tags: tag_1, tag_2
 
 Annotation 3:
 Created at: ${formattedNow}
-Comment: Annotation text
-jane
+Author: jane
 Quote: "null"
+Comment: Annotation text
 Tags: foo, bar
 
 Annotation 4:
 Created at: ${formattedNow}
-Comment: Annotation text
-bill
-Quote: "null"
-Tags: tag_1, tag_2
+Author: bill
 Page: 23
+Quote: "null"
+Comment: Annotation text
+Tags: tag_1, tag_2
 
 Annotation 5:
 Created at: ${formattedNow}
-Comment: Annotation text
-bill
+Author: bill
+Page: iii
 Quote: "null"
-Page: iii`,
+Comment: Annotation text`,
       );
     });
 
@@ -184,9 +184,9 @@ Total replies: 0
 
 Annotation 1:
 Created at: ${formattedNow}
-Comment: Annotation text
-John Doe
+Author: John Doe
 Quote: "null"
+Comment: Annotation text
 Tags: tag_1, tag_2`,
       );
     });
@@ -229,10 +229,10 @@ Tags: tag_1, tag_2`,
 
       assert.equal(
         result,
-        `Created at,URL,Group,Annotation/Reply Type,Quote,User,Comment,Tags,Page
-${formattedNow},http://example.com,My group,Annotation,,jane,Annotation text,"foo,bar",
-${formattedNow},http://example.com,My group,Reply,"includes ""double quotes"", and commas",bill,Annotation text,"tag_1,tag_2",23
-${formattedNow},http://example.com,My group,Annotation,,bill,Annotation text,,iii`,
+        `Created at,Author,Page,URL,Group,Annotation/Reply Type,Quote,Comment,Tags
+${formattedNow},jane,,http://example.com,My group,Annotation,,Annotation text,"foo,bar"
+${formattedNow},bill,23,http://example.com,My group,Reply,"includes ""double quotes"", and commas",Annotation text,"tag_1,tag_2"
+${formattedNow},bill,iii,http://example.com,My group,Annotation,,Annotation text,`,
       );
     });
 
@@ -252,8 +252,8 @@ ${formattedNow},http://example.com,My group,Annotation,,bill,Annotation text,,ii
 
       assert.equal(
         result,
-        `Created at,URL,Group,Annotation/Reply Type,Quote,User,Comment,Tags,Page
-${formattedNow},http://example.com,My group,Annotation,,John Doe,Annotation text,"tag_1,tag_2",`,
+        `Created at,Author,Page,URL,Group,Annotation/Reply Type,Quote,Comment,Tags
+${formattedNow},John Doe,,http://example.com,My group,Annotation,,Annotation text,"tag_1,tag_2"`,
       );
     });
   });
@@ -359,12 +359,12 @@ ${formattedNow},http://example.com,My group,Annotation,,John Doe,Annotation text
           Created at:
           <time datetime="${isoDate}">${formattedNow}</time>
         </p>
-        <p>Comment: Annotation text</p>
-        <p>jane</p>
+        <p>Author: jane</p>
         <p>
           Quote: 
           <blockquote></blockquote>
         </p>
+        <p>Comment: Annotation text</p>
         <p>Tags: foo, bar</p>
       </article>
       <article>
@@ -373,14 +373,14 @@ ${formattedNow},http://example.com,My group,Annotation,,John Doe,Annotation text
           Created at:
           <time datetime="${isoDate}">${formattedNow}</time>
         </p>
-        <p>Comment: Annotation text</p>
-        <p>bill</p>
+        <p>Author: bill</p>
+        <p>Page: 23</p>
         <p>
           Quote: 
           <blockquote>includes &lt;p>HTML&lt;/p> tags</blockquote>
         </p>
+        <p>Comment: Annotation text</p>
         <p>Tags: tag_1, tag_2</p>
-        <p>Page: 23</p>
       </article>
       <article>
         <h2>Annotation 3:</h2>
@@ -388,13 +388,13 @@ ${formattedNow},http://example.com,My group,Annotation,,John Doe,Annotation text
           Created at:
           <time datetime="${isoDate}">${formattedNow}</time>
         </p>
-        <p>Comment: Annotation text</p>
-        <p>bill</p>
+        <p>Author: bill</p>
+        <p>Page: iii</p>
         <p>
           Quote: 
           <blockquote></blockquote>
         </p>
-        <p>Page: iii</p>
+        <p>Comment: Annotation text</p>
       </article>
     </section>
   </body>

--- a/src/sidebar/services/test/annotations-exporter-test.js
+++ b/src/sidebar/services/test/annotations-exporter-test.js
@@ -355,46 +355,100 @@ ${formattedNow},John Doe,,http://example.com,My group,Annotation,,Annotation tex
       <h1>Annotations</h1>
       <article>
         <h2>Annotation 1:</h2>
-        <p>
-          Created at:
-          <time datetime="${isoDate}">${formattedNow}</time>
-        </p>
-        <p>Author: jane</p>
-        <p>
-          Quote: 
-          <blockquote></blockquote>
-        </p>
-        <p>Comment: Annotation text</p>
-        <p>Tags: foo, bar</p>
+        <table>
+          <tbody>
+            <tr>
+              <td>Created at:</td>
+              <td>
+                <time datetime="${isoDate}">${formattedNow}</time>
+              </td>
+            </tr>
+            <tr>
+              <td>Author:</td>
+              <td>jane</td>
+            </tr>
+            <tr>
+              <td>Quote:</td>
+              <td>
+                <blockquote style="margin:0px;"></blockquote>
+              </td>
+            </tr>
+            <tr>
+              <td>Comment:</td>
+              <td>Annotation text</td>
+            </tr>
+            <tr>
+              <td>Tags:</td>
+              <td>foo, bar</td>
+            </tr>
+          </tbody>
+        </table>
       </article>
       <article>
         <h2>Annotation 2:</h2>
-        <p>
-          Created at:
-          <time datetime="${isoDate}">${formattedNow}</time>
-        </p>
-        <p>Author: bill</p>
-        <p>Page: 23</p>
-        <p>
-          Quote: 
-          <blockquote>includes &lt;p>HTML&lt;/p> tags</blockquote>
-        </p>
-        <p>Comment: Annotation text</p>
-        <p>Tags: tag_1, tag_2</p>
+        <table>
+          <tbody>
+            <tr>
+              <td>Created at:</td>
+              <td>
+                <time datetime="${isoDate}">${formattedNow}</time>
+              </td>
+            </tr>
+            <tr>
+              <td>Author:</td>
+              <td>bill</td>
+            </tr>
+            <tr>
+              <td>Page:</td>
+              <td>23</td>
+            </tr>
+            <tr>
+              <td>Quote:</td>
+              <td>
+                <blockquote style="margin:0px;">includes &lt;p>HTML&lt;/p> tags</blockquote>
+              </td>
+            </tr>
+            <tr>
+              <td>Comment:</td>
+              <td>Annotation text</td>
+            </tr>
+            <tr>
+              <td>Tags:</td>
+              <td>tag_1, tag_2</td>
+            </tr>
+          </tbody>
+        </table>
       </article>
       <article>
         <h2>Annotation 3:</h2>
-        <p>
-          Created at:
-          <time datetime="${isoDate}">${formattedNow}</time>
-        </p>
-        <p>Author: bill</p>
-        <p>Page: iii</p>
-        <p>
-          Quote: 
-          <blockquote></blockquote>
-        </p>
-        <p>Comment: Annotation text</p>
+        <table>
+          <tbody>
+            <tr>
+              <td>Created at:</td>
+              <td>
+                <time datetime="${isoDate}">${formattedNow}</time>
+              </td>
+            </tr>
+            <tr>
+              <td>Author:</td>
+              <td>bill</td>
+            </tr>
+            <tr>
+              <td>Page:</td>
+              <td>iii</td>
+            </tr>
+            <tr>
+              <td>Quote:</td>
+              <td>
+                <blockquote style="margin:0px;"></blockquote>
+              </td>
+            </tr>
+            <tr>
+              <td>Comment:</td>
+              <td>Annotation text</td>
+            </tr>
+          </tbody>
+        </table>
       </article>
     </section>
   </body>


### PR DESCRIPTION
Part of #5784

This PR rearranges the fields in various annotations export formats, so that they more closly match how we display them in annotation cards.

Additionally, it uses a `table` to render the info for every annotation in HTML format, making it more compact and nicer when copied over into a text editor.