### PR TITLE
Define the requirement of CODECOV_TOKEN secret when calling ci workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,6 +2,9 @@ name: Continuous integration
 on:
   pull_request:
   workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: true
   workflow_dispatch:
 jobs:
   ci:


### PR DESCRIPTION
https://github.com/hypothesis/client/pull/6228 added a secret to be propagated from the release workflow to the continuous-integration one.

However, for that to work, the continuous-integration workflow needs to specify this secret is expected to be passed.

This PR should fix that.

For more information see https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow and https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callsecrets