### PR TITLE
Copy raw HTML to clipboard together with rich HTML

### DIFF
--- a/src/sidebar/util/test/copy-to-clipboard-test.js
+++ b/src/sidebar/util/test/copy-to-clipboard-test.js
@@ -72,7 +72,17 @@ describe('copy-to-clipboard', () => {
 
       await copyHTML(text, createFakeNavigator({ write }));
 
-      assert.called(write);
+      assert.calledOnce(write);
+
+      const [clipboardItem] = write.lastCall.args[0];
+      const getTextForType = async type => {
+        const blob = await clipboardItem.getType(type);
+        return blob.text();
+      };
+
+      assert.deepEqual(clipboardItem.types, ['text/html', 'text/plain']);
+      assert.equal(await getTextForType('text/html'), text);
+      assert.equal(await getTextForType('text/plain'), text);
     });
 
     it('falls back to execCommand if clipboard API is not supported', async () => {
@@ -92,6 +102,7 @@ describe('copy-to-clipboard', () => {
 
       assert.calledWith(document.execCommand, 'copy');
       assert.equal(clipboardData.getData('text/html'), text);
+      assert.equal(clipboardData.getData('text/plain'), text);
     });
   });
 });


### PR DESCRIPTION
> Depends on https://github.com/hypothesis/client/pull/6135

When copying HTML annotations to the clipboard, we do it using `text/html` media type. This allows the rendered version of the HTML to be then pasted into rich text editors, preserving format.

However, this makes it impossible to paste any content into a plain text editor, which can be counter intuitive.

This PR makes sure we continue copying the rendered HTML using `text/html`, but additionally, we also copy the raw HTML markup as `text/plain`, allowing to paste something in plain text contexts.

### Testing steps

1. Open the export annotations panel.
2. Select HTML from the dropdown.
3. Click `Copy to clipboard`.
4. Paste into a a rich text editor, like Google Docs -> It should paste rich text.
5. Paste into a plain text editor, like VS code -> It should paste the HTML markup.

This should work on every browser consistently. 