### PR TITLE
Make outside-assignment warnings work when assignment is specified with page range

### DIFF
--- a/dev-server/static/scripts/vitalsource-mosaic-book-element.js
+++ b/dev-server/static/scripts/vitalsource-mosaic-book-element.js
@@ -26,6 +26,7 @@ export class MosaicBookElement extends HTMLElement {
      */
     this.pageIndex = 0;
     this.pageData = [];
+    this.pageBreaks = [];
 
     const styles = document.createElement('style');
     styles.innerHTML = `
@@ -85,6 +86,27 @@ export class MosaicBookElement extends HTMLElement {
           page: '30',
         },
       ];
+      this.pageBreaks = this.pageData.flatMap(page => {
+        const breaks = [
+          {
+            cfi: page.cfi,
+            cfiWithoutAssertions: page.cfi,
+            label: page.page,
+          },
+        ];
+
+        const startPage = parseInt(page.page);
+        for (let i = 1; i < 10; i++) {
+          const cfi = `${page.cfi}!/${i * 2}`;
+          breaks.push({
+            cfi,
+            cfiWithoutAssertions: cfi,
+            label: (startPage + i).toString(),
+          });
+        }
+
+        return breaks;
+      });
     } else if (book === 'test-pdf') {
       // Each of the pages of this PDF book uses the same content, because
       // we are lazy, but we give each page a distinct URL so that only
@@ -112,6 +134,11 @@ export class MosaicBookElement extends HTMLElement {
           page: '3',
         },
       ];
+      this.pageBreaks = this.pageData.map(page => ({
+        cfi: page.cfi,
+        cfiWithoutAssertions: page.cfi,
+        label: page.page,
+      }));
     } else {
       console.warn(`Unknown VitalSource book "${book}"`);
     }
@@ -195,6 +222,10 @@ export class MosaicBookElement extends HTMLElement {
 
   async getPages() {
     return { ok: true, data: [...this.pageData], status: 200 };
+  }
+
+  async getPageBreaks() {
+    return { ok: true, data: [...this.pageBreaks], status: 200 };
   }
 
   async getTOC() {

--- a/dev-server/tsconfig.json
+++ b/dev-server/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "allowJs": true,
     "checkJs": true,
-    "lib": ["es2018", "dom"],
+    "lib": ["es2020", "dom"],
     "jsx": "react-jsx",
     "jsxImportSource": "preact",
     "module": "commonjs",

--- a/src/annotator/integrations/test/vitalsource-test.js
+++ b/src/annotator/integrations/test/vitalsource-test.js
@@ -258,6 +258,38 @@ describe('annotator/integrations/vitalsource', () => {
       return { ok: true, data };
     }
 
+    async getPageBreaks() {
+      let data = [];
+      if (this._format === 'epub') {
+        data = [
+          // Pages before chapter
+          {
+            cfi: '/0',
+            cfiWithoutAssertions: '/0',
+            label: '5',
+          },
+          // Pages within current chapter
+          {
+            cfi: '/2',
+            cfiWithoutAssertions: '/2',
+            label: '20',
+          },
+          {
+            cfi: '/2!/2',
+            cfiWithoutAssertions: '/2!/2',
+            label: '21',
+          },
+          // Pages after current chapter
+          {
+            cfi: '/4!/2',
+            cfiWithoutAssertions: '/4!/2',
+            label: '22',
+          },
+        ];
+      }
+      return { ok: true, data };
+    }
+
     async getTOC() {
       if (this._format === 'epub') {
         const toc = [
@@ -534,6 +566,7 @@ describe('annotator/integrations/vitalsource', () => {
         const segment = await integration.segmentInfo();
         assert.deepEqual(segment, {
           cfi: '/2',
+          pages: { start: '20', end: '21' },
           url: resolveURL('/pages/chapter_02.xhtml'),
         });
       });

--- a/src/sidebar/helpers/annotation-segment.ts
+++ b/src/sidebar/helpers/annotation-segment.ts
@@ -2,7 +2,7 @@ import { cfiInRange, stripCFIAssertions } from '../../shared/cfi';
 import type { SegmentInfo } from '../../types/annotator';
 import type { Annotation, EPUBContentSelector } from '../../types/api';
 import type { Filters } from '../store/modules/filters';
-import { pageRangesOverlap } from '../util/page-range';
+import { RangeOverlap, pageRangeOverlap } from '../util/page-range';
 
 /**
  * Return true if an annotation matches the currently loaded segment of a document.
@@ -46,10 +46,10 @@ export function segmentMatchesFocusFilters(
   }
   if (segment.pages && filters.page) {
     const segmentRange = `${segment.pages.start}-${segment.pages.end}`;
-    const overlap = pageRangesOverlap(segmentRange, filters.page.value);
-
-    // nb. `overlap` may be `null` if the relation is unknown.
-    return overlap === true;
+    return (
+      pageRangeOverlap(segmentRange, filters.page.value) ===
+      RangeOverlap.Overlap
+    );
   }
   return true;
 }

--- a/src/sidebar/helpers/annotation-segment.ts
+++ b/src/sidebar/helpers/annotation-segment.ts
@@ -2,6 +2,7 @@ import { cfiInRange, stripCFIAssertions } from '../../shared/cfi';
 import type { SegmentInfo } from '../../types/annotator';
 import type { Annotation, EPUBContentSelector } from '../../types/api';
 import type { Filters } from '../store/modules/filters';
+import { pageRangesOverlap } from '../util/page-range';
 
 /**
  * Return true if an annotation matches the currently loaded segment of a document.
@@ -42,6 +43,13 @@ export function segmentMatchesFocusFilters(
   if (segment.cfi && filters.cfi) {
     const [cfiStart, cfiEnd] = filters.cfi.value.split('-');
     return cfiInRange(segment.cfi, cfiStart, cfiEnd);
+  }
+  if (segment.pages && filters.page) {
+    const segmentRange = `${segment.pages.start}-${segment.pages.end}`;
+    const overlap = pageRangesOverlap(segmentRange, filters.page.value);
+
+    // nb. `overlap` may be `null` if the relation is unknown.
+    return overlap === true;
   }
   return true;
 }

--- a/src/sidebar/helpers/test/annotation-segment-test.js
+++ b/src/sidebar/helpers/test/annotation-segment-test.js
@@ -128,6 +128,18 @@ describe('segmentMatchesFocusFilters', () => {
       filters: { cfi: { value: '/2-/4' } },
       expected: false,
     },
+    // Segment within page range
+    {
+      segment: { pages: { start: '1', end: '10' } },
+      filters: { page: { value: '1-2' } },
+      expected: true,
+    },
+    // Segment outside page range
+    {
+      segment: { pages: { start: '3', end: '4' } },
+      filters: { page: { value: '1-2' } },
+      expected: false,
+    },
   ].forEach(({ segment, filters, expected }) => {
     it('returns true if segment matches filters', () => {
       assert.equal(segmentMatchesFocusFilters(segment, filters), expected);

--- a/src/sidebar/helpers/test/version-data-test.js
+++ b/src/sidebar/helpers/test/version-data-test.js
@@ -83,9 +83,18 @@ describe('sidebar/helpers/version-data', () => {
 
       it('sets `segment` property if `segment` is present in frame details', () => {
         const versionData = new VersionData({}, [
-          { segment: { cfi: '/2', url: '/chapters/02.xhtml' } },
+          {
+            segment: {
+              cfi: '/2',
+              url: '/chapters/02.xhtml',
+              pages: { start: '4', end: '9' },
+            },
+          },
         ]);
-        assert.equal(versionData.segment, 'CFI: /2, URL: /chapters/02.xhtml');
+        assert.equal(
+          versionData.segment,
+          ['CFI: /2', 'Pages: 4-9', 'URL: /chapters/02.xhtml'].join(', '),
+        );
       });
 
       it('does not set `segment` property if `segment` is not present in frame details', () => {

--- a/src/sidebar/helpers/version-data.ts
+++ b/src/sidebar/helpers/version-data.ts
@@ -52,6 +52,10 @@ export class VersionData {
       if (segmentInfo.cfi) {
         segmentFields.push(['CFI', segmentInfo.cfi]);
       }
+      if (segmentInfo.pages) {
+        const range = `${segmentInfo.pages.start}-${segmentInfo.pages.end}`;
+        segmentFields.push(['Pages', range]);
+      }
       if (segmentInfo.url) {
         segmentFields.push(['URL', segmentInfo.url]);
       }

--- a/src/sidebar/util/page-range.ts
+++ b/src/sidebar/util/page-range.ts
@@ -1,5 +1,52 @@
 /**
+ * Parse a page number or range into a `[start, end]` integer pair. The `start`
+ * or `end` may be `null` if the range is open.
+ *
+ * Returns `null` if the page range could not be parsed.
+ */
+function parseRange(range: string): [number | null, number | null] | null {
+  let start;
+  let end;
+
+  if (range.includes('-')) {
+    [start, end] = range.split('-');
+  } else {
+    start = range;
+    end = range;
+  }
+
+  let startInt = null;
+  if (start) {
+    startInt = parseInt(start);
+    if (!Number.isInteger(startInt)) {
+      return null;
+    }
+  }
+
+  let endInt = null;
+  if (end) {
+    endInt = parseInt(end);
+    if (!Number.isInteger(endInt)) {
+      return null;
+    }
+  }
+
+  if (startInt === null || endInt === null) {
+    return [startInt, endInt];
+  }
+
+  if (startInt <= endInt) {
+    return [startInt, endInt];
+  } else {
+    return [endInt, startInt];
+  }
+}
+
+/**
  * Return true if the page number `label` is within `range`.
+ *
+ * Returns `false` if the label is outside `range` or the relation between the
+ * label and the range could not be determined.
  *
  * @param label - A page number such as "10", "iv"
  * @param range - A page range expressed as a single page number, or a hyphen
@@ -8,29 +55,54 @@
  *   specify an empty range.
  */
 export function pageLabelInRange(label: string, range: string): boolean {
-  if (!range.includes('-')) {
-    return label === range;
+  return pageRangesOverlap(label, range) === true;
+}
+
+/** Convert an open range into an integer range. */
+function normalizeRange(
+  range: [number | null, number | null],
+  min: number,
+  max: number,
+): [number, number] {
+  return [range[0] ?? min, range[1] ?? max];
+}
+
+/**
+ * Return true if two page ranges overlap.
+ *
+ * Each range may be specified as a single page number, or a hyphen-separated
+ * range.
+ *
+ * Returns true if the ranges overlap, false if the ranges do not overlap, or
+ * `null` if the relation could not be determined.
+ */
+export function pageRangesOverlap(
+  rangeA: string,
+  rangeB: string,
+): boolean | null {
+  const intRangeA = parseRange(rangeA);
+  const intRangeB = parseRange(rangeB);
+
+  if (!intRangeA || !intRangeB) {
+    if (rangeA && rangeB && rangeA === rangeB) {
+      // As a special case for non-numeric ranges, we consider them overlapping
+      // if both are equal. This means `pageRangesOverlap("iv", "iv")` is true
+      // for example.
+      return true;
+    }
+
+    // We could not determine whether the ranges overlap.
+    return null;
   }
 
-  let [start, end] = range.split('-');
-  if (!start) {
-    start = label;
-  }
-  if (!end) {
-    end = label;
-  }
-  const [startInt, endInt, labelInt] = [
-    parseInt(start),
-    parseInt(end),
-    parseInt(label),
-  ];
-  if (
-    Number.isInteger(startInt) &&
-    Number.isInteger(endInt) &&
-    Number.isInteger(labelInt)
-  ) {
-    return labelInt >= startInt && labelInt <= endInt;
+  const minPage = 1;
+  const maxPage = 2 ** 31;
+  const [aStart, aEnd] = normalizeRange(intRangeA, minPage, maxPage);
+  const [bStart, bEnd] = normalizeRange(intRangeB, minPage, maxPage);
+
+  if (aStart <= bStart) {
+    return bStart <= aEnd;
   } else {
-    return false;
+    return aStart <= bEnd;
   }
 }

--- a/src/sidebar/util/test/page-range-test.js
+++ b/src/sidebar/util/test/page-range-test.js
@@ -1,4 +1,8 @@
-import { pageLabelInRange, pageRangesOverlap } from '../page-range';
+import {
+  RangeOverlap,
+  pageLabelInRange,
+  pageRangeOverlap,
+} from '../page-range';
 
 describe('pageLabelInRange', () => {
   [
@@ -95,79 +99,81 @@ describe('pageLabelInRange', () => {
   });
 });
 
+const RO = RangeOverlap;
+
 describe('pageRangesOverlap', () => {
   [
     // Matching single page
     {
       rangeA: '1',
       rangeB: '1',
-      overlap: true,
+      overlap: RO.Overlap,
     },
     // Non-matching single page
     {
       rangeA: '1',
       rangeB: '2',
-      overlap: false,
+      overlap: RO.NoOverlap,
     },
     // Overlapping numeric ranges
     {
       rangeA: '1-2',
       rangeB: '2-4',
-      overlap: true,
+      overlap: RO.Overlap,
     },
     {
       rangeA: '2-4',
       rangeB: '1-2',
-      overlap: true,
+      overlap: RO.Overlap,
     },
     // Inverted numeric ranges. These are implicitly normalized.
     {
       rangeA: '2-1',
       rangeB: '4-2',
-      overlap: true,
+      overlap: RO.Overlap,
     },
     // Half-open ranges
     {
       rangeA: '1-',
       rangeB: '-3',
-      overlap: true,
+      overlap: RO.Overlap,
     },
     // Non-overlapping numeric ranges
     {
       rangeA: '1-2',
       rangeB: '3-4',
-      overlap: false,
+      overlap: RO.NoOverlap,
     },
     {
       rangeA: '3-4',
       rangeB: '1-2',
-      overlap: false,
+      overlap: RO.NoOverlap,
     },
     // Relation is undefined if either of the ranges is non-numeric.
     {
       rangeA: 'ii',
       rangeB: '3-4',
-      overlap: null,
+      overlap: RO.Unknown,
     },
     {
       rangeA: 'i-iii',
       rangeB: 'iii-iv',
-      overlap: null,
+      overlap: RO.Unknown,
     },
     {
       rangeA: '1-ii',
       rangeB: 'ii-3',
-      overlap: null,
+      overlap: RO.Unknown,
     },
     // As a special case, matching non-numeric ranges overlap.
     {
       rangeA: 'ii',
       rangeB: 'ii',
-      overlap: true,
+      overlap: RO.Overlap,
     },
   ].forEach(({ rangeA, rangeB, overlap }) => {
-    it('returns true if the two ranges overlap', () => {
-      assert.strictEqual(pageRangesOverlap(rangeA, rangeB), overlap);
+    it('returns whether two ranges overlap', () => {
+      assert.strictEqual(pageRangeOverlap(rangeA, rangeB), overlap);
     });
   });
 });

--- a/src/sidebar/util/test/page-range-test.js
+++ b/src/sidebar/util/test/page-range-test.js
@@ -1,4 +1,4 @@
-import { pageLabelInRange } from '../page-range';
+import { pageLabelInRange, pageRangesOverlap } from '../page-range';
 
 describe('pageLabelInRange', () => {
   [
@@ -91,6 +91,83 @@ describe('pageLabelInRange', () => {
   ].forEach(({ label, range, match }) => {
     it('returns true if the label is in the page range', () => {
       assert.equal(pageLabelInRange(label, range), match);
+    });
+  });
+});
+
+describe('pageRangesOverlap', () => {
+  [
+    // Matching single page
+    {
+      rangeA: '1',
+      rangeB: '1',
+      overlap: true,
+    },
+    // Non-matching single page
+    {
+      rangeA: '1',
+      rangeB: '2',
+      overlap: false,
+    },
+    // Overlapping numeric ranges
+    {
+      rangeA: '1-2',
+      rangeB: '2-4',
+      overlap: true,
+    },
+    {
+      rangeA: '2-4',
+      rangeB: '1-2',
+      overlap: true,
+    },
+    // Inverted numeric ranges. These are implicitly normalized.
+    {
+      rangeA: '2-1',
+      rangeB: '4-2',
+      overlap: true,
+    },
+    // Half-open ranges
+    {
+      rangeA: '1-',
+      rangeB: '-3',
+      overlap: true,
+    },
+    // Non-overlapping numeric ranges
+    {
+      rangeA: '1-2',
+      rangeB: '3-4',
+      overlap: false,
+    },
+    {
+      rangeA: '3-4',
+      rangeB: '1-2',
+      overlap: false,
+    },
+    // Relation is undefined if either of the ranges is non-numeric.
+    {
+      rangeA: 'ii',
+      rangeB: '3-4',
+      overlap: null,
+    },
+    {
+      rangeA: 'i-iii',
+      rangeB: 'iii-iv',
+      overlap: null,
+    },
+    {
+      rangeA: '1-ii',
+      rangeB: 'ii-3',
+      overlap: null,
+    },
+    // As a special case, matching non-numeric ranges overlap.
+    {
+      rangeA: 'ii',
+      rangeB: 'ii',
+      overlap: true,
+    },
+  ].forEach(({ rangeA, rangeB, overlap }) => {
+    it('returns true if the two ranges overlap', () => {
+      assert.strictEqual(pageRangesOverlap(rangeA, rangeB), overlap);
     });
   });
 });

--- a/src/types/annotator.ts
+++ b/src/types/annotator.ts
@@ -57,6 +57,13 @@ export type DocumentMetadata = {
 export type SegmentInfo = {
   /** Canonical Fragment Identifier for an EPUB Content Document */
   cfi?: string;
+
+  /** Range of page numbers in this segment. */
+  pages?: {
+    start: string;
+    end: string;
+  };
+
   /** Relative or absolute URL of the segment. */
   url?: string;
 };

--- a/src/types/vitalsource.ts
+++ b/src/types/vitalsource.ts
@@ -87,6 +87,26 @@ export type PageInfo = {
 };
 
 /**
+ * Data about the location of a page break.
+ */
+export type PageBreakInfo = {
+  /**
+   * The CFI identifying the location of the page break.
+   *
+   * This will be something like `/6/26[;vnd.vst.idref=ch05]!/4/66` where the
+   * part before the `!` identifies the EPUB content document and the part
+   * after is optional and identifies a DOM element within the content document.
+   */
+  cfi: string;
+
+  /** Same as `cfi`, but with any CFI assertions stripped out. */
+  cfiWithoutAssertions: string;
+
+  /** The label of the page that begins at this point. */
+  label: string;
+};
+
+/**
  * An entry from a book's table of contents. This information comes from
  * an EPUB's Navigation Document [1] or Navigation Control File ("toc.ncx") [2].
  *
@@ -166,6 +186,9 @@ export type MosaicBookElement = HTMLElement & {
 
   /** Get the list of pages in the book. */
   getPages(): Promise<DataResponse<PageInfo[]>>;
+
+  /** Get the locations of page breaks in the book. */
+  getPageBreaks(): Promise<DataResponse<PageBreakInfo[]>>;
 
   /** Retrieve the book's table of contents. */
   getTOC(): Promise<DataResponse<TableOfContentsEntry[]>>;


### PR DESCRIPTION
This extends https://github.com/hypothesis/client/pull/6170 to work when the page range for an assignment is specified as a numeric page range rather than as a selected chapter.

Checks are done at the granularity of a book segment, which is always a single page for PDF-based books, but can span a range of pages for EPUB-based books. The outside-assignment warning is shown if the current segment's page range does not overlap the assignment page range. For example, if the segment's page range is '10-20' and the assignment page range is '15-25' the warning is not shown. It would be if the assignment page range was '21-30' though.

I am making an assumption here that it is acceptable initially that this functionality is limited to numeric page ranges, or exact matches between compared page ranges. The other common ranges that I've seen in books are roman numerals and prefixed-numeric ("A-123" for an appendix). These are generally used for front-matter and appendices etc rather than the core book content.

See commit messages for detailed notes on what changed.

Fixes https://github.com/hypothesis/client/issues/5936.

**Testing:**

1. Go to http://localhost:3000/document/vitalsource-pdf. You will now see the outside-assignment warning on the third page of the book, but not on the first two.
2. Modify `vitalsource-epub.mustache` and change the `focus` config to `{ "focus": { "pages": "15-25" } }` then go to http://localhost:3000/document/vitalsource-epub. You'll see an outside-assignment on the third chapter, but not the first two.

Additionally in these examples the page range is now shown after "Segment:" in the document/version info panel in the sidebar.