### PR TITLE
Replace use of deprecated default import in commander

### DIFF
--- a/scripts/deploy-to-s3.js
+++ b/scripts/deploy-to-s3.js
@@ -5,7 +5,7 @@
 const fs = require('fs');
 const { extname } = require('path');
 
-const commander = require('commander');
+const { program } = require('commander');
 const Arborist = require('@npmcli/arborist');
 const packlist = require('npm-packlist');
 const AWS = require('aws-sdk');
@@ -151,13 +151,13 @@ async function uploadPackageToS3(bucket, options) {
   });
 }
 
-commander
+program
   .option('--bucket [bucket]', 'S3 bucket name')
   .option('--tag [tag]', 'Version tag')
   .option('--no-cache-entry', 'Prevent CDN/browser caching of entry point')
   .parse(process.argv);
 
-const cliOpts = commander.opts();
+const cliOpts = program.opts();
 
 const options = {
   tag: cliOpts.tag,


### PR DESCRIPTION
This fixes the S3 deployment script after migration to Commander v12 ([see logs](https://github.com/hypothesis/client/actions/runs/7784076170/job/21223989018)).

See https://github.com/tj/commander.js/blob/master/CHANGELOG.md#migration-tips