### PR TITLE
Set required permissions in notebook iframe

### DIFF
--- a/src/annotator/components/NotebookModal.tsx
+++ b/src/annotator/components/NotebookModal.tsx
@@ -35,12 +35,7 @@ function NotebookIframe({ config, groupId }: NotebookIframeProps) {
     <iframe
       title={'Hypothesis annotation notebook'}
       className="h-full w-full border-0"
-      // Enable media in annotations to be shown fullscreen.
-      // TODO: Use `allow="fullscreen" once `allow` attribute available for
-      // iframe elements in all supported browsers
-      // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-allow
-      // eslint-disable-next-line react/no-unknown-property
-      allowFullScreen
+      allow="fullscreen; clipboard-write"
       src={notebookAppSrc}
     />
   );


### PR DESCRIPTION
With the migration from the deprecated `copyText` function to `copyPlainText` in https://github.com/hypothesis/client/pull/6155, it is now needed to require the `clipboard-write` permission when opening the notebook, otherwise, copying to the clipboard doesn't work in Google Chrome.

This PR fixes that, and also addresses an old `TODO` comment mentioning `allow="fullscreen"` should be used instead of the `allowfullscreen` deprecated attribute.

### Testing steps

1. Using Google Chrome, open the notebook
2. Click on "Share" for any annotation.
3. In the popover, click the "Copy to clipboard" button.
4. You should see a success toast message.

In `main`, an error toast message would be displayed instead, and the content would not be copied.