### PR TITLE
Put plain text and rich text formats next to each other

### DIFF
--- a/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
+++ b/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
@@ -56,16 +56,16 @@ const exportFormats: ExportFormat[] = [
     description: 'For import into word processors as plain text',
   },
   {
-    value: 'csv',
-    title: 'Table (CSV)',
-    shortTitle: 'CSV',
-    description: 'For import into a spreadsheet',
-  },
-  {
     value: 'html',
     title: 'Rich text (HTML)',
     shortTitle: 'HTML',
     description: 'For import into word processors as rich text',
+  },
+  {
+    value: 'csv',
+    title: 'Table (CSV)',
+    shortTitle: 'CSV',
+    description: 'For import into a spreadsheet',
   },
 ];
 

--- a/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
+++ b/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
@@ -269,13 +269,13 @@ describe('ExportAnnotations', () => {
       optionText(1, 'description'),
       'For import into word processors as plain text',
     );
-    assert.equal(optionText(2, 'name'), 'Table (CSV)');
-    assert.equal(optionText(2, 'description'), 'For import into a spreadsheet');
-    assert.equal(optionText(3, 'name'), 'Rich text (HTML)');
+    assert.equal(optionText(2, 'name'), 'Rich text (HTML)');
     assert.equal(
-      optionText(3, 'description'),
+      optionText(2, 'description'),
       'For import into word processors as rich text',
     );
+    assert.equal(optionText(3, 'name'), 'Table (CSV)');
+    assert.equal(optionText(3, 'description'), 'For import into a spreadsheet');
   });
 
   [


### PR DESCRIPTION
As discussed in https://hypothes-is.slack.com/archives/C4K6M7P5E/p1706197127224849?thread_ts=1706141764.601489&cid=C4K6M7P5E, this PR puts `Plain text` and `Rich text` formats next to each other in the format selection dropdown.

Before:

![image](https://github.com/hypothesis/client/assets/2719332/8c20748d-fb80-4512-b8e8-b2ed167ecfa7)

After:

![image](https://github.com/hypothesis/client/assets/2719332/c3ef0581-9663-4501-8674-ee665c8e6ccf)
