### PR TITLE
Use ModalDialog in the notebook

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.16.7",
     "@hypothesis/frontend-build": "^3.0.0",
-    "@hypothesis/frontend-shared": "^7.2.0",
+    "@hypothesis/frontend-shared": "^7.3.0",
     "@hypothesis/frontend-testing": "^1.2.0",
     "@npmcli/arborist": "^7.0.0",
     "@octokit/rest": "^20.0.1",

--- a/src/annotator/components/test/NotebookModal-test.js
+++ b/src/annotator/components/test/NotebookModal-test.js
@@ -14,12 +14,13 @@ describe('NotebookModal', () => {
 
   const outerSelector = '[data-testid="notebook-outer"]';
 
-  const createComponent = config => {
+  const createComponent = ({ attachTo, ...config } = {}) => {
     const component = mount(
       <NotebookModal
         eventBus={eventBus}
         config={{ notebookAppUrl: notebookURL, ...config }}
       />,
+      { attachTo },
     );
     components.push(component);
     return component;
@@ -104,6 +105,26 @@ describe('NotebookModal', () => {
       addConfigFragment(notebookURL, { group: '2' }),
     );
     assert.notEqual(iframe1.getDOMNode(), iframe3.getDOMNode());
+  });
+
+  it('focuses iframe when the notebook is opened', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    try {
+      const wrapper = createComponent({ attachTo: container });
+
+      // The body is initially focused
+      assert.equal(document.activeElement, document.body);
+
+      emitter.publish('openNotebook', '1');
+      wrapper.update();
+
+      // Once notebook is opened, focus transitions to iframe
+      assert.equal(document.activeElement, wrapper.find('iframe').getDOMNode());
+    } finally {
+      container.remove();
+    }
   });
 
   it('makes the document unscrollable on "openNotebook" event', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1995,15 +1995,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^7.2.0":
-  version: 7.2.0
-  resolution: "@hypothesis/frontend-shared@npm:7.2.0"
+"@hypothesis/frontend-shared@npm:^7.3.0":
+  version: 7.3.0
+  resolution: "@hypothesis/frontend-shared@npm:7.3.0"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^2.10.0-alpha.1
   peerDependencies:
     preact: ^10.4.0
-  checksum: fe4b515e0f856dcb6c9876e52aba2a262d1bf6cebb13176b6ee2a676df719e2331106ee1595e2de057843fe7ebe8ac03f3a8f568fb03f50b3ea0622496da2ead
+  checksum: 5b295e0cb949c858d70c96ab24e7ec387d31e4a0e5bde6555ba70843cdceaae030a119e20841fa4924888db618c7fa47bdd4f83a3be65da889ad702506cc75f4
   languageName: node
   linkType: hard
 
@@ -7793,7 +7793,7 @@ __metadata:
     "@babel/preset-react": ^7.0.0
     "@babel/preset-typescript": ^7.16.7
     "@hypothesis/frontend-build": ^3.0.0
-    "@hypothesis/frontend-shared": ^7.2.0
+    "@hypothesis/frontend-shared": ^7.3.0
     "@hypothesis/frontend-testing": ^1.2.0
     "@npmcli/arborist": ^7.0.0
     "@octokit/rest": ^20.0.1


### PR DESCRIPTION
Depends on https://github.com/hypothesis/frontend-shared/pull/1442 and https://github.com/hypothesis/frontend-shared/pull/1443

Closes https://github.com/hypothesis/client/issues/6158

Use a `ModalDialog` for the notebook, which brings a few accessibility fixes like having `role="dialog"`, `aria-modal="true"` and focus trap out of the box.

This addresses the next points from the accessibility review:

> To make the dialog more accessible: 
> 1. Add a role=”dialog” to the dialog container. This will allow assistive technologies to announce the dialog as it appears. 
> 2. Add an aria-modal=”true” attribute to the dialog. This will hide background content from assistive technologies while the modal is open. 
> 3. Shift keyboard focus into the dialog when it opens, and constrain focus within the modal until the user closes the dialog. 

### Testing steps

1. Run a screen reader
2. Open the notebook -> The screen reader should announce the opening of a dialog and mention the notebook frame
3. Press <kbd>Tab</kbd> -> Since the iframe is initially focused, it should focus the first element inside of it.

### Known issues

The Modal's focus trap causes the focus to be trapped in the close button if you focus out of the iframe. I plan to address this separately as it seems a bit complex.

### Considerations

While working on this PR I realized we are only hiding the notebook when closed, instead of fully removing it from the DOM.

At first I thought this was intentional, to avoid multiple loads of the iframe and its contents, but then I realized the iframe has a `key` prop which is intentionally updated every time it is opened, and there's a comment explaining that forces the content to be up to date.

Separately, I will check if we could avoid this extra piece of state by just fully removing the notebook from the DOM when closed, but I want to check if A) It doesn't have other side effects and B) it doesn't move us in the wrong direction, assuming the reloading of the iframe is just a workaround for something else, in which case current approach makes it more explicit that this is not the desired behavior long term.

EDIT: We have discussed the above and we are going to keep it as it is now, because the long-term intended approach is to not load the iframe at all if annotations didn't change. Destroying the notebook on close would make this desire less obvious.