### PR TITLE
Add more specific labels for some close buttons

### DIFF
--- a/src/sidebar/components/HelpPanel.tsx
+++ b/src/sidebar/components/HelpPanel.tsx
@@ -114,7 +114,7 @@ function HelpPanel({ session }: HelpPanelProps) {
       onActiveChanged={onActiveChanged}
       variant="custom"
     >
-      <TabHeader>
+      <TabHeader closeTitle="Close help panel">
         <Tab
           id={tutorialTabId}
           aria-controls={tutorialPanelId}

--- a/src/sidebar/components/ShareDialog/ShareDialog.tsx
+++ b/src/sidebar/components/ShareDialog/ShareDialog.tsx
@@ -39,7 +39,7 @@ export default function ShareDialog({ shareTab }: ShareDialogProps) {
       panelName="shareGroupAnnotations"
       variant="custom"
     >
-      <TabHeader>
+      <TabHeader closeTitle="Close share panel">
         {shareTab && (
           <Tab
             id="share-panel-tab"

--- a/src/sidebar/components/tabs/TabHeader.tsx
+++ b/src/sidebar/components/tabs/TabHeader.tsx
@@ -2,14 +2,16 @@ import { CloseButton, TabList } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import type { ComponentChildren } from 'preact';
 
+export type TabHeaderProps = {
+  children: ComponentChildren;
+  /** Title for the close button. */
+  closeTitle: string;
+};
+
 /**
  * Render a header to go above a Card, with contents in a TabList
  */
-export default function TabHeader({
-  children,
-}: {
-  children: ComponentChildren;
-}) {
+export default function TabHeader({ children, closeTitle }: TabHeaderProps) {
   return (
     <div data-testid="tab-header" className="flex items-center">
       <CloseButton
@@ -30,7 +32,7 @@ export default function TabHeader({
           // the `Tab` components rendered inside the `TabList`. See issue #6131.
           'touch:!min-h-0',
         )}
-        title="Close"
+        title={closeTitle}
         variant="custom"
         size="sm"
       />


### PR DESCRIPTION
Try to improve the label set to some close buttons so that it is more specific. They previously only had the "Close" value, but the changes on this PR make it also include what is the button specifically closing.

This is part of #6194.

> [!NOTE]  
> I couldn't find more cases for this issue in the client, but there are some in the LMS. I'll address that afterwards.