### PR TITLE
Add annotation type to all annotation export formats

### DIFF
--- a/src/sidebar/helpers/annotation-metadata.ts
+++ b/src/sidebar/helpers/annotation-metadata.ts
@@ -142,7 +142,7 @@ export function isSaved(annotation: Annotation): annotation is SavedAnnotation {
  *
  * @deprecated - Use {@link isSaved} instead
  */
-export function isNew(annotation: Annotation): boolean {
+export function isNew(annotation: APIAnnotationData): boolean {
   return !annotation.id;
 }
 
@@ -173,7 +173,7 @@ export function isPublic(annotation: Annotation): boolean {
  * as opposed to a Page Note which refers to the whole document or a reply,
  * which refers to another annotation.
  */
-function hasSelector(annotation: Annotation): boolean {
+function hasSelector(annotation: APIAnnotationData): boolean {
   return !!(
     annotation.target &&
     annotation.target.length > 0 &&
@@ -208,12 +208,14 @@ export function isHidden(annotation: Annotation): boolean {
  * Highlights are generally identifiable by having no text content AND no tags,
  * but there is some nuance.
  */
-export function isHighlight(annotation: Annotation): boolean {
+export function isHighlight(
+  annotation: Annotation | APIAnnotationData,
+): boolean {
   // `$highlight` is an ephemeral attribute set by the `annotator` on new
   // annotation objects (created by clicking the "highlight" button).
   // It is not persisted and cannot be relied upon, but if it IS present,
   // this is definitely a highlight (one which is not yet saved).
-  if (annotation.$highlight) {
+  if ('$highlight' in annotation && annotation.$highlight) {
     return true;
   }
 
@@ -246,7 +248,7 @@ export function isOrphan(annotation: Annotation): boolean {
 /**
  * Return `true` if the given annotation is a page note.
  */
-export function isPageNote(annotation: Annotation): boolean {
+export function isPageNote(annotation: APIAnnotationData): boolean {
   return !hasSelector(annotation) && !isReply(annotation);
 }
 
@@ -260,7 +262,7 @@ export function isAnnotation(annotation: Annotation): boolean {
 /**
  * Return a human-readable string describing the annotation's role.
  */
-export function annotationRole(annotation: Annotation): string {
+export function annotationRole(annotation: APIAnnotationData): string {
   if (isReply(annotation)) {
     return 'Reply';
   } else if (isHighlight(annotation)) {

--- a/src/sidebar/services/annotations-exporter.tsx
+++ b/src/sidebar/services/annotations-exporter.tsx
@@ -4,6 +4,7 @@ import { escapeCSVValue } from '../../shared/csv';
 import { trimAndDedent } from '../../shared/trim-and-dedent';
 import type { APIAnnotationData, Profile } from '../../types/api';
 import {
+  annotationRole,
   documentMetadata,
   isReply,
   pageLabel,
@@ -82,6 +83,7 @@ export class AnnotationsExporter {
         `Created at: ${formatDateTime(new Date(annotation.created))}`,
         `Author: ${extractUsername(annotation)}`,
         page ? `Page: ${page}` : undefined,
+        `Type: ${annotationRole(annotation)}`,
         annotationQuote ? `Quote: "${annotationQuote}"` : undefined,
         `Comment: ${annotation.text}`,
         annotation.tags.length > 0
@@ -127,7 +129,7 @@ export class AnnotationsExporter {
         pageLabel(annotation) ?? '',
         uri,
         groupName,
-        isReply(annotation) ? 'Reply' : 'Annotation',
+        annotationRole(annotation),
         quote(annotation) ?? '',
         annotation.text,
         annotation.tags.join(','),
@@ -141,7 +143,7 @@ export class AnnotationsExporter {
       'Page',
       'URL',
       'Group',
-      'Annotation/Reply Type',
+      'Type',
       'Quote',
       'Comment',
       'Tags',
@@ -245,6 +247,10 @@ export class AnnotationsExporter {
                           <td>{page}</td>
                         </tr>
                       )}
+                      <tr>
+                        <td>Type:</td>
+                        <td>{annotationRole(annotation)}</td>
+                      </tr>
                       {annotationQuote && (
                         <tr>
                           <td>Quote:</td>

--- a/src/sidebar/services/test/annotations-exporter-test.js
+++ b/src/sidebar/services/test/annotations-exporter-test.js
@@ -1,5 +1,6 @@
 import {
   newAnnotation,
+  newHighlight,
   newReply,
   publicAnnotation,
 } from '../../test/annotation-fixtures';
@@ -123,6 +124,7 @@ Total replies: 1
 Annotation 1:
 Created at: ${formattedNow}
 Author: bill
+Type: Annotation
 Quote: "this is the quote"
 Comment: Annotation text
 Tags: tag_1, tag_2
@@ -130,12 +132,14 @@ Tags: tag_1, tag_2
 Annotation 2:
 Created at: ${formattedNow}
 Author: bill
+Type: Annotation
 Comment: Annotation text
 Tags: tag_1, tag_2
 
 Annotation 3:
 Created at: ${formattedNow}
 Author: jane
+Type: Annotation
 Quote: "The quote"
 Comment: Annotation text
 Tags: foo, bar
@@ -144,6 +148,7 @@ Annotation 4:
 Created at: ${formattedNow}
 Author: bill
 Page: 23
+Type: Reply
 Comment: Annotation text
 Tags: tag_1, tag_2
 
@@ -151,6 +156,7 @@ Annotation 5:
 Created at: ${formattedNow}
 Author: bill
 Page: iii
+Type: Annotation
 Comment: Annotation text`,
       );
     });
@@ -183,6 +189,7 @@ Total replies: 0
 Annotation 1:
 Created at: ${formattedNow}
 Author: John Doe
+Type: Annotation
 Comment: Annotation text
 Tags: tag_1, tag_2`,
       );
@@ -214,6 +221,7 @@ Tags: tag_1, tag_2`,
         },
         {
           ...baseAnnotation,
+          ...newHighlight(),
           tags: [],
           target: targetWithSelectors(pageSelector('iii')),
         },
@@ -226,10 +234,10 @@ Tags: tag_1, tag_2`,
 
       assert.equal(
         result,
-        `Created at,Author,Page,URL,Group,Annotation/Reply Type,Quote,Comment,Tags
+        `Created at,Author,Page,URL,Group,Type,Quote,Comment,Tags
 ${formattedNow},jane,,http://example.com,My group,Annotation,,Annotation text,"foo,bar"
 ${formattedNow},bill,23,http://example.com,My group,Reply,"includes ""double quotes"", and commas",Annotation text,"tag_1,tag_2"
-${formattedNow},bill,iii,http://example.com,My group,Annotation,,Annotation text,`,
+${formattedNow},bill,iii,http://example.com,My group,Highlight,,Annotation text,`,
       );
     });
 
@@ -249,7 +257,7 @@ ${formattedNow},bill,iii,http://example.com,My group,Annotation,,Annotation text
 
       assert.equal(
         result,
-        `Created at,Author,Page,URL,Group,Annotation/Reply Type,Quote,Comment,Tags
+        `Created at,Author,Page,URL,Group,Type,Quote,Comment,Tags
 ${formattedNow},John Doe,,http://example.com,My group,Annotation,,Annotation text,"tag_1,tag_2"`,
       );
     });
@@ -362,6 +370,10 @@ ${formattedNow},John Doe,,http://example.com,My group,Annotation,,Annotation tex
               <td>jane</td>
             </tr>
             <tr>
+              <td>Type:</td>
+              <td>Annotation</td>
+            </tr>
+            <tr>
               <td>Quote:</td>
               <td>
                 <blockquote style="margin:0px;">The quote</blockquote>
@@ -397,6 +409,10 @@ ${formattedNow},John Doe,,http://example.com,My group,Annotation,,Annotation tex
               <td>23</td>
             </tr>
             <tr>
+              <td>Type:</td>
+              <td>Annotation</td>
+            </tr>
+            <tr>
               <td>Quote:</td>
               <td>
                 <blockquote style="margin:0px;">includes &lt;p>HTML&lt;/p> tags</blockquote>
@@ -430,6 +446,10 @@ ${formattedNow},John Doe,,http://example.com,My group,Annotation,,Annotation tex
             <tr>
               <td>Page:</td>
               <td>iii</td>
+            </tr>
+            <tr>
+              <td>Type:</td>
+              <td>Reply</td>
             </tr>
             <tr>
               <td>Comment:</td>


### PR DESCRIPTION
Part of #5784 

This PR adds a `type` field to HTML and Text export formats, for consistency with the CSV format.

The field can have the values `Annotation`, `Reply`, `Highlight` or `Page Note`. This applies to CSV as well, which previously could only have one of the first two.