### PR TITLE
Fix top bar toggle buttons extending outside top bar on touch devices

### DIFF
--- a/src/sidebar/components/TopBar.tsx
+++ b/src/sidebar/components/TopBar.tsx
@@ -1,3 +1,4 @@
+import type { IconButtonProps } from '@hypothesis/frontend-shared';
 import { LinkButton, HelpIcon, ShareIcon } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 
@@ -33,6 +34,26 @@ export type TopBarProps = {
   frameSync: FrameSyncService;
   settings: SidebarSettings;
 };
+
+/**
+ * Toggle button for the top bar, with a background to indicate its "pressed"
+ * state.
+ */
+export function TopBarToggleButton(buttonProps: IconButtonProps) {
+  return (
+    <PressableIconButton
+      // The containing form has a white background. The top bar is only
+      // 40px high. If we allow standard touch-minimum height here (44px),
+      // the visible white background exceeds the height of the top bar in
+      // touch contexts. Disable touch sizing via `size="custom"`, then
+      // add back the width rule and padding to keep horizontal spacing
+      // consistent.
+      size="custom"
+      classes="touch:min-w-touch-minimum p-1"
+      {...buttonProps}
+    />
+  );
+}
 
 /**
  * The toolbar which appears at the top of the sidebar providing actions
@@ -105,23 +126,21 @@ function TopBar({
               )}
               {searchPanelEnabled && <SearchIconButton />}
               <SortMenu />
-              <PressableIconButton
+              <TopBarToggleButton
                 icon={ShareIcon}
                 expanded={isAnnotationsPanelOpen}
                 pressed={isAnnotationsPanelOpen}
                 onClick={toggleSharePanel}
-                size="xs"
                 title="Share annotations on this page"
                 data-testid="share-icon-button"
               />
             </>
           )}
-          <PressableIconButton
+          <TopBarToggleButton
             icon={HelpIcon}
             expanded={isHelpPanelOpen}
             pressed={isHelpPanelOpen}
             onClick={requestHelp}
-            size="xs"
             title="Help"
             data-testid="help-icon-button"
           />

--- a/src/sidebar/components/search/SearchIconButton.tsx
+++ b/src/sidebar/components/search/SearchIconButton.tsx
@@ -5,7 +5,7 @@ import { useShortcut } from '../../../shared/shortcut';
 import { isMacOS } from '../../../shared/user-agent';
 import type { SidebarStore } from '../../store';
 import { useSidebarStore } from '../../store';
-import PressableIconButton from '../PressableIconButton';
+import { TopBarToggleButton } from '../TopBar';
 
 /**
  * Respond to keydown events on the document (shortcut keys):
@@ -61,20 +61,12 @@ export default function SearchIconButton() {
     <>
       {isLoading && <Spinner />}
       {!isLoading && (
-        <PressableIconButton
+        <TopBarToggleButton
           icon={SearchIcon}
           expanded={isSearchPanelOpen}
           pressed={isSearchPanelOpen}
           onClick={toggleSearchPanel}
           title="Search annotations"
-          // The containing form has a white background. The top bar is only
-          // 40px high. If we allow standard touch-minimum height here (44px),
-          // the visible white background exceeds the height of the top bar in
-          // touch contexts. Disable touch sizing via `size="custom"`, then
-          // add back the width rule and padding to keep horizontal spacing
-          // consistent.
-          size="custom"
-          classes="touch:min-w-touch-minimum p-1"
         />
       )}
     </>


### PR DESCRIPTION
There was already a solution for this issue implemented in `SearchIconButton`. Extract that into a component that the other top bar buttons can use.

Part of https://github.com/hypothesis/client/issues/6131.

**Before:** See screenshot in https://github.com/hypothesis/client/issues/6131
**After:**

<img width="538" alt="Top bar new toggle buttons" src="https://github.com/hypothesis/client/assets/2458/7970f55e-fa44-4319-b71d-bc8f2a963d15">

The buttons still don't look amazing because of the spacing between them, but at least they are not extending beyond the borders of the top bar any more.