### PR TITLE
Make selection override other filters

### DIFF
--- a/src/sidebar/helpers/build-thread.ts
+++ b/src/sidebar/helpers/build-thread.ts
@@ -307,18 +307,15 @@ export function buildThread(
 
   let thread = threadAnnotations(annotations);
 
+  // When a selection is present, it overrides other filters.
   if (hasSelection) {
-    // Remove threads (annotations) that are not selected or
-    // are not forced-visible
     thread.children = thread.children.filter(child => {
       const isSelected = options.selected.includes(child.id);
       const isForcedVisible =
         hasForcedVisible && options.forcedVisible.includes(child.id);
       return isSelected || isForcedVisible;
     });
-  }
-
-  if (options.threadFilterFn) {
+  } else if (options.threadFilterFn) {
     // Remove threads not matching thread-level filters
     thread.children = thread.children.filter(options.threadFilterFn);
   }
@@ -329,6 +326,12 @@ export function buildThread(
   // are the top-level annotations.
   thread.visible = false;
   thread = mapThread(thread, thread => {
+    if (hasSelection) {
+      // When a selection is active, make the full conversation thread for
+      // each selected annotation visible.
+      return { ...thread, visible: true };
+    }
+
     let threadIsVisible = thread.visible;
 
     if (options.filterFn) {

--- a/src/sidebar/helpers/test/build-thread-test.js
+++ b/src/sidebar/helpers/test/build-thread-test.js
@@ -413,16 +413,27 @@ describe('sidebar/helpers/build-thread', () => {
 
     context('when there is a selection', () => {
       it('shows only selected annotations', () => {
-        const thread = createThread(SIMPLE_FIXTURE, {
-          selected: ['1'],
-        });
+        const thread = createThread(
+          SIMPLE_FIXTURE,
+          {
+            selected: ['1'],
+
+            // Other thread and annotation-level filters should be ignored
+            // when there is a selection.
+            threadFilterFn: () => false,
+            filterFn: () => false,
+          },
+          ['visible'],
+        );
         assert.deepEqual(thread, [
           {
             annotation: SIMPLE_FIXTURE[0],
+            visible: true,
             children: [
               {
                 annotation: SIMPLE_FIXTURE[2],
                 children: [],
+                visible: true,
               },
             ],
           },

--- a/src/sidebar/store/modules/filters.ts
+++ b/src/sidebar/store/modules/filters.ts
@@ -176,16 +176,6 @@ const reducers = {
       focusActive,
     };
   },
-
-  // Actions defined in other modules
-
-  CLEAR_SELECTION() {
-    return {
-      filters: {},
-      focusActive: new Set<FilterKey>(),
-      query: null,
-    };
-  },
 };
 
 // Action creators

--- a/src/sidebar/store/modules/test/filters-test.js
+++ b/src/sidebar/store/modules/test/filters-test.js
@@ -179,22 +179,6 @@ describe('sidebar/store/modules/filters', () => {
         assert.deepEqual(store.getFocusActive(), new Set(['user', 'page']));
       });
     });
-
-    describe('CLEAR_SELECTION', () => {
-      it('responds to CLEAR_SELECTION by clearing filters and focus', () => {
-        store.changeFocusModeUser({
-          username: 'testuser',
-          displayName: 'Test User',
-        });
-        store.toggleFocusMode({ active: true });
-
-        assert.deepEqual(store.getFocusActive(), new Set(['user']));
-
-        store.clearSelection();
-
-        assert.deepEqual(store.getFocusActive(), new Set());
-      });
-    });
   });
 
   describe('selectors', () => {


### PR DESCRIPTION
When the user clicks highlight(s) in the document and makes a "selection" in the
sidebar, we want the selected threads to always be visible. Previously this was
handled by clearing other types of filter when the selection was made, in
addition to setting the selection. This however meant that after the selection
was cleared, the state was different than prior to making the selection, with
any non-selection filters being disabled.

This commit changes the behavior so that the selection, if present, temporarily
overrides other filters rather than being combined with them. This allows the
selection to later be removed to revert back to the previous state.

Part of https://github.com/hypothesis/client/issues/6006

---

**Testing:**

1. Go to http://localhost:3000/pdf/gatsby-section and make some annotations that are inside the page range focus (10-30) and outside
2. Click on highlights that are inside and separately outside these ranges. When clicked, the corresponding highlight should appear in the sidebar whether or not it matches the filter
3. When a selection is made in the sidebar, it should not change the state of the page range filter
4. Clear the selection in the sidebar, it should not change the state of the page range filter
5. Apply a search in the sidebar while a selection is active. This should clear the selection. Similarly toggling the filter should also clear the selection.

A known behavior which may be surprising is that making a selection does not clear the search bar. That remains populated, but the selection takes precedence. One way we could handle this would be by disabling the UI controls that correspond to the overridden filters when a selection is present. That is not implemented yet however.