### PR TITLE
Make search/clear buttons visually part of the input field

### DIFF
--- a/src/sidebar/components/search/SearchField.tsx
+++ b/src/sidebar/components/search/SearchField.tsx
@@ -90,7 +90,7 @@ export default function SearchField({
         <IconButton
           // Vertically center icon on left side of input. Increase the text
           // size to make the icon the same size as the top bar icons.
-          classes="absolute left-1 text-[16px] top-[50%] translate-y-[-50%]"
+          classes="absolute left-0 text-[16px] top-[50%] translate-y-[-50%]"
           icon={SearchIcon}
           size="lg"
           title="Search"
@@ -100,7 +100,7 @@ export default function SearchField({
         <Input
           aria-label="Search annotations"
           classes={classnames(
-            'pl-9 pr-9', // Add padding so input does not overlap search/clear buttons.
+            'pl-8 pr-8', // Add padding so input does not overlap search/clear buttons.
             'disabled:text-grey-6', // Dim text when input is disabled
           )}
           data-testid="search-input"
@@ -117,7 +117,7 @@ export default function SearchField({
         />
         {pendingQuery && (
           <IconButton
-            classes="absolute right-1 text-[16px] top-[50%] translate-y-[-50%]"
+            classes="absolute right-0 text-[16px] top-[50%] translate-y-[-50%]"
             size="lg"
             icon={CancelIcon}
             data-testid="clear-button"

--- a/src/sidebar/components/search/SearchField.tsx
+++ b/src/sidebar/components/search/SearchField.tsx
@@ -2,7 +2,6 @@ import {
   CancelIcon,
   IconButton,
   Input,
-  InputGroup,
   SearchIcon,
   useSyncedRef,
 } from '@hypothesis/frontend-shared';
@@ -87,9 +86,13 @@ export default function SearchField({
       onSubmit={onSubmit}
       className={classnames('space-y-3', classes)}
     >
-      <InputGroup>
+      <div className="relative">
         <IconButton
+          // Vertically center icon on left side of input. Increase the text
+          // size to make the icon the same size as the top bar icons.
+          classes="absolute left-1 text-[16px] top-[50%] translate-y-[-50%]"
           icon={SearchIcon}
+          size="lg"
           title="Search"
           type="submit"
           disabled={disabled}
@@ -97,9 +100,8 @@ export default function SearchField({
         <Input
           aria-label="Search annotations"
           classes={classnames(
-            'p-1.5',
-            'transition-[max-width] duration-300 ease-out',
-            'disabled:text-grey-6',
+            'pl-9 pr-9', // Add padding so input does not overlap search/clear buttons.
+            'disabled:text-grey-6', // Dim text when input is disabled
           )}
           data-testid="search-input"
           dir="auto"
@@ -115,6 +117,8 @@ export default function SearchField({
         />
         {pendingQuery && (
           <IconButton
+            classes="absolute right-1 text-[16px] top-[50%] translate-y-[-50%]"
+            size="lg"
             icon={CancelIcon}
             data-testid="clear-button"
             title="Clear search"
@@ -122,7 +126,7 @@ export default function SearchField({
             disabled={disabled}
           />
         )}
-      </InputGroup>
+      </div>
     </form>
   );
 }


### PR DESCRIPTION
Align the styling of the search/clear buttons with the mocks [1] by:

 - Making the icons visually part of the input field
 - Increasing their size to match the top bar icons
 - Adjusting the padding

The implementation of the styling follows the way the "clear" button is implemented in Via's search field. We will probably want to extract a shared component in the pattern library in future.

[1] https://github.com/hypothesis/client/issues/6006#issuecomment-1887328191

---

**Before:**

<img width="483" alt="Search field before" src="https://github.com/hypothesis/client/assets/2458/53ead0bb-0ca4-4da7-b665-e81e42649922">

**After:**

<img width="478" alt="Search field after" src="https://github.com/hypothesis/client/assets/2458/ebb7a151-a4a6-404d-98ea-aabd488aaf77">
