### PR TITLE
Render annotation cards as list items

### DIFF
--- a/src/sidebar/components/ThreadList.tsx
+++ b/src/sidebar/components/ThreadList.tsx
@@ -277,28 +277,30 @@ export default function ThreadList({ threads }: ThreadListProps) {
   return (
     <div>
       <div style={{ height: offscreenUpperHeight }} />
-      {visibleThreads.map(child => (
-        <div
-          className={classnames(
-            // The goal is to space out each annotation card vertically. Typically
-            // this is better handled by applying vertical spacing to the parent
-            // element (e.g. `space-y-3`) but in this case, the constraints of
-            // sibling divs before and after the list of annotation cards prevents
-            // this, so a bottom margin is added to each card's wrapping element.
-            'mb-3',
-          )}
-          data-testid="thread-card-container"
-          id={child.id}
-          key={child.id}
-        >
-          {headings.get(child) && (
-            <h3 className="text-md text-grey-7 font-bold pt-3 pb-2">
-              {headings.get(child)}
-            </h3>
-          )}
-          <ThreadCard thread={child} />
-        </div>
-      ))}
+      <ul>
+        {visibleThreads.map(child => (
+          <li
+            className={classnames(
+              // The goal is to space out each annotation card vertically. Typically
+              // this is better handled by applying vertical spacing to the parent
+              // element (e.g. `space-y-3`) but in this case, the constraints of
+              // sibling divs before and after the list of annotation cards prevents
+              // this, so a bottom margin is added to each card's wrapping element.
+              'mb-3',
+            )}
+            data-testid="thread-card-container"
+            id={child.id}
+            key={child.id}
+          >
+            {headings.get(child) && (
+              <h3 className="text-md text-grey-7 font-bold pt-3 pb-2">
+                {headings.get(child)}
+              </h3>
+            )}
+            <ThreadCard thread={child} />
+          </li>
+        ))}
+      </ul>
       <div style={{ height: offscreenLowerHeight }} />
     </div>
   );


### PR DESCRIPTION
Relates to #6185 

This PR is an attempt to improve the annotation cards semantics, by rendering them as list items (`<li />`) inside an unordered list (`<ul />`).

This is the simplest solution from the ones suggested in#6185. However, I have to admit I haven't been able to fully verify this makes a difference for assistive technologies.

It should have no visual changes.

The other solutions would be a bit trickier, as the component which renders the `article[aria-label]` is deeply nested down the component tree, compared to the component that iterates annotations and therefore knows the index (`ThreadList` -> `ThreadCard` -> `Thread` -> `Annotation`).

This gets even more inconvenient if we want to index annotations per users (not globally), which would require moving some logic up the component tree in order to do that.

Another option would be to make the `Annotation` component pull all annotations from the store, filter those belonging to the same user, and then trying to compute the index, but this would be slightly inefficient.

> [!NOTE]  
> It's easier to review this PR [ignoring whitespaces](https://github.com/hypothesis/client/pull/6195/files?w=1)