### PR TITLE
Remove no-longer needed path mapping from tsconfig

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -21,11 +21,7 @@
     // Prevent automatic inclusion of global variables defined in `@types/<name>` packages.
     // This prevents eg. Node globals from `@types/node` being included when writing
     // code for the browser.
-    "types": [],
-
-    "paths": {
-        "preact-render-to-string/jsx": ["./types/preact-render-to-string"]
-    }
+    "types": []
   },
   "include": ["**/*.js", "**/*.ts", "**/*.tsx", "types/*.d.ts"],
   "exclude": [


### PR DESCRIPTION
While working on something else, I realized I forgot to remove this path mapping that should have been part of https://github.com/hypothesis/client/pull/6224