### PR TITLE
Allow notebook to be closed by pressing Esc

### DIFF
--- a/src/annotator/components/test/NotebookModal-test.js
+++ b/src/annotator/components/test/NotebookModal-test.js
@@ -173,17 +173,26 @@ describe('NotebookModal', () => {
       assert.isTrue(wrapper.exists('dialog'));
     });
 
-    it('opens and closes native dialog', () => {
-      const wrapper = createComponent({});
-      const isDialogOpen = () => wrapper.find('dialog').getDOMNode().open;
+    [
+      // Close via clicking close button
+      wrapper => getCloseButton(wrapper).props().onClick(),
 
-      act(() => emitter.publish('openNotebook', 'myGroup'));
-      wrapper.update();
-      assert.isTrue(isDialogOpen());
+      // Close via "cancel" event, like pressing `Esc` key
+      wrapper =>
+        wrapper.find('dialog').getDOMNode().dispatchEvent(new Event('cancel')),
+    ].forEach(closeDialog => {
+      it('opens and closes native dialog', () => {
+        const wrapper = createComponent({});
+        const isDialogOpen = () => wrapper.find('dialog').getDOMNode().open;
 
-      act(() => getCloseButton(wrapper).prop('onClick')());
-      wrapper.update();
-      assert.isFalse(isDialogOpen());
+        act(() => emitter.publish('openNotebook', 'myGroup'));
+        wrapper.update();
+        assert.isTrue(isDialogOpen());
+
+        act(() => closeDialog(wrapper));
+        wrapper.update();
+        assert.isFalse(isDialogOpen());
+      });
     });
   });
 


### PR DESCRIPTION
Part of #6158 

https://github.com/hypothesis/client/pull/6187 changed the notebook to be displayed in a native `dialog` when possible.

That PR disabled the default behavior to close the dialog via <kbd>Esc</kbd> key, as it didn't work out of the box.

This PR enables that behavior back, and implements the missing logic to make everything work as expected.

### Testing steps

1. Open the notebook.
2. Close it via "Close" button.
3. Open it again. Press <kbd>Esc</kbd>  and verify the notebook is closed and the sidebar is opened.
4. Check that it is possible to open the notebook again, as many times as required.