### PR TITLE
Add `PreactContainer` utility and refactor adder/bucket-bar to use it

### DIFF
--- a/src/annotator/test/adder-test.js
+++ b/src/annotator/test/adder-test.js
@@ -57,7 +57,7 @@ describe('Adder', () => {
   }
 
   function getContent() {
-    return adder._shadowRoot;
+    return adder._container.element.shadowRoot;
   }
 
   function adderRect() {
@@ -255,7 +255,7 @@ describe('Adder', () => {
   describe('adder Z index', () => {
     function getAdderZIndex(left, top) {
       adder._showAt(left, top);
-      return parseInt(adder._outerContainer.style.zIndex);
+      return parseInt(adder._container.element.style.zIndex);
     }
 
     it('returns hard coded value if `document.elementsFromPoint` is not available', () => {

--- a/src/annotator/test/bucket-bar-test.js
+++ b/src/annotator/test/bucket-bar-test.js
@@ -51,7 +51,7 @@ describe('BucketBar', () => {
     const bucketBar = createBucketBar();
     assert.calledWith(fakeComputeBuckets, []);
     assert.ok(
-      bucketBar._bucketsContainer.shadowRoot.querySelector('.FakeBuckets'),
+      bucketBar._container.element.shadowRoot.querySelector('.FakeBuckets'),
     );
   });
 

--- a/src/annotator/util/preact-container.ts
+++ b/src/annotator/util/preact-container.ts
@@ -1,0 +1,55 @@
+import type { JSX } from 'preact';
+import { render } from 'preact';
+
+import type { Destroyable } from '../../types/annotator';
+import { createShadowRoot } from './shadow-root';
+
+/**
+ * Manages the root `<hypothesis-*>` container for a top-level Hypothesis UI
+ * element.
+ *
+ * This implements common functionality for these elements, such as:
+ *
+ *  - Creating the `<hypothesis-{name}>` element with a shadow root, and loading
+ *    stylesheets into it.
+ *  - Re-rendering the Preact component tree when {@link PreactContainer.render} is called.
+ *  - Unmounting the component and removing the container element when
+ *    {@link PreactContainer.destroy} is called
+ */
+export class PreactContainer implements Destroyable {
+  private _element: HTMLElement;
+  private _shadowRoot: ShadowRoot;
+  private _render: () => JSX.Element;
+
+  /**
+   * Create a new `<hypothesis-{name}>` container element.
+   *
+   * After constructing the container, {@link PreactContainer.render} should be
+   * called to perform the initial render.
+   *
+   * @param name - Suffix for the element
+   * @param render - Callback that renders the root JSX element for this container
+   */
+  constructor(name: string, render: () => JSX.Element) {
+    const tag = `hypothesis-${name}`;
+    this._element = document.createElement(tag);
+    this._shadowRoot = createShadowRoot(this._element);
+    this._render = render;
+  }
+
+  /** Unmount the Preact component and remove the container element from the DOM. */
+  destroy() {
+    render(null, this._shadowRoot);
+    this._element.remove();
+  }
+
+  /** Return a reference to the container element. */
+  get element(): HTMLElement {
+    return this._element;
+  }
+
+  /** Re-render the root Preact component. */
+  render() {
+    render(this._render(), this._shadowRoot);
+  }
+}

--- a/src/annotator/util/test/preact-container-test.js
+++ b/src/annotator/util/test/preact-container-test.js
@@ -1,0 +1,59 @@
+import { useLayoutEffect } from 'preact/hooks';
+
+import { PreactContainer } from '../preact-container';
+
+describe('PreactContainer', () => {
+  let rootContainer;
+  let unmounted;
+
+  function Widget({ label }) {
+    // Use a layout effect here so it runs synchronously on unmount.
+    useLayoutEffect(() => {
+      return () => {
+        unmounted = true;
+      };
+    }, []);
+    return <button>{label}</button>;
+  }
+
+  beforeEach(() => {
+    rootContainer = document.createElement('div');
+    unmounted = false;
+  });
+
+  afterEach(() => {
+    rootContainer.remove();
+  });
+
+  it('should create container and render element', () => {
+    let label = 'foo';
+    const container = new PreactContainer('widget', () => (
+      <Widget label={label} />
+    ));
+    container.render();
+    assert.equal(container.element.localName, 'hypothesis-widget');
+
+    const button = container.element.shadowRoot.querySelector('button');
+    assert.ok(button);
+    assert.equal(button.textContent, 'foo');
+
+    label = 'bar';
+    container.render();
+
+    assert.equal(button.textContent, 'bar');
+  });
+
+  it('should unmount and remove element when `destroy` is called', () => {
+    let label = 'foo';
+    const container = new PreactContainer('widget', () => (
+      <Widget label={label} />
+    ));
+    rootContainer.append(container);
+    container.render();
+
+    container.destroy();
+
+    assert.equal(rootContainer.children.length, 0);
+    assert.isTrue(unmounted);
+  });
+});


### PR DESCRIPTION
The various top-level Hypothesis UI elements in the annotator have a common structure where:

 - There is a `<hypothesis-{name}>` container element

 - The container has a shadow root with the annotator stylesheet loaded into it

 - Preact is used to render the contents of the element, into the shadow root.

 - There is a controller which wraps the container element and has methods to read/write the displayed data. When the data is changed, the Preact tree is re-rendered.

Add a `PreactContainer` utility which implements common parts of this pattern, and refactor two of the top-level UI controls (bucket bar and adder) to use it.