### PR TITLE
Infer service names from component props when calling `withServices` HOC

### DIFF
--- a/src/sidebar/service-context.tsx
+++ b/src/sidebar/service-context.tsx
@@ -58,7 +58,7 @@ export const ServiceContext = createContext(fallbackInjector);
  */
 export function withServices<
   Props extends Record<string, unknown>,
-  ServiceName extends string,
+  ServiceName extends string & keyof Props,
 >(
   Component: ComponentType<Props>,
   serviceNames: ServiceName[],
@@ -71,16 +71,14 @@ export function withServices<
     // Inject services, unless they have been overridden by props passed from
     // the parent component.
 
-    const services: Record<string, unknown> = {};
+    const services: Partial<Record<ServiceName, unknown>> = {};
     for (const service of serviceNames) {
       // Debugging check to make sure the store is used correctly.
-      if (process.env.NODE_ENV !== 'production') {
-        if (service === 'store') {
-          /* istanbul ignore next - Ignore debug code */
-          throw new Error(
-            'Do not use `withServices` to inject the `store` service. Use the `useStore` hook instead',
-          );
-        }
+      if (process.env.NODE_ENV !== 'production' && service === 'store') {
+        /* istanbul ignore next - Ignore debug code */
+        throw new Error(
+          'Do not use `withServices` to inject the `store` service. Use the `useStore` hook instead',
+        );
       }
 
       if (!(service in props)) {


### PR DESCRIPTION
This PR makes the type of the `serviceNames` param in `withServices()` a bit stricter, accepting only values which are component property names.

The reasons that motivated this PR are a couple of mistakes I faced while refactoring a component and changing the services it needs to get injected, ending up with some `undefined` dependencies at runtime, with a not immediately obvious reason.

With these changes, the type checking now works like this, which is a bit more helpful:

https://github.com/hypothesis/client/assets/2719332/200bcaf9-9867-46bd-91e8-9e06bf96fed5

