### PR TITLE
Add aria-pressed attribute to highlights toggle

### DIFF
--- a/src/annotator/components/Toolbar.tsx
+++ b/src/annotator/components/Toolbar.tsx
@@ -181,7 +181,7 @@ export default function Toolbar({
             <ToolbarButton
               title="Show highlights"
               icon={showHighlights ? ShowIcon : HideIcon}
-              selected={showHighlights}
+              pressed={showHighlights}
               onClick={toggleHighlights}
             />
             <ToolbarButton

--- a/src/annotator/components/test/Toolbar-test.js
+++ b/src/annotator/components/test/Toolbar-test.js
@@ -91,6 +91,15 @@ describe('Toolbar', () => {
     assert.equal(statusEl.text(), 'Highlights visible');
   });
 
+  [true, false].forEach(showHighlights => {
+    it('sets props in highlights toggle', () => {
+      const wrapper = createToolbar({ showHighlights });
+      const highlightsButton = findButton(wrapper, 'Show highlights');
+
+      assert.equal(highlightsButton.prop('aria-pressed'), showHighlights);
+    });
+  });
+
   it(
     'should pass a11y checks',
     checkAccessibility([


### PR DESCRIPTION
Closes https://github.com/hypothesis/client/issues/6166

Add `aria-pressed` attribute to highlights toggle, to indicate if highlights are being shown or not.

Also, removed the previously used `selected` attribute, which is reserved for `<option />` elements.