### PR TITLE
Make sure selected user is live updated on export pannel

### DIFF
--- a/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
+++ b/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
@@ -210,11 +210,12 @@ describe('ExportAnnotations', () => {
       assert.equal(users.length, userEntries.length);
 
       for (const [i, entry] of userEntries.entries()) {
-        const value = users.at(i).prop('value');
+        const user = users.at(i);
+        const value = user.prop('value');
+        const text = user.text();
 
-        assert.equal(value.userid, entry.userid);
-        assert.equal(value.displayName, entry.displayName);
-        assert.equal(value.annotations.length, entry.annotationsCount);
+        assert.equal(value, entry.userid);
+        assert.equal(text, `${entry.displayName}${entry.annotationsCount}`);
       }
     });
   });
@@ -376,14 +377,8 @@ describe('ExportAnnotations', () => {
 
       // Select the user whose annotations we want to export
       const userList = await waitForTestId(wrapper, 'user-select');
-      const option = userList
-        .find(SelectNext.Option)
-        .filterWhere(
-          option => option.prop('value').userid === 'acct:john@example.com',
-        )
-        .first();
       act(() => {
-        userList.prop('onChange')(option.prop('value'));
+        userList.prop('onChange')('acct:john@example.com');
       });
       wrapper.update();
 


### PR DESCRIPTION
Part of #5784

This PR solves a rendering issue introduced at some point while implementing annotations export formats, which caused selected user to not update when creating or deleting annotations while the export panel was open.

This also affected the value being exported or copied to the clipboard, which included outdated information.

With these changes we make sure `selectedUser` (which includes the annotations to export) is updated both if the `Select` value is manually changed, but also if existing annotations change in the background.

### Testing steps

1. Check out this branch
2. Open the export panel and select logged-in user.
3. Create an annotation. The value in the select should reflect the change and increment the number.
4. Delete an annotation. The value in the select should reflect the change and decrement the number.
5. Export annotations, and check the file includes an amount of annotations matching the number displayed.

You can also repeat this, but selecting "All annotations" from the dropdown in step 2.