### PR TITLE
Add multiple "pages" to the VitalSource PDF demo and a focus filter

### DIFF
--- a/dev-server/documents/html/vitalsource-pdf.mustache
+++ b/dev-server/documents/html/vitalsource-pdf.mustache
@@ -37,6 +37,16 @@
       by searching for the book ID (9781938168239) in the Bookshelf store.
     </p>
 
+    <!-- Add a focus filter to simulate an LMS assignment with a page range
+         configured. -->
+    <script type="application/json" class="js-hypothesis-config">
+      {
+        "focus": {
+          "pages": "1-2"
+        }
+      }
+    </script>
+
     <mosaic-book book="test-pdf"></mosaic-book>
 
     {{{hypothesisScript}}}

--- a/dev-server/static/scripts/vitalsource-mosaic-book-element.js
+++ b/dev-server/static/scripts/vitalsource-mosaic-book-element.js
@@ -55,6 +55,12 @@ export class MosaicBookElement extends HTMLElement {
   connectedCallback() {
     const book = this.getAttribute('book');
 
+    const isPDF = book?.includes('pdf');
+    const stepType = isPDF ? 'page' : 'chapter';
+
+    this.prevButton.textContent = `Prev ${stepType}`;
+    this.nextButton.textContent = `Next ${stepType}`;
+
     if (book === 'little-women') {
       this.pageData = [
         {
@@ -80,13 +86,30 @@ export class MosaicBookElement extends HTMLElement {
         },
       ];
     } else if (book === 'test-pdf') {
+      // Each of the pages of this PDF book uses the same content, because
+      // we are lazy, but we give each page a distinct URL so that only
+      // annotations made on that page anchor there.
       this.pageData = [
         {
           absoluteURL: '/document/vitalsource-pdf-page',
-          chapterTitle: 'Test chapter',
+          chapterTitle: 'Test page 1',
           cfi: '/0',
           index: 0,
           page: '1',
+        },
+        {
+          absoluteURL: '/document/vitalsource-pdf-page?dummy_page=2',
+          chapterTitle: 'Test page 2',
+          cfi: '/1',
+          index: 1,
+          page: '2',
+        },
+        {
+          absoluteURL: '/document/vitalsource-pdf-page?dummy_page=3',
+          chapterTitle: 'Test page 3',
+          cfi: '/2',
+          index: 2,
+          page: '3',
         },
       ];
     } else {


### PR DESCRIPTION
This enables testing that appropriate annotations are loaded as you navigate between pages in a PDF-based VitalSource book. I also plan to use it to test [outside-of-assignment](https://github.com/hypothesis/client/pull/6170) warnings when the assignment is specified using a page range.

Creating realistic dummy content for a VS PDF page is quite involved, so each page just re-uses the same content but with different metadata and a distinct URL.
