### PR TITLE
Add noop setter to sidebar iframe allow attribute

### DIFF
--- a/src/annotator/sidebar.tsx
+++ b/src/annotator/sidebar.tsx
@@ -89,9 +89,12 @@ export function createSidebarIframe(config: SidebarConfig): HTMLIFrameElement {
 
   // In viahtml, pywb uses wombat.js, which monkey-patches some JS methods.
   // One of those causes the `allow` attribute to be overwritten, so we want to
-  // make it non-writable to preserve the permissions we set above.
+  // define a noop setter to preserve the permissions we set above.
+  // We can remove this workaround once pywb has been updated to use the latest
+  // version of wombat.js, which includes a fix for this.
+  // See https://github.com/webrecorder/wombat/pull/134
   return Object.defineProperty(sidebarFrame, 'allow', {
-    writable: false,
+    set: () => {},
   });
 }
 

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -1142,10 +1142,11 @@ describe('Sidebar', () => {
   describe('createSidebarIframe', () => {
     it('does not let `allow` attribute to be overwritten', () => {
       const iframe = createSidebarIframe({ sidebarAppUrl: 'https://foo.com' });
+      const initialAllow = iframe.allow;
 
-      assert.throws(() => {
-        iframe.allow = 'something else';
-      }, "Cannot assign to read only property 'allow' of object '#<HTMLIFrameElement>'");
+      iframe.allow = 'something else';
+
+      assert.equal(iframe.allow, initialAllow);
     });
   });
 });


### PR DESCRIPTION
This PR is an improvement over https://github.com/hypothesis/client/pull/6119, and an attempt to fix https://github.com/hypothesis/client/issues/6212

This PR protects the sidebar iframe's `allow` attribute from getting overwritten, by adding a noop setter to it.

Previous iteration protected it by making it non-writable, but that can cause an error to be thrown when running in strict mode, as reported in https://github.com/hypothesis/client/issues/6212

### Testing steps

1. Check out this branch
2. Open viahtml locally, and run `python ./bin/build_static.py`. This will copy and expose pywb static assets, including wombat.js
3. Go to http://localhost:9083/https://www.example.com/ and open the "Version" tab of the help panel.
  ![image](https://github.com/hypothesis/client/assets/2719332/f656bec9-2203-41d4-b964-f31e9c22e061)
4. Click "Copy version details". You should see a success toast message.

If you want to be extra safe, you can call `console.log` from the setter, and verify the value `autoplay 'self'; fullscreen 'self'` gets printed. This is what wombat.js does when appending the iframe.

```diff
- set: () => {}
+ set: console.log
```