### PR TITLE
Add logic to dynamically display instructor dashboard entry point

### DIFF
--- a/src/sidebar/components/UserMenu.tsx
+++ b/src/sidebar/components/UserMenu.tsx
@@ -8,6 +8,7 @@ import {
   username as getUsername,
 } from '../helpers/account-id';
 import { withServices } from '../service-context';
+import type { DashboardService } from '../services/dashboard';
 import type { FrameSyncService } from '../services/frame-sync';
 import { useSidebarStore } from '../store';
 import Menu from './Menu';
@@ -16,6 +17,9 @@ import MenuSection from './MenuSection';
 
 export type UserMenuProps = {
   onLogout: () => void;
+
+  // Injected
+  dashboard: DashboardService;
   frameSync: FrameSyncService;
   settings: SidebarSettings;
 };
@@ -26,7 +30,7 @@ export type UserMenuProps = {
  * This menu will contain different items depending on service configuration,
  * context and whether the user is first- or third-party.
  */
-function UserMenu({ frameSync, onLogout, settings }: UserMenuProps) {
+function UserMenu({ frameSync, onLogout, settings, dashboard }: UserMenuProps) {
   const store = useSidebarStore();
   const defaultAuthority = store.defaultAuthority();
   const profile = store.profile();
@@ -110,6 +114,11 @@ function UserMenu({ frameSync, onLogout, settings }: UserMenuProps) {
           )}
           <MenuItem label="Open notebook" onClick={() => onSelectNotebook()} />
         </MenuSection>
+        {settings.dashboard?.showEntryPoint && (
+          <MenuSection>
+            <MenuItem label="Open dashboard" onClick={() => dashboard.open()} />
+          </MenuSection>
+        )}
         {logoutAvailable && (
           <MenuSection>
             <MenuItem
@@ -124,4 +133,4 @@ function UserMenu({ frameSync, onLogout, settings }: UserMenuProps) {
   );
 }
 
-export default withServices(UserMenu, ['frameSync', 'settings']);
+export default withServices(UserMenu, ['dashboard', 'frameSync', 'settings']);

--- a/src/sidebar/components/test/UserMenu-test.js
+++ b/src/sidebar/components/test/UserMenu-test.js
@@ -7,6 +7,7 @@ import UserMenu, { $imports } from '../UserMenu';
 describe('UserMenu', () => {
   let fakeProfile;
   let fakeFrameSync;
+  let fakeDashboard;
   let fakeIsThirdPartyUser;
   let fakeOnLogout;
   let fakeServiceConfig;
@@ -18,6 +19,7 @@ describe('UserMenu', () => {
     return mount(
       <UserMenu
         frameSync={fakeFrameSync}
+        dashboard={fakeDashboard}
         onLogout={fakeOnLogout}
         settings={fakeSettings}
       />,
@@ -38,6 +40,7 @@ describe('UserMenu', () => {
       userid: 'acct:eleanorFishtail@hypothes.is',
     };
     fakeFrameSync = { notifyHost: sinon.stub() };
+    fakeDashboard = { open: sinon.stub() };
     fakeIsThirdPartyUser = sinon.stub();
     fakeOnLogout = sinon.stub();
     fakeServiceConfig = sinon.stub();
@@ -363,6 +366,33 @@ describe('UserMenu', () => {
           assert.equal(logOutMenuItem.prop('onClick'), fakeOnLogout);
         }
       });
+    });
+  });
+
+  describe('open dashboard menu item', () => {
+    [
+      { dashboard: undefined, menuShouldExist: false },
+      { dashboard: { showEntryPoint: false }, menuShouldExist: false },
+      { dashboard: { showEntryPoint: true }, menuShouldExist: true },
+    ].forEach(({ dashboard, menuShouldExist }) => {
+      it('shows the menu item only if enabled in settings', () => {
+        fakeSettings.dashboard = dashboard;
+        const wrapper = createUserMenu();
+
+        assert.equal(
+          wrapper.exists('MenuItem[label="Open dashboard"]'),
+          menuShouldExist,
+        );
+      });
+    });
+
+    it('opens dashboard when clicked', () => {
+      fakeSettings.dashboard = { showEntryPoint: true };
+      const wrapper = createUserMenu();
+
+      wrapper.find('MenuItem[label="Open dashboard"]').props().onClick();
+
+      assert.called(fakeDashboard.open);
     });
   });
 });

--- a/src/sidebar/index.tsx
+++ b/src/sidebar/index.tsx
@@ -25,6 +25,7 @@ import { APIService } from './services/api';
 import { APIRoutesService } from './services/api-routes';
 import { AuthService } from './services/auth';
 import { AutosaveService } from './services/autosave';
+import { DashboardService } from './services/dashboard';
 import { FrameSyncService } from './services/frame-sync';
 import { GroupsService } from './services/groups';
 import { ImportAnnotationsService } from './services/import-annotations';
@@ -143,6 +144,7 @@ function startApp(settings: SidebarSettings, appEl: HTMLElement) {
     .register('apiRoutes', APIRoutesService)
     .register('auth', AuthService)
     .register('autosaveService', AutosaveService)
+    .register('dashboard', DashboardService)
     .register('frameSync', FrameSyncService)
     .register('groups', GroupsService)
     .register('importAnnotationsService', ImportAnnotationsService)

--- a/src/sidebar/services/dashboard.ts
+++ b/src/sidebar/services/dashboard.ts
@@ -1,0 +1,27 @@
+import type { SidebarSettings } from '../../types/config';
+import * as postMessageJsonRpc from '../util/postmessage-json-rpc';
+
+/**
+ * @inject
+ */
+export class DashboardService {
+  private _rpc: SidebarSettings['rpc'];
+  private _dashboardConfig: SidebarSettings['dashboard'];
+
+  constructor(settings: SidebarSettings) {
+    this._rpc = settings.rpc;
+    this._dashboardConfig = settings.dashboard;
+  }
+
+  open() {
+    if (!this._rpc || !this._dashboardConfig) {
+      return;
+    }
+
+    postMessageJsonRpc.notify(
+      this._rpc.targetFrame,
+      this._rpc.origin,
+      this._dashboardConfig.entryPointRPCMethod,
+    );
+  }
+}

--- a/src/sidebar/services/test/dashboard-test.js
+++ b/src/sidebar/services/test/dashboard-test.js
@@ -1,0 +1,63 @@
+import sinon from 'sinon';
+
+import { DashboardService, $imports } from '../dashboard';
+
+describe('DashboardService', () => {
+  let fakeRpc;
+  let fakeDashboard;
+  let fakePostMessageJsonRpc;
+
+  beforeEach(() => {
+    fakeRpc = {
+      targetFrame: window,
+      origin: 'https://www.example.com',
+    };
+    fakeDashboard = {
+      entryPointRPCMethod: 'openDashboard',
+    };
+    fakePostMessageJsonRpc = {
+      notify: sinon.stub(),
+    };
+
+    $imports.$mock({
+      '../util/postmessage-json-rpc': fakePostMessageJsonRpc,
+    });
+  });
+
+  afterEach(() => $imports.$restore());
+
+  function createDashboardService({
+    withRpc = true,
+    withDashboard = true,
+  } = {}) {
+    return new DashboardService({
+      rpc: withRpc ? fakeRpc : undefined,
+      dashboard: withDashboard ? fakeDashboard : undefined,
+    });
+  }
+
+  describe('open', () => {
+    [
+      { withRpc: false },
+      { withDashboard: false },
+      { withRpc: false, withDashboard: false },
+    ].forEach(settings => {
+      it('does not notify frame if there is any missing config', () => {
+        const dashboard = createDashboardService(settings);
+        dashboard.open();
+        assert.notCalled(fakePostMessageJsonRpc.notify);
+      });
+    });
+
+    it('notifies frame to open the dashboard', () => {
+      const dashboard = createDashboardService();
+      dashboard.open();
+      assert.calledWith(
+        fakePostMessageJsonRpc.notify,
+        window,
+        'https://www.example.com',
+        'openDashboard',
+      );
+    });
+  });
+});

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -81,6 +81,20 @@ export type ReportAnnotationActivityConfig = {
   events: AnnotationEventType[];
 };
 
+export type DashboardConfig = {
+  /**
+   * Whether the dashboard entry point should be displayed in the profile menu
+   * or not.
+   * Typically, only instructors should see this option.
+   */
+  showEntryPoint: boolean;
+
+  /**
+   * Name of the RPC method to call in embedded frame on entry point activation.
+   */
+  entryPointRPCMethod: string;
+};
+
 /**
  * Configure the client to focus on a specific subset of annotations.
  *
@@ -275,4 +289,7 @@ export type ConfigFromEmbedder = ConfigFromHost & {
    * `requestConfigFromFrame` when certain annotation activity happens.
    */
   reportActivity?: ReportAnnotationActivityConfig;
+
+  /** Configuration for menu items etc. related to LMS instructor dashboard */
+  dashboard?: DashboardConfig;
 };


### PR DESCRIPTION
Closes https://github.com/orgs/hypothesis/projects/135/views/1?pane=issue&itemId=53521476.
Requires https://github.com/hypothesis/lms/pull/6168

Add configuration and logic so that embedder frames can choose to display an entry point for the instructor dashboard in the sidebar's user menu.

The configuration is expected to be provided like `reportActivity` one, including a flag to determine if the menu item should be displayed or not, and the RPC method to invoke when clicked.

![image](https://github.com/hypothesis/client/assets/2719332/ec9b1e78-de6f-426d-916b-11cad61af3bb)

### Testing steps

1. Check out this branch
2. Go to https://hypothesis.instructure.com/courses/125/assignments/873 and log-in as a teacher
3. Click the user icon. The menu should **not** display the entry point.
4. Go to http://localhost:8001/admin/instance/8/settings and check the "Enable instructor dashboard" setting.
  ![image](https://github.com/hypothesis/client/assets/2719332/8cb9bee9-27cc-4045-a9fe-112096ffb479)
5. Go to https://hypothesis.instructure.com/courses/125/assignments/873 as a teacher again. This time you should see the "Show dashboard" menu item.
6. Logout and log-in as a student. The menu should **not** display "Show dashboard".

#### Testing the RPC message:

When this menu item is clicked, it sends a message to a parent frame. This frame is currently not handling this message yet, so you'll seen an error in the browser's console: `Received JSON-RPC notification for unrecognized method: openDashboard`.

The handling for this message will be implemented separately, but you can test the message works by applying this diff in the LMS project:

```diff
diff --git a/lms/static/scripts/frontend_apps/services/client-rpc.ts b/lms/static/scripts/frontend_apps/services/client-rpc.ts
index 992f728c..6e43c9c9 100644
--- a/lms/static/scripts/frontend_apps/services/client-rpc.ts
+++ b/lms/static/scripts/frontend_apps/services/client-rpc.ts
@@ -137,6 +137,10 @@ export class ClientRPC extends TinyEmitter {
       },
     );
 
+    this._server.register('openDashboard', () => {
+      console.log('Open dashboard');
+    });
+
     this._resolveGroups = () => {};
     const groups = new Promise(resolve => {
       this._resolveGroups = resolve;
```

With that, when the menu item is clicked, you should see the message "Open dashboard" being logged in the console.