### PR TITLE
Do not render empty quotes when exporting to Text or HTML

### DIFF
--- a/src/sidebar/services/annotations-exporter.tsx
+++ b/src/sidebar/services/annotations-exporter.tsx
@@ -77,11 +77,12 @@ export class AnnotationsExporter {
 
     const annotationsAsText = annotations.map((annotation, index) => {
       const page = pageLabel(annotation);
+      const annotationQuote = quote(annotation);
       const lines = [
         `Created at: ${formatDateTime(new Date(annotation.created))}`,
         `Author: ${extractUsername(annotation)}`,
         page ? `Page: ${page}` : undefined,
-        `Quote: "${quote(annotation)}"`,
+        annotationQuote ? `Quote: "${annotationQuote}"` : undefined,
         `Comment: ${annotation.text}`,
         annotation.tags.length > 0
           ? `Tags: ${annotation.tags.join(', ')}`
@@ -219,6 +220,8 @@ export class AnnotationsExporter {
             <h1>Annotations</h1>
             {annotations.map((annotation, index) => {
               const page = pageLabel(annotation);
+              const annotationQuote = quote(annotation);
+
               return (
                 <article key={annotation.id}>
                   <h2>Annotation {index + 1}:</h2>
@@ -242,14 +245,16 @@ export class AnnotationsExporter {
                           <td>{page}</td>
                         </tr>
                       )}
-                      <tr>
-                        <td>Quote:</td>
-                        <td>
-                          <blockquote style={{ margin: 0 }}>
-                            {quote(annotation)}
-                          </blockquote>
-                        </td>
-                      </tr>
+                      {annotationQuote && (
+                        <tr>
+                          <td>Quote:</td>
+                          <td>
+                            <blockquote style={{ margin: 0 }}>
+                              {annotationQuote}
+                            </blockquote>
+                          </td>
+                        </tr>
+                      )}
                       <tr>
                         <td>Comment:</td>
                         <td>{annotation.text}</td>

--- a/src/sidebar/services/test/annotations-exporter-test.js
+++ b/src/sidebar/services/test/annotations-exporter-test.js
@@ -90,6 +90,7 @@ describe('AnnotationsExporter', () => {
           ...baseAnnotation,
           user: 'acct:jane@localhost',
           tags: ['foo', 'bar'],
+          target: targetWithSelectors(quoteSelector('The quote')),
         },
         {
           ...baseAnnotation,
@@ -129,14 +130,13 @@ Tags: tag_1, tag_2
 Annotation 2:
 Created at: ${formattedNow}
 Author: bill
-Quote: "null"
 Comment: Annotation text
 Tags: tag_1, tag_2
 
 Annotation 3:
 Created at: ${formattedNow}
 Author: jane
-Quote: "null"
+Quote: "The quote"
 Comment: Annotation text
 Tags: foo, bar
 
@@ -144,7 +144,6 @@ Annotation 4:
 Created at: ${formattedNow}
 Author: bill
 Page: 23
-Quote: "null"
 Comment: Annotation text
 Tags: tag_1, tag_2
 
@@ -152,7 +151,6 @@ Annotation 5:
 Created at: ${formattedNow}
 Author: bill
 Page: iii
-Quote: "null"
 Comment: Annotation text`,
       );
     });
@@ -185,7 +183,6 @@ Total replies: 0
 Annotation 1:
 Created at: ${formattedNow}
 Author: John Doe
-Quote: "null"
 Comment: Annotation text
 Tags: tag_1, tag_2`,
       );
@@ -273,10 +270,10 @@ ${formattedNow},John Doe,,http://example.com,My group,Annotation,,Annotation tex
           ...baseAnnotation,
           user: 'acct:jane@localhost',
           tags: ['foo', 'bar'],
+          target: targetWithSelectors(quoteSelector('The quote')),
         },
         {
           ...baseAnnotation,
-          ...newReply(),
           target: targetWithSelectors(
             quoteSelector('includes <p>HTML</p> tags'),
             pageSelector(23),
@@ -284,6 +281,7 @@ ${formattedNow},John Doe,,http://example.com,My group,Annotation,,Annotation tex
         },
         {
           ...baseAnnotation,
+          ...newReply(),
           tags: [],
           target: targetWithSelectors(pageSelector('iii')),
         },
@@ -370,7 +368,7 @@ ${formattedNow},John Doe,,http://example.com,My group,Annotation,,Annotation tex
             <tr>
               <td>Quote:</td>
               <td>
-                <blockquote style="margin:0px;"></blockquote>
+                <blockquote style="margin:0px;">The quote</blockquote>
               </td>
             </tr>
             <tr>
@@ -436,12 +434,6 @@ ${formattedNow},John Doe,,http://example.com,My group,Annotation,,Annotation tex
             <tr>
               <td>Page:</td>
               <td>iii</td>
-            </tr>
-            <tr>
-              <td>Quote:</td>
-              <td>
-                <blockquote style="margin:0px;"></blockquote>
-              </td>
             </tr>
             <tr>
               <td>Comment:</td>


### PR DESCRIPTION
Part of https://github.com/hypothesis/client/issues/5784

This PR makes sure we do not render a "Quote" field with null value when exporting annotations to HTML or text format, for annotations that do not have one.

This PR is just making sure we don't render information which does not make sense, but there are some improvements that should be made around exporting replies, including referencing the original annotation or user, and clearly "labeling" them as replies.

That's out of this PR's scope though.