### PR TITLE
Add accessible tabpanel role to sidebar panel

### DIFF
--- a/src/sidebar/components/SidebarView.tsx
+++ b/src/sidebar/components/SidebarView.tsx
@@ -9,10 +9,8 @@ import { useSidebarStore } from '../store';
 import LoggedOutMessage from './LoggedOutMessage';
 import LoginPromptPanel from './LoginPromptPanel';
 import PendingUpdatesNotification from './PendingUpdatesNotification';
-import SelectionTabs from './SelectionTabs';
 import SidebarContentError from './SidebarContentError';
-import ThreadList from './ThreadList';
-import { useRootThread } from './hooks/use-root-thread';
+import SidebarTabs from './SidebarTabs';
 import FilterControls from './search/FilterControls';
 
 export type SidebarViewProps = {
@@ -35,8 +33,6 @@ function SidebarView({
   loadAnnotationsService,
   streamer,
 }: SidebarViewProps) {
-  const { rootThread, tabCounts } = useRootThread();
-
   // Store state values
   const store = useSidebarStore();
   const focusedGroupId = store.focusedGroupId();
@@ -67,8 +63,6 @@ function SidebarView({
 
   const hasContentError =
     hasDirectLinkedAnnotationError || hasDirectLinkedGroupError;
-
-  const showTabs = !hasContentError;
 
   // Whether to render the new filter UI. Note that when the search panel is
   // open, filter controls are integrated into it. The UI may render nothing
@@ -150,15 +144,12 @@ function SidebarView({
       {hasDirectLinkedGroupError && (
         <SidebarContentError errorType="group" onLoginRequest={onLogin} />
       )}
-      {showTabs && (
-        <SelectionTabs isLoading={isLoading} tabCounts={tabCounts} />
-      )}
+      {!hasContentError && <SidebarTabs isLoading={isLoading} />}
       {pendingUpdatesNotification && (
         <div className="fixed z-1 right-2 top-12">
           <PendingUpdatesNotification />
         </div>
       )}
-      <ThreadList threads={rootThread.children} />
       {showLoggedOutMessage && <LoggedOutMessage onLogin={onLogin} />}
     </div>
   );

--- a/src/sidebar/components/test/SidebarView-test.js
+++ b/src/sidebar/components/test/SidebarView-test.js
@@ -9,7 +9,6 @@ import SidebarView, { $imports } from '../SidebarView';
 describe('SidebarView', () => {
   let fakeFrameSync;
   let fakeLoadAnnotationsService;
-  let fakeUseRootThread;
   let fakeStore;
   let fakeStreamer;
   let fakeTabsUtil;
@@ -34,16 +33,6 @@ describe('SidebarView', () => {
     fakeLoadAnnotationsService = {
       load: sinon.stub(),
     };
-    fakeUseRootThread = sinon.stub().returns({
-      rootThread: {
-        children: [],
-      },
-      tabCounts: {
-        annotation: 1,
-        note: 2,
-        orphan: 0,
-      },
-    });
     fakeStreamer = {
       connect: sinon.stub(),
     };
@@ -79,7 +68,6 @@ describe('SidebarView', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      './hooks/use-root-thread': { useRootThread: fakeUseRootThread },
       '../store': { useSidebarStore: () => fakeStore },
       '../helpers/tabs': fakeTabsUtil,
     });
@@ -210,7 +198,7 @@ describe('SidebarView', () => {
 
       it('does not render tabs', () => {
         const wrapper = createComponent();
-        assert.isFalse(wrapper.find('SelectionTabs').exists());
+        assert.isFalse(wrapper.find('SidebarTabs').exists());
       });
 
       it('does not render filter status', () => {
@@ -239,7 +227,7 @@ describe('SidebarView', () => {
 
     it('does not render tabs', () => {
       const wrapper = createComponent();
-      assert.isFalse(wrapper.find('SelectionTabs').exists());
+      assert.isFalse(wrapper.find('SidebarTabs').exists());
     });
 
     it('does not render filter status', () => {


### PR DESCRIPTION
Fixes https://github.com/hypothesis/client/issues/6267

This PR is an alternative to #6270, but with some improvements to address the issues highlighted in [this comment](https://github.com/hypothesis/client/pull/6270#discussion_r1530022461).

The PR has two commits. The first one refactors the structure of the `SelectionTabs` component (now renamed to `SidebarTabbedPanel`) so that it also takes care of rendering the `ThreadsList` component. This was previously done in a common parent component, making it harder to wrap the appropriate children in a new `role="tabpanel"` container.

Now everything which should be part of that container is rendered inside of the new `SidebarTabbedPanel`.

The second commit adds the accessibility fixes that were originally introduced in #6270, but with the benefit that tab and panel IDs are now all generated in a single place with a couple helper functions, to reduce the risk of breaking it in potential future refactors.

> [!TIP]
> This PR is easier to review [ignoring whitespaces](https://github.com/hypothesis/client/pull/6271/files?w=1).

### Considerations

There's a problem inherited from #6270 which I don't love, the fact that we just have one tabpanel which `id` and `aria-labelledby` attributes are changed dynamically based on active tab.

This means there's two tabs at all times pointing to DOM nodes which don't exist, and that may cause some assistive technologies to malfunction.

However, since we render the main content with the same `ThreadList`, it is tricky to solve this in an efficient way.

I can think on something like this though:

```tsx
<div
  role="tabpanel" 
  id="annotation-panel"
  aria-labelledby="annotation-tab"
  className={classnames({ hidden: selectedTab !== 'annotation' })}
>
  {selectedTab === 'annotation' &&  (
    <>
      // Other annotation-only components...
      <ThreadList threads={rootThread.children} />
    </>
  )}
</div>
<div
  role="tabpanel" 
  id="note-panel"
  aria-labelledby="note-tab"
  className={classnames({ hidden: selectedTab !== 'note' })}
>
  {selectedTab === 'note' && (
    <>
      // Other note-only components...
      <ThreadList threads={rootThread.children} />
    </>
  )}
</div>
<div
  role="tabpanel" 
  id="orphan-panel"
  aria-labelledby="orphan-tab"
  className={classnames({ hidden: selectedTab !== 'orphan' })}
>
  {selectedTab === 'orphan' &&  (
    <>
      // Other orphan-only components...
      <ThreadList threads={rootThread.children} />
    </>
  )}
</div>
```