### PR TITLE
Fix `autoDismiss` option ignored in toast messages

### DIFF
--- a/src/sidebar/services/test/toast-messenger-test.js
+++ b/src/sidebar/services/test/toast-messenger-test.js
@@ -91,25 +91,25 @@ describe('ToastMessengerService', () => {
       assert.notCalled(fakeStore.addToastMessage);
     });
 
-    it('adds a new error toast message to the store', () => {
-      fakeStore.hasToastMessage.returns(false);
+    [
+      { autoDismiss: undefined, expectedAutoDismiss: true },
+      { autoDismiss: true, expectedAutoDismiss: true },
+      { autoDismiss: false, expectedAutoDismiss: false },
+    ].forEach(({ autoDismiss, expectedAutoDismiss }) => {
+      it('adds a new error toast message to the store', () => {
+        fakeStore.hasToastMessage.returns(false);
 
-      service.error('boo');
+        service.error('boo', { autoDismiss });
 
-      assert.calledWith(
-        fakeStore.addToastMessage,
-        sinon.match({ type: 'error', message: 'boo' }),
-      );
-    });
-
-    it('does not dismiss the message if `autoDismiss` is false', () => {
-      fakeStore.hasToastMessage.returns(false);
-      fakeStore.getToastMessage.returns(undefined);
-
-      service.error('boo', { autoDismiss: false });
-
-      assert.notCalled(fakeStore.getToastMessage);
-      assert.notCalled(fakeStore.removeToastMessage);
+        assert.calledWith(
+          fakeStore.addToastMessage,
+          sinon.match({
+            type: 'error',
+            message: 'boo',
+            autoDismiss: expectedAutoDismiss,
+          }),
+        );
+      });
     });
   });
 

--- a/src/sidebar/services/toast-messenger.ts
+++ b/src/sidebar/services/toast-messenger.ts
@@ -114,6 +114,7 @@ export class ToastMessengerService extends TinyEmitter {
       id,
       message: messageText,
       visuallyHidden,
+      autoDismiss,
     };
 
     this._store.addToastMessage(message);


### PR DESCRIPTION
At some point (probably when we integrated the shared `ToastMessages` component) we stopped forwarding the `autoDismiss` option, which means all toast messages were auto dismissed even with `autoDismiss: false`.

This PR fixes that.