### PR TITLE
Adjust pending updates notification alignment

### DIFF
--- a/src/sidebar/components/SidebarTabs.tsx
+++ b/src/sidebar/components/SidebarTabs.tsx
@@ -154,7 +154,7 @@ function SidebarTabs({
           'space-y-3 pb-[9px]',
         )}
       >
-        <div className="flex gap-x-6 theme-clean:ml-[15px]" role="tablist">
+        <div className="flex gap-x-6 theme-clean:ml-[15px] mt-1" role="tablist">
           <Tab
             count={annotationCount}
             isWaitingToAnchor={isWaitingToAnchorAnnotations}

--- a/src/sidebar/components/SidebarView.tsx
+++ b/src/sidebar/components/SidebarView.tsx
@@ -1,3 +1,4 @@
+import classnames from 'classnames';
 import { useEffect, useRef } from 'preact/hooks';
 
 import { tabForAnnotation } from '../helpers/tabs';
@@ -146,7 +147,15 @@ function SidebarView({
       )}
       {!hasContentError && <SidebarTabs isLoading={isLoading} />}
       {pendingUpdatesNotification && (
-        <div className="fixed z-1 right-2 top-12">
+        <div
+          className={classnames(
+            'fixed z-1',
+            // Setting 9px to the right instead of some standard tailwind size,
+            // so that it matches the padding of the sidebar's container.
+            // DEFAULT `.container` padding is defined in tailwind.conf.mjs
+            'right-[9px] top-12',
+          )}
+        >
           <PendingUpdatesNotification />
         </div>
       )}


### PR DESCRIPTION
Part of https://github.com/hypothesis/client/issues/6255

Add some small placement adjustments to the pending updates notification so that it better aligns with other components in specific use cases:

* Replace `right-2` with `right-[9px]` to match the `container` class that the sidebar uses, which has a 9px padding.
  When there's no scroll or in systems where the scrollbar does not use space (like MacOS), the notification looked a bit off to the right compared to other sidebar components.
  Before:
  ![image](https://github.com/hypothesis/client/assets/2719332/4bed3428-3568-455c-8f37-464658d975e0)
  After:
  ![image](https://github.com/hypothesis/client/assets/2719332/649f83b2-0570-4d0c-b893-0709cb164baf)
* Add a bit of margin top to the sidebar tabs, so that they have the same space above and below, and therefore they vertically align with the notification when the scroll is right at the top or there's no scroll.
  Before:
  ![image](https://github.com/hypothesis/client/assets/2719332/6f7c0c83-3d20-47f9-8cf6-88938f8c7f63)
  After:
  ![image](https://github.com/hypothesis/client/assets/2719332/efb07473-605d-48ba-b553-0591e985d91e)

> These improvements were suggested during internal testing