### PR TITLE
Only clear search rather than all filter state when closing search panel

### DIFF
--- a/src/sidebar/components/search/SearchPanel.tsx
+++ b/src/sidebar/components/search/SearchPanel.tsx
@@ -19,7 +19,7 @@ export default function SearchPanel() {
       initialFocus={inputRef}
       onActiveChanged={active => {
         if (!active) {
-          store.clearSelection();
+          store.setFilterQuery(null);
         }
       }}
     >

--- a/src/sidebar/components/search/test/SearchPanel-test.js
+++ b/src/sidebar/components/search/test/SearchPanel-test.js
@@ -8,7 +8,6 @@ describe('SearchPanel', () => {
 
   beforeEach(() => {
     fakeStore = {
-      clearSelection: sinon.stub(),
       setFilterQuery: sinon.stub(),
       filterQuery: sinon.stub().returns(null),
       closeSidebarPanel: sinon.stub(),
@@ -36,7 +35,11 @@ describe('SearchPanel', () => {
 
       wrapper.find('SidebarPanel').props().onActiveChanged(active);
 
-      assert.equal(fakeStore.clearSelection.called, !active);
+      if (!active) {
+        assert.calledWith(fakeStore.setFilterQuery, null);
+      } else {
+        assert.notCalled(fakeStore.setFilterQuery);
+      }
     });
   });
 

--- a/src/sidebar/store/modules/filters.ts
+++ b/src/sidebar/store/modules/filters.ts
@@ -149,7 +149,7 @@ const reducers = {
     return { filters: updatedFilters };
   },
 
-  SET_FILTER_QUERY(state: State, action: { query: string }) {
+  SET_FILTER_QUERY(state: State, action: { query: string | null }) {
     return { query: action.query };
   },
 
@@ -217,9 +217,10 @@ function setFilter(filterName: FilterKey, filterOption: FilterOption) {
 }
 
 /**
- * Set the query used to filter displayed annotations.
+ * Set the query used to filter displayed annotations or `null` to clear the
+ * filter.
  */
-function setFilterQuery(query: string) {
+function setFilterQuery(query: string | null) {
   return makeAction(reducers, 'SET_FILTER_QUERY', { query });
 }
 

--- a/src/sidebar/store/modules/test/filters-test.js
+++ b/src/sidebar/store/modules/test/filters-test.js
@@ -138,10 +138,12 @@ describe('sidebar/store/modules/filters', () => {
     });
 
     describe('setFilterQuery', () => {
-      it('sets the filter query', () => {
-        store.setFilterQuery('a-query');
-        assert.equal(getFiltersState().query, 'a-query');
-        assert.equal(store.filterQuery(), 'a-query');
+      ['a-query', '', null].forEach(query => {
+        it('sets the filter query', () => {
+          store.setFilterQuery(query);
+          assert.equal(getFiltersState().query, query);
+          assert.equal(store.filterQuery(), query);
+        });
       });
     });
 


### PR DESCRIPTION
One of the goals of the new search/filter UI is to make it possible to toggle the different filters independently. As part of this, change the behavior of the search panel, in the new search UI only, so that clearing a search does not affect the state of user/page focus filters.

**Testing:**

With the `search_panel` feature flag enabled:

1. Go to http://localhost:3000/pdf/gatsby-section and make sure the page filter is active (it will be when the assignment loads)
2. Execute a search
3. Clear the search by closing the panel or clicking the "X" button in the search panel

On `main`, clearing the search will also toggle the filter state. On this branch, only the search will be cleared.