### PR TITLE
Make filter toggle row wrap and truncate long labels

### DIFF
--- a/src/sidebar/components/search/FilterControls.tsx
+++ b/src/sidebar/components/search/FilterControls.tsx
@@ -72,7 +72,7 @@ function FilterToggle({
       title={description}
     >
       {IconComponent && <IconComponent className="w-em h-em" />}
-      {label}
+      <span className="max-w-36 truncate">{label}</span>
       <div
         // Vertical divider line between label and active/inactive state.
         // This should fill the button vertically.
@@ -155,7 +155,7 @@ export default function FilterControls({
   return (
     <Container>
       <div
-        className="flex flex-row gap-x-2 items-center"
+        className="flex flex-row flex-wrap gap-x-2 gap-y-2 items-center"
         data-testid="filter-controls"
       >
         <b>Filters</b>

--- a/src/sidebar/components/search/FilterControls.tsx
+++ b/src/sidebar/components/search/FilterControls.tsx
@@ -155,7 +155,7 @@ export default function FilterControls({
   return (
     <Container>
       <div
-        className="flex flex-row flex-wrap gap-x-2 gap-y-2 items-center"
+        className="flex flex-row flex-wrap gap-2 items-center"
         data-testid="filter-controls"
       >
         <b>Filters</b>


### PR DESCRIPTION
Prevent the filter toggle button row from overflowing the containing panel by wrapping onto multiple lines if needed, and truncate long labels within individual toggle buttons if needed.

Fixes https://github.com/hypothesis/client/issues/6140

**Truncation of long labels:**

<img width="486" alt="Filter toggle truncation" src="https://github.com/hypothesis/client/assets/2458/de5ead27-425f-4bff-a685-12c6d0dc84d1">

**Filter toggle row wrapping:**

<img width="391" alt="Filter toggle wrap" src="https://github.com/hypothesis/client/assets/2458/db7002e1-f6cd-42ee-a800-a6b4c29b2a53">
