### PR TITLE
Add accessible names to profile and notebook dialogs

### DIFF
--- a/src/annotator/components/ModalDialog.tsx
+++ b/src/annotator/components/ModalDialog.tsx
@@ -7,6 +7,7 @@ type DialogProps = {
   children: ComponentChildren;
   onClose: () => void;
   'data-testid'?: string;
+  'aria-label'?: string;
 };
 
 function NativeDialog({
@@ -14,6 +15,7 @@ function NativeDialog({
   onClose,
   children,
   'data-testid': testId,
+  'aria-label': label,
 }: DialogProps) {
   const dialogRef = useRef<HTMLDialogElement | null>(null);
 
@@ -39,6 +41,7 @@ function NativeDialog({
       ref={dialogRef}
       className="relative w-full h-full backdrop:bg-black/50"
       data-testid={testId}
+      aria-label={label}
     >
       {children}
     </dialog>

--- a/src/annotator/components/NotebookModal.tsx
+++ b/src/annotator/components/NotebookModal.tsx
@@ -112,10 +112,11 @@ export default function NotebookModal({
       closed={isHidden}
       onClose={onClose}
       data-testid="notebook-outer"
+      aria-label="Hypothesis notebook"
     >
       <div className="absolute right-0 m-3">
         <IconButton
-          title="Close the Notebook"
+          title="Close notebook"
           onClick={onClose}
           variant="dark"
           classes={classnames(

--- a/src/annotator/components/ProfileModal.tsx
+++ b/src/annotator/components/ProfileModal.tsx
@@ -42,6 +42,7 @@ export default function ProfileModal({ eventBus, config }: ProfileModalProps) {
       closed={isHidden}
       onClose={onClose}
       data-testid="profile-outer"
+      aria-label="Hypothesis profile"
     >
       <div className="absolute right-0 m-3">
         <IconButton


### PR DESCRIPTION
After the work from https://github.com/hypothesis/client/pull/6187, the has been a second accessibility review, which has highlighted the lack of an accessible name for the notebook dialog.

We have been suggested to use `aria-labelledby` to do this, which is also the recommendation in https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role.

However, since the label value is not displayed anywhere else, this PR implements a solution using `aria-label` instead.