### PR TITLE
Troubleshooting release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: Release
 
 permissions:
-  id-token: write  # Required for AWS OIDC auth.
+  id-token: write # Required for AWS OIDC auth.
+  contents: write # Required to tag
 
 concurrency:
   group: ${{ github.event.repository.name }}-deploy


### PR DESCRIPTION
- This commit manual sets the `contents` permission to write.
- We were running into failures after enabling the `id-token: write` permission required for AWS OIDC auth