### PR TITLE
Improve matching of segments against CFI ranges

### DIFF
--- a/src/shared/cfi.ts
+++ b/src/shared/cfi.ts
@@ -82,10 +82,11 @@ export function stripCFIAssertions(cfi: string): string {
  *
  * The full sorting rules for CFIs are specified by https://idpf.org/epub/linking/cfi/#sec-sorting.
  *
- * This function currently only implements what is necessary to compare simple
- * CFIs that specify a location within an EPUB's Package Document, without any step
- * indirections ("!"). These CFIs consist of a "/"-delimited sequence of numbers,
- * with optional assertions in `[...]` brackets (eg. "/2/4[chapter2ref]").
+ * This function only considers the part of the CFI up to the first step
+ * indirection ("!"), which identify a location within the EPUB's Package
+ * Document. These portions of CFIs consist of a "/"-delimited sequence of
+ * numbers, with optional assertions in `[...]` brackets (eg.
+ * "/2/4[chapter2ref]").
  *
  * Per the sorting rules linked above, the input CFIs are assumed to be
  * unescaped. This means that they may contain circumflex (^) escape characters,
@@ -102,7 +103,7 @@ export function stripCFIAssertions(cfi: string): string {
  */
 export function compareCFIs(a: string, b: string): number {
   const parseCFI = (cfi: string) => {
-    return stripCFIAssertions(cfi)
+    return documentCFI(cfi)
       .split('/')
       .map(str => {
         // CFI step values _should_ always be integers. We currently handle
@@ -117,6 +118,9 @@ export function compareCFIs(a: string, b: string): number {
 
 /**
  * Return true if the CFI `cfi` lies in the range [start, end).
+ *
+ * Only the part of the CFI up to the first step indirection ("!") is
+ * considered. See {@link documentCFI}.
  */
 export function cfiInRange(cfi: string, start: string, end: string): boolean {
   return compareCFIs(cfi, start) >= 0 && compareCFIs(cfi, end) < 0;

--- a/src/shared/cfi.ts
+++ b/src/shared/cfi.ts
@@ -35,6 +35,22 @@ function compareArrays(
 }
 
 /**
+ * Split a hyphen-separated CFI range.
+ *
+ * CFI assertions are stripped in the process. If `range` does not contain a
+ * hyphen, the result will be an empty range with the end point being the same
+ * as the start point.
+ *
+ * @example
+ *   splitCFIRange("/2/4[chap-02]-/2/6[chap-03]") // returns `["/2/4", "/2/6"]`.
+ */
+export function splitCFIRange(range: string): [string, string] {
+  const rangeWithoutAssertions = stripCFIAssertions(range);
+  const [start, end] = rangeWithoutAssertions.split('-', 2);
+  return [start, end ?? start];
+}
+
+/**
  * Strip assertions from a Canonical Fragment Identifier.
  *
  * Assertions are `[...]` enclosed sections which act as checks on the validity

--- a/src/shared/test/cfi-test.js
+++ b/src/shared/test/cfi-test.js
@@ -97,6 +97,23 @@ describe('sidebar/util/cfi', () => {
         b: '',
         expected: 0,
       },
+      // CFIs with step indirections. Only the part before the step indirection
+      // is considered.
+      {
+        a: '/2!/4',
+        b: '/2!/8',
+        expected: 0,
+      },
+      {
+        a: '/2!/4',
+        b: '/4!/8',
+        expected: -1,
+      },
+      {
+        a: '/4!/8',
+        b: '/2!/4',
+        expected: 1,
+      },
     ].forEach(({ a, b, expected }) => {
       it('compares CFIs', () => {
         assert.equal(
@@ -161,6 +178,14 @@ describe('sidebar/util/cfi', () => {
         start: '/2',
         end: '/4',
         expected: false,
+      },
+      // CFIs with step indirections. Only the part before the first step
+      // indirection is considered.
+      {
+        cfi: '/6',
+        start: '/6!/2',
+        end: '/8!/4',
+        expected: true,
       },
     ].forEach(({ cfi, start, end, expected }) => {
       it('should return true if the cfi is in the range [start, end)', () => {

--- a/src/shared/test/cfi-test.js
+++ b/src/shared/test/cfi-test.js
@@ -2,6 +2,7 @@ import {
   cfiInRange,
   compareCFIs,
   documentCFI,
+  splitCFIRange,
   stripCFIAssertions,
 } from '../cfi';
 
@@ -22,6 +23,25 @@ describe('sidebar/util/cfi', () => {
     it('ignores escaped characters', () => {
       assert.equal(stripCFIAssertions('/1/2[chap4^[ignoreme^]ref]'), '/1/2');
       assert.equal(stripCFIAssertions('/1/2[a^[b^]]/3[c^[d^]]'), '/1/2/3');
+    });
+  });
+
+  describe('splitCFIRange', () => {
+    [
+      {
+        range: '/2/4-/4/6',
+        expected: ['/2/4', '/4/6'],
+      },
+      {
+        range: '/2/4[chap-02]-/2/6[chap-03]',
+        expected: ['/2/4', '/2/6'],
+      },
+      {
+        range: '/2/4',
+        expected: ['/2/4', '/2/4'],
+      },
+    ].forEach(({ range, expected }) => {
+      assert.deepEqual(splitCFIRange(range), expected);
     });
   });
 

--- a/src/sidebar/helpers/annotation-segment.ts
+++ b/src/sidebar/helpers/annotation-segment.ts
@@ -1,4 +1,8 @@
-import { cfiInRange, stripCFIAssertions } from '../../shared/cfi';
+import {
+  cfiInRange,
+  splitCFIRange,
+  stripCFIAssertions,
+} from '../../shared/cfi';
 import type { SegmentInfo } from '../../types/annotator';
 import type { Annotation, EPUBContentSelector } from '../../types/api';
 import type { Filters } from '../store/modules/filters';
@@ -41,7 +45,7 @@ export function segmentMatchesFocusFilters(
   filters: Filters,
 ): boolean {
   if (segment.cfi && filters.cfi) {
-    const [cfiStart, cfiEnd] = filters.cfi.value.split('-');
+    const [cfiStart, cfiEnd] = splitCFIRange(filters.cfi.value);
     return cfiInRange(segment.cfi, cfiStart, cfiEnd);
   }
   if (segment.pages && filters.page) {

--- a/src/sidebar/helpers/filter-annotations.ts
+++ b/src/sidebar/helpers/filter-annotations.ts
@@ -1,4 +1,8 @@
-import { cfiInRange, stripCFIAssertions } from '../../shared/cfi';
+import {
+  cfiInRange,
+  splitCFIRange,
+  stripCFIAssertions,
+} from '../../shared/cfi';
 import type { Annotation } from '../../types/api';
 import { pageLabelInRange } from '../util/page-range';
 import * as unicodeUtils from '../util/unicode';
@@ -113,12 +117,11 @@ const fieldMatchers: Record<string, Matcher | Matcher<number>> = {
       //
       // If we wanted to use a more standard CFI range representation,
       // we could follow https://idpf.org/epub/linking/cfi/#sec-ranges.
-      if (cfiTerm.includes('-')) {
-        const [start, end] = cfiTerm.split('-');
-        return cfiInRange(cfi, start, end);
-      } else {
-        return false;
-      }
+      //
+      // If `cfiTerm` does not contain a hyphen, the result will be an empty
+      // range that does not match any CFIs.
+      const [start, end] = splitCFIRange(cfiTerm);
+      return cfiInRange(cfi, start, end);
     },
     normalize: (val: string) => stripCFIAssertions(val.trim()),
   },

--- a/src/sidebar/helpers/test/annotation-segment-test.js
+++ b/src/sidebar/helpers/test/annotation-segment-test.js
@@ -122,6 +122,13 @@ describe('segmentMatchesFocusFilters', () => {
       filters: { cfi: { value: '/2-/4' } },
       expected: true,
     },
+    // Filter present, matches segment. Filter CFI has step indirections,
+    // which should be ignored.
+    {
+      segment: { cfi: '/2' },
+      filters: { cfi: { value: '/2!/2-/4!/4' } },
+      expected: true,
+    },
     // Filter present, does not match segment
     {
       segment: { cfi: '/6' },


### PR DESCRIPTION
This PR contains a couple of improvements to how we match CFI ranges (eg. for ebook assignments) against the CFI of the current book segment:

1. Ignore the part of CFIs after the step indirection ("!") (first commit). As a reminder, the part before the step indirection identifies the content document/HTML file, the part after identifies the location within that file.
2. Ignore hyphens inside assertions when splitting CFI ranges (second commit)

This resolves an issue where the user was incorrectly presented with a "you are outside the assignment" notice when a VitalSource assignment was created, and the CFIs in the table of contents had step indirections in them. See the added test case in `annotation-segment-test.js` for an example. See also [this Slack thread](https://hypothes-is.slack.com/archives/C4K6M7P5E/p1710190672323349) reporting the issue.