### PR TITLE
Spotlight annotations when loaded via pending updates notification

### DIFF
--- a/src/sidebar/services/streamer.ts
+++ b/src/sidebar/services/streamer.ts
@@ -82,7 +82,10 @@ export class StreamerService {
    * applied.
    */
   applyPendingUpdates() {
-    const updates = Object.values(this._store.pendingUpdates());
+    const updates = Object.values(this._store.pendingUpdates()).map(ann => ({
+      ...ann,
+      $spotlight: true,
+    }));
     if (updates.length) {
       this._store.addAnnotations(updates);
     }

--- a/src/sidebar/services/test/streamer-test.js
+++ b/src/sidebar/services/test/streamer-test.js
@@ -401,7 +401,10 @@ describe('StreamerService', () => {
         });
         assert.calledWith(
           fakeStore.addAnnotations,
-          fixtures.createNotification.payload,
+          fixtures.createNotification.payload.map(ann => ({
+            ...ann,
+            $spotlight: true,
+          })),
         );
       });
     });
@@ -447,7 +450,9 @@ describe('StreamerService', () => {
     it('applies pending updates', () => {
       fakeStore.pendingUpdates.returns({ 'an-id': { id: 'an-id' } });
       activeStreamer.applyPendingUpdates();
-      assert.calledWith(fakeStore.addAnnotations, [{ id: 'an-id' }]);
+      assert.calledWith(fakeStore.addAnnotations, [
+        { id: 'an-id', $spotlight: true },
+      ]);
     });
 
     it('applies pending deletions', () => {

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -37,4 +37,7 @@ export type ClientAnnotationData = {
    * `true` if anchoring failed or `false` if it succeeded.
    */
   $orphan?: boolean;
+
+  /** Whether the annotation should be spotlighted or not. */
+  $spotlight?: boolean;
 };


### PR DESCRIPTION
Part of https://github.com/hypothesis/client/issues/6255

This PR changes annotation cards so that they display a brand-color border for 5 seconds when updated/created via pending updates button or notification.

This helps catching the user's attention regarding the new updates applied using this mechanism.

### Out of scope

* Scrolling to the "closest" updated/created annotation.
* Advanced logic to determine when to stop spotlighting an annotation card. For now it's just a static 5 second timeout.
* Spotlight a card when its replies have changed.

### Testing steps

1. Open https://localhost:3000 in two browsers.
2. Create an annotation in one of them.
3. Click the pending updates button/notification on the other one -> the new annotation should appear with brand-color border.
4. Repeat steps 2 and 3, but editing an existing annotation instead of creating a new one.