### PR TITLE
Remove `user` property from `focusFilters` state when no user selected

### DIFF
--- a/src/sidebar/store/modules/filters.ts
+++ b/src/sidebar/store/modules/filters.ts
@@ -118,19 +118,21 @@ function focusFiltersFromConfig(focusConfig: FocusConfig): Filters {
 
 const reducers = {
   CHANGE_FOCUS_MODE_USER(state: State, action: { user: FocusUserInfo }) {
+    const focusFilters = { ...state.focusFilters };
     const { user } = focusFiltersFromConfig({ user: action.user });
+
     const focusActive = new Set(state.focusActive);
     if (user !== undefined) {
       focusActive.add('user');
+      focusFilters.user = user;
     } else {
       focusActive.delete('user');
+      delete focusFilters.user;
     }
+
     return {
       focusActive,
-      focusFilters: {
-        ...state.focusFilters,
-        user,
-      },
+      focusFilters,
     };
   },
 

--- a/src/sidebar/store/modules/test/filters-test.js
+++ b/src/sidebar/store/modules/test/filters-test.js
@@ -68,7 +68,7 @@ describe('sidebar/store/modules/filters', () => {
 
         const secondFilterState = getFiltersState();
         assert.deepEqual(secondFilterState.focusActive, new Set());
-        assert.isUndefined(secondFilterState.focusFilters.user);
+        assert.notProperty(secondFilterState.focusFilters, 'user');
       });
     });
 


### PR DESCRIPTION
Several pieces of code tested only for the presence of keys in `focusFilters` to determine whether a focus filter was configured, rather than whether the property was set to a "valid" value for that particular filter. The `changeFocusModeUser` store action would always set this property, instead of removing it when the passed user info was empty (logically meaning "no user is focused").

Fixes https://github.com/hypothesis/client/issues/6109