### PR TITLE
Attempt to fix issues #531 and #5202, annotation error due to URI encoding error

### DIFF
--- a/src/annotator/integrations/html-metadata.ts
+++ b/src/annotator/integrations/html-metadata.ts
@@ -47,16 +47,23 @@ export class HTMLMetadata {
    * Returns the primary URI for the document being annotated
    */
   uri(): string {
-    let uri = decodeURIComponent(this._getDocumentHref());
+    let uri = this._getDocumentHref(); // Get the URI without decoding it first
 
-    // Use the `link[rel=canonical]` element's href as the URL if present.
+    // Attempt to decode the URI, handle exceptions if the URI is malformed
+    try {
+      uri = decodeURIComponent(uri);
+    } catch (error) {
+      // Log error for debugging. After this point we fall back to the original URI
+      console.error('Error decoding URI:', error);
+    }
+
+    // Use the `link[rel=canonical]` element's href as the URI if present.
     const links = this._getLinks();
     for (const link of links) {
       if (link.rel === 'canonical') {
-        uri = link.href;
+        uri = link.href; // Assuming canonical hrefs are correctly encoded
       }
     }
-
     return uri;
   }
 

--- a/src/annotator/integrations/test/html-metadata-test.js
+++ b/src/annotator/integrations/test/html-metadata-test.js
@@ -405,5 +405,24 @@ describe('HTMLMetadata', () => {
 
       assert.equal(doc.uri(), canonicalLink.href);
     });
+
+    it('should log an error if URI is not decodable', () => {
+      // '%%CUST_ID%%' is an invalid escape sequence, so it will throw a URIError when decoded
+      const badURI = 'https://example.com/?foo=%%CUST_ID%%';
+      const doc = createDoc(badURI);
+      const consoleErrorSpy = sinon.stub(console, 'error');
+
+      try {
+        assert.equal(badURI, doc.uri());
+        assert.calledOnce(consoleErrorSpy);
+        assert.calledWith(
+          consoleErrorSpy,
+          'Error decoding URI:',
+          sinon.match.instanceOf(URIError),
+        );
+      } finally {
+        console.error.restore();
+      }
+    });
   });
 });


### PR DESCRIPTION
Implemented a change to the `HTMLMetadata` class in `html-metadata.ts` to address a URI encoding issue that prevented annotations from being made.

Specifically, the URI decoding process is now wrapped in a try-catch block. If `URIError` is caught, the original encoded URI is used instead and the error is logged using `console.error`.

This way URIs that previously were successfully decoded will be unaffected and existing annotations do not go missing.

Have not run into any issues by not decoding the URI, and seems to work for the pages mentioned in issues #5202 and #531.

Is there maybe a better approach or some edge case that will cause this approach to fail?