### PR TITLE
Add copy to clipboard button to export annotations

### DIFF
--- a/src/annotator/sidebar.tsx
+++ b/src/annotator/sidebar.tsx
@@ -85,6 +85,7 @@ function createSidebarIframe(config: SidebarConfig): HTMLIFrameElement {
   sidebarFrame.src = sidebarAppSrc;
   sidebarFrame.title = 'Hypothesis annotation viewer';
   sidebarFrame.className = 'sidebar-frame';
+  sidebarFrame.allow = 'clipboard-write';
 
   return sidebarFrame;
 }

--- a/src/shared/download-file.ts
+++ b/src/shared/download-file.ts
@@ -19,25 +19,6 @@ function downloadFile(
   URL.revokeObjectURL(url);
 }
 
-/**
- * Download a file containing JSON-serialized `object` as `filename`
- *
- * @param data - JSON-serializable object
- * @return The contents of the downloaded file
- * @throws {Error} If provided data cannot be JSON-serialized
- */
-export function downloadJSONFile(
-  data: object,
-  filename: string,
-  /* istanbul ignore next - test seam */
-  _document = document,
-): string {
-  const fileContent = JSON.stringify(data, null, 2);
-  downloadFile(fileContent, 'application/json', filename, _document);
-
-  return fileContent;
-}
-
 function buildTextFileDownloader(type: string) {
   return (
     text: string,
@@ -46,6 +27,8 @@ function buildTextFileDownloader(type: string) {
     _document = document,
   ) => downloadFile(text, type, filename, _document);
 }
+
+export const downloadJSONFile = buildTextFileDownloader('application/json');
 
 export const downloadTextFile = buildTextFileDownloader('text/plain');
 

--- a/src/shared/test/download-file-test.js
+++ b/src/shared/test/download-file-test.js
@@ -48,13 +48,12 @@ describe('download-file', () => {
   }
 
   it('downloadJSONFile generates JSON file with provided data', () => {
-    const data = { foo: ['bar', 'baz'] };
+    const data = JSON.stringify({ foo: ['bar', 'baz'] }, null, 2);
     const filename = 'my-file.json';
 
-    const fileContent = downloadJSONFile(data, filename, fakeDocument);
+    downloadJSONFile(data, filename, fakeDocument);
 
-    assert.equal(fileContent, JSON.stringify(data, null, 2));
-    assertDownloadHappened(filename, fileContent, 'application/json');
+    assertDownloadHappened(filename, data, 'application/json');
   });
 
   it('downloadTextFile generates text file with provided data', () => {

--- a/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
+++ b/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
@@ -469,8 +469,8 @@ describe('ExportAnnotations', () => {
   context('when copying annotations export to clipboard', () => {
     [true, false].forEach(exportFormatsEnabled => {
       it('displays copy button if `export_formats` FF is enabled', () => {
-        fakeStore.isFeatureEnabled.callsFake(
-          ff => exportFormatsEnabled || ff !== 'export_formats',
+        fakeStore.isFeatureEnabled.callsFake(ff =>
+          ff === 'export_formats' ? exportFormatsEnabled : true,
         );
 
         const wrapper = createComponent();

--- a/src/sidebar/services/annotations-exporter.tsx
+++ b/src/sidebar/services/annotations-exporter.tsx
@@ -275,7 +275,10 @@ export class AnnotationsExporter {
       </html>,
       {},
       { pretty: true },
-    );
+      // `renderToString` indents lines with tabs when using `pretty: true`.
+      // Replacing them with double spaces we avoid side effects when pasting
+      // the result in a web app.
+    ).replace(/\t/g, '  ');
   }
 
   private _exportCommon(

--- a/src/sidebar/services/test/annotations-exporter-test.js
+++ b/src/sidebar/services/test/annotations-exporter-test.js
@@ -292,13 +292,9 @@ ${formattedNow},John Doe,,http://example.com,My group,Annotation,,Annotation tex
         now,
       });
 
-      // The result uses tabs to indent lines.
-      // We can get rid of that for simplicity and just compare the markup
-      const removeAllIndentation = str => str.replace(/^[ \t]+/gm, '');
-
       assert.equal(
-        removeAllIndentation(result),
-        removeAllIndentation(`<html lang="en">
+        result,
+        `<html lang="en">
   <head>
     <title>
       Annotations on &quot;A special document&quot;
@@ -444,7 +440,7 @@ ${formattedNow},John Doe,,http://example.com,My group,Annotation,,Annotation tex
       </article>
     </section>
   </body>
-</html>`),
+</html>`,
       );
     });
   });

--- a/src/sidebar/util/copy-to-clipboard.ts
+++ b/src/sidebar/util/copy-to-clipboard.ts
@@ -7,6 +7,8 @@
  * @throws {Error}
  *   This function may throw an exception if the browser rejects the attempt
  *   to copy text.
+ *
+ * @deprecated Use copyPlainText instead
  */
 export function copyText(text: string) {
   const temp = document.createElement('textarea'); // use textarea instead of input to preserve line breaks
@@ -28,5 +30,37 @@ export function copyText(text: string) {
     document.execCommand('copy');
   } finally {
     temp.remove();
+  }
+}
+
+/**
+ * Copy the string `text` to the clipboard verbatim.
+ *
+ * @throws {Error}
+ *   This function may throw an error if the `clipboard-write` permission was
+ *   not allowed.
+ */
+export async function copyPlainText(text: string, navigator_ = navigator) {
+  await navigator_.clipboard.writeText(text);
+}
+
+/**
+ * Copy the string `text` to the clipboard, rendering HTML if any, instead of
+ * raw markup.
+ *
+ * If the browser does not support this, it will fall back to copy the string
+ * as plain text.
+ *
+ * @throws {Error}
+ *   This function may throw an error if the `clipboard-write` permission was
+ *   not allowed.
+ */
+export async function copyHTML(text: string, navigator_ = navigator) {
+  if (!navigator_.clipboard.write) {
+    await copyPlainText(text, navigator_);
+  } else {
+    const type = 'text/html';
+    const blob = new Blob([text], { type });
+    await navigator_.clipboard.write([new ClipboardItem({ [type]: blob })]);
   }
 }

--- a/src/sidebar/util/copy-to-clipboard.ts
+++ b/src/sidebar/util/copy-to-clipboard.ts
@@ -45,8 +45,7 @@ export async function copyPlainText(text: string, navigator_ = navigator) {
 }
 
 /**
- * Copy the string `text` to the clipboard, rendering HTML if any, instead of
- * raw markup.
+ * Copy the string `text` to the clipboard with an HTML media type.
  *
  * If the browser does not support this, it will fall back to copy the string
  * as plain text.


### PR DESCRIPTION
Part of #5784 

Add a "Copy to clipboard" button to export annotations.

This button, when clicked, will copy the contents to export to the clipboard, instead of downloading a file.

When selected content is HTML, if the browser supports it, the copy will be done in a way that the rich text is copied, instead of the raw HTML markup.

![image](https://github.com/hypothesis/client/assets/2719332/d84b7df7-3ea6-4ae3-bf71-636c3f5c1df6)

### Considerations

* When copying HTML into the clipboard and then pasting it into a document, I'm not getting the same result as when downloading an HTML file, opening it in the browser, selecting and copying everything, and then pasting in a doc.
  I'm still investigating this, but maybe it makes sense to polish it in a follow-up PR.