### PR TITLE
Include extra toast message info when exporting annotations fails

### DIFF
--- a/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
+++ b/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
@@ -216,7 +216,9 @@ function ExportAnnotations({
 
         downloadFile(exportData, mimeType, filename);
       } catch (e) {
-        toastMessenger.error('Exporting annotations failed');
+        toastMessenger.error(`Exporting annotations failed: ${e.message}`, {
+          autoDismiss: false,
+        });
       }
     },
     [
@@ -240,7 +242,9 @@ function ExportAnnotations({
 
       toastMessenger.success('Annotations copied');
     } catch (e) {
-      toastMessenger.error('Copying annotations failed');
+      toastMessenger.error(`Copying annotations failed: ${e.message}`, {
+        autoDismiss: false,
+      });
     }
   }, [buildExportContent, exportFormat.value, toastMessenger]);
 

--- a/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
+++ b/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
@@ -446,7 +446,8 @@ describe('ExportAnnotations', () => {
         assert.calledOnce(fakeAnnotationsExporter.buildJSONExportContent);
         assert.calledWith(
           fakeToastMessenger.error,
-          'Exporting annotations failed',
+          'Exporting annotations failed: Error exporting',
+          { autoDismiss: false },
         );
       });
     });
@@ -512,7 +513,11 @@ describe('ExportAnnotations', () => {
         copyButton.simulate('click');
       });
 
-      assert.calledWith(fakeToastMessenger.error, 'Copying annotations failed');
+      assert.calledWith(
+        fakeToastMessenger.error,
+        'Copying annotations failed: Something failed',
+        { autoDismiss: false },
+      );
     });
   });
 


### PR DESCRIPTION
When exporting annotations fails (either exporting to file or copying to clipboard), we display a generic toast message that doesn't help debugging potential issues.

This PR ensures thrown error message is included in the toast message. It can have technical stuff less useful for end users, but will help us know what went wrong when reported by someone.

It also makes those errors not auto-dismiss, as they can now have more info that's hard to read in the default 5-second interval.

> [!WARNING]  
> By testing this PR I have noticed `autoDismiss: false` has stopped working at some point. I'll address that separately.
> Edit: This is the fix https://github.com/hypothesis/client/pull/6115

### Testing steps

1. Open `sidebar.tsx` and comment `sidebarFrame.allow = 'clipboard-write';` line.
    ```diff
    sidebarFrame.className = 'sidebar-frame';
    -sidebarFrame.allow = 'clipboard-write';
    +// sidebarFrame.allow = 'clipboard-write';
    ```
2. Try to copy annotations to the clipboard in any format.
  ![image](https://github.com/hypothesis/client/assets/2719332/299b35d0-8560-43b0-b4f1-c423d0d817cf)
3. You should see an error toast message with extra information about the missing permission.
  ![image](https://github.com/hypothesis/client/assets/2719332/6f84746b-440d-445e-9eee-285dfea45994)
4. Open `ExportAnnotations.tsx`, and edit the `buildExportContent` function to throw an error as the first statement.
    ```diff
    const buildExportContent = useCallback(
      (format: ExportFormat['value']): string => {
   +   throw new Error('Something went wrong');
        const annotationsToExport =
    ```
5. Try to export annotations file in any format.
  ![image](https://github.com/hypothesis/client/assets/2719332/6f4bb758-d380-422f-b258-b2bf2a9199e5)
6. You should see an error toast message with extra information about the error.
  ![image](https://github.com/hypothesis/client/assets/2719332/161986c4-5d61-4fe1-b751-1259cd044d80)


