### PR TITLE
Protect the sidebar's iframe `allow` attribute

### DIFF
--- a/src/annotator/sidebar.tsx
+++ b/src/annotator/sidebar.tsx
@@ -70,7 +70,7 @@ export type SidebarContainerConfig = {
 /**
  * Create the iframe that will load the sidebar application.
  */
-function createSidebarIframe(config: SidebarConfig): HTMLIFrameElement {
+export function createSidebarIframe(config: SidebarConfig): HTMLIFrameElement {
   const sidebarURL = config.sidebarAppUrl;
   const sidebarAppSrc = addConfigFragment(
     sidebarURL,
@@ -79,15 +79,20 @@ function createSidebarIframe(config: SidebarConfig): HTMLIFrameElement {
 
   const sidebarFrame = document.createElement('iframe');
 
-  // Enable media in annotations to be shown fullscreen
-  sidebarFrame.setAttribute('allowfullscreen', '');
-
   sidebarFrame.src = sidebarAppSrc;
   sidebarFrame.title = 'Hypothesis annotation viewer';
   sidebarFrame.className = 'sidebar-frame';
-  sidebarFrame.allow = 'clipboard-write';
 
-  return sidebarFrame;
+  // Enable media in annotations to be shown fullscreen, and allow copying to
+  // the clipboard.
+  sidebarFrame.allow = 'fullscreen; clipboard-write';
+
+  // In viahtml, pywb uses wombat.js, which monkey-patches some JS methods.
+  // One of those causes the `allow` attribute to be overwritten, so we want to
+  // make it non-writable to preserve the permissions we set above.
+  return Object.defineProperty(sidebarFrame, 'allow', {
+    writable: false,
+  });
 }
 
 type GestureState = {

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -1,7 +1,7 @@
 import { TinyEmitter } from 'tiny-emitter';
 
 import { addConfigFragment } from '../../shared/config-fragment';
-import { Sidebar, MIN_RESIZE, $imports } from '../sidebar';
+import { Sidebar, MIN_RESIZE, $imports, createSidebarIframe } from '../sidebar';
 import { Emitter } from '../util/emitter';
 
 const DEFAULT_WIDTH = 350;
@@ -1136,6 +1136,16 @@ describe('Sidebar', () => {
       onSelectAnnotations(tags, toggle);
 
       assert.calledWith(guestRPC().call, 'selectAnnotations', tags, true);
+    });
+  });
+
+  describe('createSidebarIframe', () => {
+    it('does not let `allow` attribute to be overwritten', () => {
+      const iframe = createSidebarIframe({ sidebarAppUrl: 'https://foo.com' });
+
+      assert.throws(() => {
+        iframe.allow = 'something else';
+      }, "Cannot assign to read only property 'allow' of object '#<HTMLIFrameElement>'");
     });
   });
 });


### PR DESCRIPTION
This PR does a couple of changes to how we enable permissions in the sidebar's iframe.

* It "protects" the `allow` attribute itself from being overwritten, by using `Object.defineProperty(sidebarFrame, 'allow', ...)`. This is needed because when loading the client in viahtml, it includes a library which monkey-patches a few javascript methods.
  Among other things, when that library detects an iframe being appended to an element via `appendChild`, it overwrites the `allow` attribute with some hardcoded value, breaking copy export annotations to the clipboard.
  See https://github.com/webrecorder/wombat/issues/133
* Additionally, it migrates from the `allowfullscreen` attribute to setting `fullscreen` as one of the values for the `allow` attribute, as `allowfullscreen` is legacy. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#allowfullscreen

### Testing steps

1. Check out this branch
2. Make sure `export_formats` feature is enabled in http://localhost:5000/admin/features
3. Open viahtml locally, and run `./bin/build_static.py`. This will copy and expose pywb static assets, including wombat.js
4. Go to http://localhost:9083/https://www.example.com/ and create some annotation if there's none.
5. Open the export panel, and click "Copy to clipboard". You should see a success toast message.

In `main` branch, the last step would result in an error.

### Todo

- [x] Cover logic with tests
- [x] Document testing steps locally and with via/viahtml