### PR TITLE
Include highlight quote text in hidden toast message

### DIFF
--- a/src/sidebar/services/autosave.ts
+++ b/src/sidebar/services/autosave.ts
@@ -1,3 +1,4 @@
+import { quote } from '../helpers/annotation-metadata';
 import type { SidebarStore } from '../store';
 import { retryPromiseOperation } from '../util/retry';
 import type { AnnotationsService } from './annotations';
@@ -65,7 +66,7 @@ export class AutosaveService {
 
         retryPromiseOperation(() => this._annotationsService.save(highlight))
           .then(() => {
-            this._toastMessenger.success('Highlight saved', {
+            this._toastMessenger.success(`Highlighted "${quote(highlight)}"`, {
               visuallyHidden: true,
             });
           })

--- a/src/sidebar/services/test/autosave-test.js
+++ b/src/sidebar/services/test/autosave-test.js
@@ -31,8 +31,19 @@ describe('AutosaveService', () => {
    * Make `fakeStore.newHighlights` return a single highlight fixture.
    */
   const oneNewHighlight = () => {
-    const newHighlight = annotationFixtures.newHighlight();
-    newHighlight.$tag = 'deadbeef';
+    const newHighlight = Object.assign(annotationFixtures.newHighlight(), {
+      $tag: 'deadbeef',
+      target: [
+        {
+          selector: [
+            {
+              type: 'TextQuoteSelector',
+              exact: 'Quote',
+            },
+          ],
+        },
+      ],
+    });
     fakeStore.newHighlights.returns([newHighlight]);
     return newHighlight;
   };
@@ -73,7 +84,7 @@ describe('AutosaveService', () => {
     await waitFor(() => !svc.isSaving());
 
     assert.calledOnce(fakeToastMessenger.success);
-    assert.calledWith(fakeToastMessenger.success, 'Highlight saved', {
+    assert.calledWith(fakeToastMessenger.success, 'Highlighted "Quote"', {
       visuallyHidden: true,
     });
   });


### PR DESCRIPTION
Closes #6188 

Enhance hidden message which is toasted when a highlight is created, so that it includes the quote text.