### PR TITLE
Add tab panel linked with selected sidebar tab

### DIFF
--- a/src/sidebar/components/SelectionTabs.tsx
+++ b/src/sidebar/components/SelectionTabs.tsx
@@ -29,6 +29,7 @@ type TabProps = {
   isWaitingToAnchor: boolean;
 
   label: string;
+  name: TabName;
 
   /** Callback to invoke when this tab is selected */
   onSelect: () => void;
@@ -44,6 +45,7 @@ function Tab({
   isSelected,
   label,
   onSelect,
+  name,
 }: TabProps) {
   const selectTab = () => {
     if (!isSelected) {
@@ -69,6 +71,8 @@ function Tab({
       tabIndex={0}
       title={title}
       underline="none"
+      id={`${name}-tab`}
+      aria-controls={`${name}-panel`}
     >
       <>
         {children}
@@ -163,6 +167,7 @@ function SelectionTabs({
             isSelected={selectedTab === 'annotation'}
             label="Annotations"
             onSelect={() => selectTab('annotation')}
+            name="annotation"
           >
             Annotations
           </Tab>
@@ -172,6 +177,7 @@ function SelectionTabs({
             isSelected={selectedTab === 'note'}
             label="Page notes"
             onSelect={() => selectTab('note')}
+            name="note"
           >
             Page Notes
           </Tab>
@@ -182,6 +188,7 @@ function SelectionTabs({
               isSelected={selectedTab === 'orphan'}
               label="Orphans"
               onSelect={() => selectTab('orphan')}
+              name="orphan"
             >
               Orphans
             </Tab>

--- a/src/sidebar/components/SidebarView.tsx
+++ b/src/sidebar/components/SidebarView.tsx
@@ -42,6 +42,7 @@ function SidebarView({
   const focusedGroupId = store.focusedGroupId();
   const isLoading = store.isLoading();
   const isLoggedIn = store.isLoggedIn();
+  const selectedTab = store.selectedTab();
   const pendingUpdatesNotification = store.isFeatureEnabled(
     'pending_updates_notification',
   );
@@ -158,7 +159,13 @@ function SidebarView({
           <PendingUpdatesNotification />
         </div>
       )}
-      <ThreadList threads={rootThread.children} />
+      <div
+        role="tabpanel"
+        id={`${selectedTab}-panel`}
+        aria-labelledby={`${selectedTab}-tab`}
+      >
+        <ThreadList threads={rootThread.children} />
+      </div>
       {showLoggedOutMessage && <LoggedOutMessage onLogin={onLogin} />}
     </div>
   );

--- a/src/sidebar/components/test/SidebarView-test.js
+++ b/src/sidebar/components/test/SidebarView-test.js
@@ -3,6 +3,7 @@ import {
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
 import { mount } from 'enzyme';
+import sinon from 'sinon';
 
 import SidebarView, { $imports } from '../SidebarView';
 
@@ -71,6 +72,7 @@ describe('SidebarView', () => {
       searchUris: sinon.stub().returns([]),
       toggleFocusMode: sinon.stub(),
       isFeatureEnabled: sinon.stub().returns(false),
+      selectedTab: sinon.stub().returns(''),
     };
 
     fakeTabsUtil = {


### PR DESCRIPTION
Closes https://github.com/hypothesis/client/issues/6267

Add the necessary accessible attributes to the sidebar tabs and the panels they control, so that assistive technologies know what's the corresponding panel.

The changes include:

* Adding an `id` to every tab.
* Adding the `aria-controls` attribute to every tab, pointing to the panel's id.
* Adding `role="tabpanel"` to the content panel.
* Adding a dynamic `id` to the content panel, so that it matches selected tab.
* Adding a dynamic `aria-labelledby` attribute to the content panel, so that it matches selected tab.

### Considerations

Technically speaking, the recommendation is to have different DOM nodes for every tab panel, and make sure only the selected one is visible.

However, we are currently re-using the same `<ThreadList />` for all panels, and just dynamically changing its contents, so I have wrapped it in a `role="tabpanel"` container which `id` and `aria-labelledby` are changed dynamically.

I have tested it with `orca` and `NVDA`, and it works the same as with other tabbed panels where we do have different DOM nodes per panel.