### PR TITLE
Show warning when user is outside chapter for assignment

### DIFF
--- a/dev-server/documents/html/vitalsource-epub.mustache
+++ b/dev-server/documents/html/vitalsource-epub.mustache
@@ -23,9 +23,25 @@
       Gutenberg EPUB</a>.
     </p>
 
+    <p>
+      A CFI-based <i>focus filter</i> is configured. This is used in assignments
+      to direct students to annotate a particular region of a document.
+    </p>
+
     <button class="js-toggle-client">Unload client</button>
 
     <mosaic-book book="little-women"></mosaic-book>
+
+    <script type="application/json" class="js-hypothesis-config">
+      {
+        "focus": {
+          "cfi": {
+            "range": "/2-/4",
+            "display": "Chapter one"
+          }
+        }
+      }
+    </script>
 
     <script type="module">
       import { MosaicBookElement } from '/scripts/vitalsource-mosaic-book-element.js';

--- a/src/annotator/components/OutsideAssignmentNotice.tsx
+++ b/src/annotator/components/OutsideAssignmentNotice.tsx
@@ -1,0 +1,15 @@
+import { Callout } from '@hypothesis/frontend-shared';
+
+export default function OutsideAssignmentNotice() {
+  return (
+    <Callout
+      classes="fixed left-[10px] top-[10px]"
+      data-testid="outside-assignment-notice"
+      status="notice"
+      variant="raised"
+    >
+      You are outside the page range for this assignment. Annotations made here
+      may not be counted.
+    </Callout>
+  );
+}

--- a/src/annotator/guest.ts
+++ b/src/annotator/guest.ts
@@ -586,9 +586,12 @@ export class Guest extends TinyEmitter implements Annotator, Destroyable {
       this._integration.showContentInfo?.(info),
     );
 
-    this._sidebarRPC.on('showOutsideAssignmentNotice', (show: boolean) => {
-      this._showOutsideAssignmentNotice(show);
-    });
+    this._sidebarRPC.on(
+      'setOutsideAssignmentNoticeVisible',
+      (show: boolean) => {
+        this._setOutsideAssignmentNoticeVisible(show);
+      },
+    );
 
     this._sidebarRPC.on('navigateToSegment', (annotation: AnnotationData) =>
       this._integration.navigateToSegment?.(annotation),
@@ -925,13 +928,14 @@ export class Guest extends TinyEmitter implements Annotator, Destroyable {
   /**
    * Handle a potential shortcut trigger.
    */
-  _handleShortcut(event: KeyboardEvent) {
+  private _handleShortcut(event: KeyboardEvent) {
     if (matchShortcut(event, 'Ctrl+Shift+H')) {
       this.setHighlightsVisible(!this._highlightsVisible);
     }
   }
 
-  _showOutsideAssignmentNotice(show: boolean) {
+  /** Show or hide banner warning user they are outside page range for assignment. */
+  private _setOutsideAssignmentNoticeVisible(show: boolean) {
     if (!this._outsideAssignmentNotice) {
       this._outsideAssignmentNotice = new OutsideAssignmentNoticeController(
         this.element,

--- a/src/annotator/guest.ts
+++ b/src/annotator/guest.ts
@@ -37,6 +37,7 @@ import {
   setHighlightsVisible,
 } from './highlighter';
 import { createIntegration } from './integrations';
+import { OutsideAssignmentNoticeController } from './outside-assignment-notice';
 import {
   itemsForRange,
   isSelectionBackwards,
@@ -247,6 +248,8 @@ export class Guest extends TinyEmitter implements Annotator, Destroyable {
    */
   private _hoveredAnnotations: Set<string>;
 
+  private _outsideAssignmentNotice: OutsideAssignmentNoticeController | null;
+
   /**
    * @param element -
    *   The root element in which the `Guest` instance should be able to anchor
@@ -270,6 +273,7 @@ export class Guest extends TinyEmitter implements Annotator, Destroyable {
     this._isAdderVisible = false;
     this._informHostOnNextSelectionClear = true;
     this.selectedRanges = [];
+    this._outsideAssignmentNotice = null;
 
     this._adder = new Adder(this.element, {
       onAnnotate: () => this.createAnnotation(),
@@ -582,6 +586,10 @@ export class Guest extends TinyEmitter implements Annotator, Destroyable {
       this._integration.showContentInfo?.(info),
     );
 
+    this._sidebarRPC.on('showOutsideAssignmentNotice', (show: boolean) => {
+      this._showOutsideAssignmentNotice(show);
+    });
+
     this._sidebarRPC.on('navigateToSegment', (annotation: AnnotationData) =>
       this._integration.navigateToSegment?.(annotation),
     );
@@ -608,6 +616,7 @@ export class Guest extends TinyEmitter implements Annotator, Destroyable {
     this._adder.destroy();
     this._bucketBarClient.destroy();
     this._clusterToolbar?.destroy();
+    this._outsideAssignmentNotice?.destroy();
 
     removeAllHighlights(this.element);
 
@@ -920,5 +929,14 @@ export class Guest extends TinyEmitter implements Annotator, Destroyable {
     if (matchShortcut(event, 'Ctrl+Shift+H')) {
       this.setHighlightsVisible(!this._highlightsVisible);
     }
+  }
+
+  _showOutsideAssignmentNotice(show: boolean) {
+    if (!this._outsideAssignmentNotice) {
+      this._outsideAssignmentNotice = new OutsideAssignmentNoticeController(
+        this.element,
+      );
+    }
+    this._outsideAssignmentNotice.setVisible(show);
   }
 }

--- a/src/annotator/outside-assignment-notice.tsx
+++ b/src/annotator/outside-assignment-notice.tsx
@@ -1,0 +1,35 @@
+import type { Destroyable } from '../types/annotator';
+import OutsideAssignmentNotice from './components/OutsideAssignmentNotice';
+import { PreactContainer } from './util/preact-container';
+
+/**
+ * Notice displayed in the guest frame informing users that they are viewing
+ * part of the document that is outside the scope of the current activity (eg.
+ * a classroom assignment).
+ */
+export class OutsideAssignmentNoticeController implements Destroyable {
+  private _container: PreactContainer;
+  private _visible: boolean;
+
+  constructor(container: HTMLElement) {
+    this._visible = false;
+    this._container = new PreactContainer('notice', () => this._render());
+    container.appendChild(this._container.element);
+  }
+
+  destroy() {
+    this._container.destroy();
+  }
+
+  setVisible(visible: boolean) {
+    this._visible = visible;
+    this._container.render();
+  }
+
+  private _render() {
+    if (!this._visible) {
+      return null;
+    }
+    return <OutsideAssignmentNotice />;
+  }
+}

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -47,6 +47,7 @@ describe('Guest', () => {
   let fakePortFinder;
   let FakePortRPC;
   let fakePortRPCs;
+  let fakeOutsideAssignmentNotice;
 
   const createGuest = (config = {}) => {
     const element = document.createElement('div');
@@ -190,6 +191,11 @@ describe('Guest', () => {
       destroy: sinon.stub(),
     };
 
+    fakeOutsideAssignmentNotice = {
+      destroy: sinon.stub(),
+      setVisible: sinon.stub(),
+    };
+
     class FakeSelectionObserver {
       constructor(callback) {
         notifySelectionChanged = callback;
@@ -217,6 +223,11 @@ describe('Guest', () => {
         createIntegration: fakeCreateIntegration,
       },
       './range-util': rangeUtil,
+      './outside-assignment-notice': {
+        OutsideAssignmentNoticeController: sinon
+          .stub()
+          .returns(fakeOutsideAssignmentNotice),
+      },
       './selection-observer': {
         SelectionObserver: FakeSelectionObserver,
       },
@@ -592,6 +603,16 @@ describe('Guest', () => {
         createGuest();
         fakeIntegration.showContentInfo = null;
         emitSidebarEvent('showContentInfo', contentInfo);
+      });
+    });
+
+    describe('on "showOutsideAssignmentNotice" event', () => {
+      [true, false].forEach(arg => {
+        it('shows notice if argument is `true`', () => {
+          createGuest();
+          emitSidebarEvent('showOutsideAssignmentNotice', arg);
+          assert.calledWith(fakeOutsideAssignmentNotice.setVisible, arg);
+        });
       });
     });
   });

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -606,11 +606,11 @@ describe('Guest', () => {
       });
     });
 
-    describe('on "showOutsideAssignmentNotice" event', () => {
+    describe('on "setOutsideAssignmentNoticeVisible" event', () => {
       [true, false].forEach(arg => {
         it('shows notice if argument is `true`', () => {
           createGuest();
-          emitSidebarEvent('showOutsideAssignmentNotice', arg);
+          emitSidebarEvent('setOutsideAssignmentNoticeVisible', arg);
           assert.calledWith(fakeOutsideAssignmentNotice.setVisible, arg);
         });
       });

--- a/src/annotator/test/outside-assignment-notice-test.js
+++ b/src/annotator/test/outside-assignment-notice-test.js
@@ -1,0 +1,33 @@
+import { OutsideAssignmentNoticeController } from '../outside-assignment-notice';
+
+describe('OutsideAssignmentNoticeController', () => {
+  function getNotice(container) {
+    return container
+      .querySelector('hypothesis-notice')
+      ?.shadowRoot.querySelector('[data-testid="outside-assignment-notice"]');
+  }
+
+  it('shows notice when `setVisible(true)` is called', () => {
+    const container = document.createElement('div');
+    const controller = new OutsideAssignmentNoticeController(container);
+
+    assert.notOk(getNotice(container));
+
+    controller.setVisible(true);
+    assert.ok(getNotice(container));
+
+    controller.setVisible(false);
+    assert.notOk(getNotice(container));
+  });
+
+  it('removes notice when `destroy` is called', () => {
+    const container = document.createElement('div');
+    const controller = new OutsideAssignmentNoticeController(container);
+
+    controller.setVisible(true);
+    assert.ok(getNotice(container));
+
+    controller.destroy();
+    assert.notOk(getNotice(container));
+  });
+});

--- a/src/annotator/util/preact-container.ts
+++ b/src/annotator/util/preact-container.ts
@@ -1,4 +1,4 @@
-import type { JSX } from 'preact';
+import type { ComponentChild } from 'preact';
 import { render } from 'preact';
 
 import type { Destroyable } from '../../types/annotator';
@@ -19,7 +19,7 @@ import { createShadowRoot } from './shadow-root';
 export class PreactContainer implements Destroyable {
   private _element: HTMLElement;
   private _shadowRoot: ShadowRoot;
-  private _render: () => JSX.Element;
+  private _render: () => ComponentChild;
 
   /**
    * Create a new `<hypothesis-{name}>` container element.
@@ -30,7 +30,7 @@ export class PreactContainer implements Destroyable {
    * @param name - Suffix for the element
    * @param render - Callback that renders the root JSX element for this container
    */
-  constructor(name: string, render: () => JSX.Element) {
+  constructor(name: string, render: () => ComponentChild) {
     const tag = `hypothesis-${name}`;
     this._element = document.createElement(tag);
     this._shadowRoot = createShadowRoot(this._element);

--- a/src/sidebar/helpers/annotation-segment.ts
+++ b/src/sidebar/helpers/annotation-segment.ts
@@ -1,6 +1,7 @@
-import { stripCFIAssertions } from '../../shared/cfi';
+import { cfiInRange, stripCFIAssertions } from '../../shared/cfi';
 import type { SegmentInfo } from '../../types/annotator';
 import type { Annotation, EPUBContentSelector } from '../../types/api';
+import type { Filters } from '../store/modules/filters';
 
 /**
  * Return true if an annotation matches the currently loaded segment of a document.
@@ -28,4 +29,19 @@ export function annotationMatchesSegment(
         selector.cfi &&
         stripCFIAssertions(selector.cfi) === stripCFIAssertions(segment.cfi)),
   );
+}
+
+/**
+ * Return true if the document segment displayed in a guest frame matches the
+ * configured focus filters.
+ */
+export function segmentMatchesFocusFilters(
+  segment: SegmentInfo,
+  filters: Filters,
+): boolean {
+  if (segment.cfi && filters.cfi) {
+    const [cfiStart, cfiEnd] = filters.cfi.value.split('-');
+    return cfiInRange(segment.cfi, cfiStart, cfiEnd);
+  }
+  return true;
 }

--- a/src/sidebar/helpers/test/annotation-segment-test.js
+++ b/src/sidebar/helpers/test/annotation-segment-test.js
@@ -1,4 +1,7 @@
-import { annotationMatchesSegment } from '../annotation-segment';
+import {
+  annotationMatchesSegment,
+  segmentMatchesFocusFilters,
+} from '../annotation-segment';
 
 describe('annotationMatchesSegment', () => {
   it('returns true if annotation has no segment selectors', () => {
@@ -88,6 +91,46 @@ describe('annotationMatchesSegment', () => {
     it(`returns true if CFI or URL matches current segment (${index})`, () => {
       const ann = { target: [{ selector: [selector] }] };
       assert.equal(annotationMatchesSegment(ann, segment), expected);
+    });
+  });
+});
+
+describe('segmentMatchesFocusFilters', () => {
+  [
+    // No segment CFI
+    {
+      segment: {},
+      filters: {},
+      expected: true,
+    },
+    // No filters
+    {
+      segment: { cfi: '/2' },
+      filters: {},
+      expected: true,
+    },
+
+    // Filter present, but segment CFI is unknown.
+    {
+      segment: {},
+      filters: { cfi: { value: '/2-/4' } },
+      expected: true,
+    },
+    // Filter present, matches segment
+    {
+      segment: { cfi: '/2' },
+      filters: { cfi: { value: '/2-/4' } },
+      expected: true,
+    },
+    // Filter present, does not match segment
+    {
+      segment: { cfi: '/6' },
+      filters: { cfi: { value: '/2-/4' } },
+      expected: false,
+    },
+  ].forEach(({ segment, filters, expected }) => {
+    it('returns true if segment matches filters', () => {
+      assert.equal(segmentMatchesFocusFilters(segment, filters), expected);
     });
   });
 });

--- a/src/sidebar/services/frame-sync.ts
+++ b/src/sidebar/services/frame-sync.ts
@@ -370,7 +370,7 @@ export class FrameSyncService {
           info.segmentInfo,
           focusFilters,
         );
-        guestRPC.call('showOutsideAssignmentNotice', !match);
+        guestRPC.call('setOutsideAssignmentNoticeVisible', !match);
       }
 
       this._store.connectFrame({

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -468,7 +468,7 @@ describe('FrameSyncService', () => {
         it('is not displayed if no focus filter is configured', async () => {
           await connectEPUBGuest();
           assert.isFalse(
-            guestRPC().call.calledWith('showOutsideAssignmentNotice'),
+            guestRPC().call.calledWith('setOutsideAssignmentNoticeVisible'),
           );
         });
 
@@ -477,7 +477,7 @@ describe('FrameSyncService', () => {
           await connectEPUBGuest();
           assert.calledWith(
             guestRPC().call,
-            'showOutsideAssignmentNotice',
+            'setOutsideAssignmentNoticeVisible',
             false,
           );
         });
@@ -487,7 +487,7 @@ describe('FrameSyncService', () => {
           await connectEPUBGuest();
           assert.calledWith(
             guestRPC().call,
-            'showOutsideAssignmentNotice',
+            'setOutsideAssignmentNoticeVisible',
             true,
           );
         });

--- a/src/types/port-rpc-events.d.ts
+++ b/src/types/port-rpc-events.d.ts
@@ -144,7 +144,7 @@ export type SidebarToGuestEvent =
    * Show a notice that the user is outside the region of the document for the
    * current activity / assignment.
    */
-  | 'showOutsideAssignmentNotice';
+  | 'setOutsideAssignmentNoticeVisible';
 
 /**
  * Events that the sidebar sends to the host

--- a/src/types/port-rpc-events.d.ts
+++ b/src/types/port-rpc-events.d.ts
@@ -138,7 +138,13 @@ export type SidebarToGuestEvent =
   /**
    * Show a banner with information about the current content.
    */
-  | 'showContentInfo';
+  | 'showContentInfo'
+
+  /**
+   * Show a notice that the user is outside the region of the document for the
+   * current activity / assignment.
+   */
+  | 'showOutsideAssignmentNotice';
 
 /**
  * Events that the sidebar sends to the host


### PR DESCRIPTION
This PR adds infrastructure for showing a warning when the user is in a classroom assignment with a configured chapter, and the user has navigated outside that chapter. Any annotations they create here will (probably) not be counted towards the assignment.

This initial PR only works with CFI (ie. chapter) focus filters. There is follow-up work coming which will make it work with page range filters.

The contents of the notice are not finalized.

Summary of changes:

- Add a new `showOutsideAssignmentNotice` sent from the sidebar to guest
- Send this event when a guest connects, if it provides document segment (chapter/page) info and there is a focus filter configured
- In the guest, listen for the event and display a fixed-positioned callout in a `<hypothesis-notice>` container when the `showOutsideAssignmentNotice` event is received

**Testing:**

1. Go to http://localhost:3000/document/vitalsource-epub. This example is now configured with a focus filter for the first chapter. Only annotations from this chapter will show by default.
2. Navigate to a different chapter, you should see a warning notice appear at the top of the content indicating that you are outside the assignment's chapter.
3. Navigate back to the first chapter. The notice should disappear

Part of https://github.com/hypothesis/client/issues/5936