### PR TITLE
Increase input font size for touch devices

### DIFF
--- a/src/sidebar/components/TagEditor.tsx
+++ b/src/sidebar/components/TagEditor.tsx
@@ -1,5 +1,6 @@
 import { useElementShouldClose } from '@hypothesis/frontend-shared';
 import { Input } from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
 import { useRef, useState } from 'preact/hooks';
 
 import { withServices } from '../service-context';
@@ -277,6 +278,10 @@ function TagEditor({
           aria-label="Add tags"
           dir="auto"
           role="combobox"
+          classes={classnames(
+            // Larger font on touch devices
+            'text-base touch:text-touch-base',
+          )}
         />
         <AutocompleteList
           id={`${tagEditorId}-AutocompleteList`}

--- a/src/sidebar/components/search/SearchField.tsx
+++ b/src/sidebar/components/search/SearchField.tsx
@@ -102,6 +102,7 @@ export default function SearchField({
           classes={classnames(
             'pl-8 pr-8', // Add padding so input does not overlap search/clear buttons.
             'disabled:text-grey-6', // Dim text when input is disabled
+            'text-base touch:text-touch-base', // Larger font on touch devices
           )}
           data-testid="search-input"
           dir="auto"


### PR DESCRIPTION
This fixes an issue on smaller iOS devices (eg. iPhone) where the browser zooms in when an input field with < 16px font size is tapped. This change ought to be applied to the `Input` component in the pattern library, but until then, apply it to input fields in the client.

This change was taken from the `MarkdownEditor` component.