### PR TITLE
Export CSV separated with tab when copied to clipboard

### DIFF
--- a/src/shared/csv.ts
+++ b/src/shared/csv.ts
@@ -1,13 +1,15 @@
+export type CSVSeparator = ',' | '\t';
+
 /**
  * Escape a CSV field value (see https://www.ietf.org/rfc/rfc4180.txt)
  *
  * - foo -> foo
  * - foo,bar -> "foo,bar"
  * - with "quoted" text -> "with ""quoted"" text"
+ *
+ * @param separator - Indicates the separator used in the CSV
  */
-export function escapeCSVValue(value: string): string {
-  if (/[",\n\r]/.test(value)) {
-    return `"${value.replace(/"/g, '""')}"`;
-  }
-  return value;
+export function escapeCSVValue(value: string, separator: CSVSeparator): string {
+  const regexp = new RegExp(`["\n\r${separator}]`);
+  return regexp.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
 }

--- a/src/shared/test/csv-test.js
+++ b/src/shared/test/csv-test.js
@@ -4,6 +4,7 @@ describe('escapeCSVValue', () => {
   [
     { value: 'foo', expected: 'foo' },
     { value: 'foo,bar', expected: '"foo,bar"' },
+    { value: 'foo,bar', expected: 'foo,bar', separator: '\t' },
     { value: 'with \r carriage return', expected: '"with \r carriage return"' },
     {
       value: `multiple
@@ -12,9 +13,11 @@ describe('escapeCSVValue', () => {
     lines"`,
     },
     { value: 'with "quotes"', expected: '"with ""quotes"""' },
-  ].forEach(({ value, expected }) => {
+    { value: 'foo\tbar', expected: 'foo\tbar' },
+    { value: 'foo\tbar', expected: '"foo\tbar"', separator: '\t' },
+  ].forEach(({ value, expected, separator = ',' }) => {
     it('escapes values', () => {
-      assert.equal(escapeCSVValue(value), expected);
+      assert.equal(escapeCSVValue(value, separator), expected);
     });
   });
 });

--- a/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
+++ b/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
@@ -148,7 +148,7 @@ function ExportAnnotations({
   const [customFilename, setCustomFilename] = useState<string>();
 
   const buildExportContent = useCallback(
-    (format: ExportFormat['value']): string => {
+    (format: ExportFormat['value'], context: 'file' | 'clipboard'): string => {
       const annotationsToExport =
         selectedUserAnnotations?.annotations ?? exportableAnnotations;
       switch (format) {
@@ -173,6 +173,10 @@ function ExportAnnotations({
           return annotationsExporter.buildCSVExportContent(
             annotationsToExport,
             {
+              // We want to use tabs when copying to clipboard, so that it's
+              // possible to paste in apps like Google Sheets or OneDrive Excel.
+              // They do not properly populate a grid for comma-based CSV.
+              separator: context === 'file' ? ',' : '\t',
               groupName: group?.name,
               defaultAuthority,
               displayNamesEnabled,
@@ -211,7 +215,7 @@ function ExportAnnotations({
       try {
         const format = exportFormat.value;
         const filename = `${customFilename ?? defaultFilename}.${format}`;
-        const exportData = buildExportContent(format);
+        const exportData = buildExportContent(format, 'file');
         const mimeType = formatToMimeType(format);
 
         downloadFile(exportData, mimeType, filename);
@@ -231,7 +235,7 @@ function ExportAnnotations({
   );
   const copyAnnotationsExport = useCallback(async () => {
     const format = exportFormat.value;
-    const exportData = buildExportContent(format);
+    const exportData = buildExportContent(format, 'clipboard');
 
     try {
       if (format === 'html') {


### PR DESCRIPTION
Closes #6110 

This PR makes annotations exported as CSV use the comma character when exporting to a file, but the tab (`\t`) when copying to the clipboard.

This makes pasting the content into web-based spreadsheets work out of the box, in a way that the values are pasted in multiple cells and properly form a grid.

> [!TIP]
> This PR is easier to review [ignoring whitespaces](https://github.com/hypothesis/client/pull/6127/files?w=1), due to some indentation changes in tests.

### Testing steps

1. Check out this branch
2. Export annotations to a CSV file. Verify it uses the comma.
3. Copy annotations to clipboard as CSV. Verify in uses the tab if you paste into a plain text editor.
4. Paste into Google Sheets or OneDrive Excel. Verify the grid values are properly set. 

### TODO

- [x] Add more tests