### PR TITLE
Pending updates notification improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.16.7",
     "@hypothesis/frontend-build": "^3.0.0",
-    "@hypothesis/frontend-shared": "^7.2.0",
+    "@hypothesis/frontend-shared": "^7.6.0",
     "@hypothesis/frontend-testing": "^1.2.0",
     "@npmcli/arborist": "^7.0.0",
     "@octokit/rest": "^20.0.1",

--- a/src/shared/pluralize.ts
+++ b/src/shared/pluralize.ts
@@ -1,0 +1,6 @@
+/**
+ * Naive simple English pluralization
+ */
+export function pluralize(count: number, singular: string, plural: string) {
+  return count === 1 ? singular : plural;
+}

--- a/src/shared/test/pluralize-test.js
+++ b/src/shared/test/pluralize-test.js
@@ -1,0 +1,14 @@
+import { pluralize } from '../pluralize';
+
+describe('pluralize', () => {
+  [
+    { count: 0, expectedResult: 'people' },
+    { count: 1, expectedResult: 'person' },
+    { count: 2, expectedResult: 'people' },
+    { count: 10, expectedResult: 'people' },
+  ].forEach(({ count, expectedResult }) => {
+    it('returns expected form', () => {
+      assert.equal(pluralize(count, 'person', 'people'), expectedResult);
+    });
+  });
+});

--- a/src/sidebar/components/PendingUpdatesNotification.tsx
+++ b/src/sidebar/components/PendingUpdatesNotification.tsx
@@ -1,4 +1,4 @@
-import { Button, RefreshIcon } from '@hypothesis/frontend-shared';
+import { Button, DownloadIcon } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 
@@ -66,12 +66,12 @@ function PendingUpdatesNotification({
           'flex gap-1.5 items-center py-1 px-2',
           'rounded shadow-lg bg-gray-900 text-white',
         )}
+        icon={DownloadIcon}
         onMouseEnter={() => setCollapsed(false)}
         onFocus={() => setCollapsed(false)}
         onMouseLeave={() => !timeout.current && setCollapsed(true)}
         onBlur={() => !timeout.current && setCollapsed(true)}
       >
-        <RefreshIcon />
         {!collapsed && (
           <span data-testid="full-notification" className="whitespace-nowrap">
             Load <span className="font-bold">{pendingUpdateCount}</span> updates{' '}

--- a/src/sidebar/components/PendingUpdatesNotification.tsx
+++ b/src/sidebar/components/PendingUpdatesNotification.tsx
@@ -67,12 +67,12 @@ function PendingUpdatesNotification({
           'flex gap-1.5 items-center py-1 px-2',
           'rounded shadow-lg bg-gray-900 text-white',
         )}
-        icon={DownloadIcon}
         onMouseEnter={() => setCollapsed(false)}
         onFocus={() => setCollapsed(false)}
         onMouseLeave={() => !timeout.current && setCollapsed(true)}
         onBlur={() => !timeout.current && setCollapsed(true)}
       >
+        <DownloadIcon className="w-em h-em opacity-80" />
         {!collapsed && (
           <span data-testid="full-notification" className="whitespace-nowrap">
             Load <span className="font-bold">{pendingUpdateCount}</span>{' '}

--- a/src/sidebar/components/PendingUpdatesNotification.tsx
+++ b/src/sidebar/components/PendingUpdatesNotification.tsx
@@ -2,6 +2,7 @@ import { Button, DownloadIcon } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 
+import { pluralize } from '../../shared/pluralize';
 import { useShortcut } from '../../shared/shortcut';
 import { withServices } from '../service-context';
 import type { StreamerService } from '../services/streamer';
@@ -74,7 +75,8 @@ function PendingUpdatesNotification({
       >
         {!collapsed && (
           <span data-testid="full-notification" className="whitespace-nowrap">
-            Load <span className="font-bold">{pendingUpdateCount}</span> updates{' '}
+            Load <span className="font-bold">{pendingUpdateCount}</span>{' '}
+            {pluralize(pendingUpdateCount, 'update', 'updates')}{' '}
             <span className="sr-only">by pressing l</span>
           </span>
         )}

--- a/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
+++ b/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
@@ -9,6 +9,7 @@ import {
 import { useCallback, useId, useMemo, useState } from 'preact/hooks';
 
 import { downloadFile } from '../../../shared/download-file';
+import { pluralize } from '../../../shared/pluralize';
 import type { APIAnnotationData } from '../../../types/api';
 import { annotationDisplayName } from '../../helpers/annotation-user';
 import type { UserAnnotations } from '../../helpers/annotations-by-user';
@@ -255,11 +256,6 @@ function ExportAnnotations({
   if (!exportReady) {
     return <LoadingSpinner />;
   }
-
-  // Naive simple English pluralization
-  const pluralize = (count: number, singular: string, plural: string) => {
-    return count === 1 ? singular : plural;
-  };
 
   return (
     <form

--- a/src/sidebar/components/SidebarTabs.tsx
+++ b/src/sidebar/components/SidebarTabs.tsx
@@ -9,6 +9,7 @@ import {
 import classnames from 'classnames';
 import type { ComponentChildren } from 'preact';
 
+import { pluralize } from '../../shared/pluralize';
 import type { SidebarSettings } from '../../types/config';
 import type { TabName } from '../../types/sidebar';
 import { applyTheme } from '../helpers/theme';
@@ -126,11 +127,6 @@ function SidebarTabs({
     !isWaitingToAnchorAnnotations;
 
   const showNotesUnavailableMessage = selectedTab === 'note' && noteCount === 0;
-
-  // Naive simple English pluralization
-  const pluralize = (count: number, singular: string, plural: string) => {
-    return count === 1 ? singular : plural;
-  };
 
   const tabCountsSummaryPieces = [];
   if (annotationCount > 0) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2705,15 +2705,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^7.2.0":
-  version: 7.5.0
-  resolution: "@hypothesis/frontend-shared@npm:7.5.0"
+"@hypothesis/frontend-shared@npm:^7.6.0":
+  version: 7.6.0
+  resolution: "@hypothesis/frontend-shared@npm:7.6.0"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.4.0
-  checksum: 180cef619b7a0d9c74ff0f580db211d86b7c41359b8c8c3bec3c04c71a6d028cbea1dc52867191c3a3e9cdcaa4bc8635d997f6beddefd438f2fa5b7153a60a74
+  checksum: 1d8c15817f8cbbf590b723f3426f3057ff90b0654986e2408760626910e71f1ea1857a7e9935e0773f0e53230ab96bc8ddd8a990d8f73e2e9b58038c03eca382
   languageName: node
   linkType: hard
 
@@ -9325,7 +9325,7 @@ __metadata:
     "@babel/preset-react": ^7.0.0
     "@babel/preset-typescript": ^7.16.7
     "@hypothesis/frontend-build": ^3.0.0
-    "@hypothesis/frontend-shared": ^7.2.0
+    "@hypothesis/frontend-shared": ^7.6.0
     "@hypothesis/frontend-testing": ^1.2.0
     "@npmcli/arborist": ^7.0.0
     "@octokit/rest": ^20.0.1


### PR DESCRIPTION
Part of https://github.com/hypothesis/client/issues/6255

This PR fixes a couple of things highlighted while internally testing the new pending updates notification:

* Use the "download" icon from the designs.
* Use the singular "update" form when there's only one pending update ("Load 1 update" vs "Load 3 updates")
* Make the icon's color slightly lighter than the text (the design set an 80% opacity to the icon in order to achieve this).