### PR TITLE
Remove export_formats feature flag

### DIFF
--- a/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
+++ b/src/sidebar/components/ShareDialog/ExportAnnotations.tsx
@@ -130,7 +130,6 @@ function ExportAnnotations({
     [allAnnotationsOption, selectedUserId, userList],
   );
 
-  const exportFormatsEnabled = store.isFeatureEnabled('export_formats');
   const [exportFormat, setExportFormat] = useState(exportFormats[0]);
 
   const fileInputId = useId();
@@ -325,35 +324,31 @@ function ExportAnnotations({
                 required
                 maxLength={250}
               />
-              {exportFormatsEnabled && (
-                <div className="grow-0 ml-2 min-w-[5rem]">
-                  <SelectNext
-                    value={exportFormat}
-                    onChange={setExportFormat}
-                    buttonContent={
-                      exportFormat.shortTitle ?? exportFormat.title
-                    }
-                    data-testid="export-format-select"
-                    right
-                  >
-                    {exportFormats.map(exportFormat => (
-                      <SelectNext.Option
-                        key={exportFormat.value}
-                        value={exportFormat}
-                      >
-                        <div className="flex-col gap-y-2">
-                          <div className="font-bold" data-testid="format-name">
-                            {exportFormat.title}
-                          </div>
-                          <div data-testid="format-description">
-                            {exportFormat.description}
-                          </div>
+              <div className="grow-0 ml-2 min-w-[5rem]">
+                <SelectNext
+                  value={exportFormat}
+                  onChange={setExportFormat}
+                  buttonContent={exportFormat.shortTitle ?? exportFormat.title}
+                  data-testid="export-format-select"
+                  right
+                >
+                  {exportFormats.map(exportFormat => (
+                    <SelectNext.Option
+                      key={exportFormat.value}
+                      value={exportFormat}
+                    >
+                      <div className="flex-col gap-y-2">
+                        <div className="font-bold" data-testid="format-name">
+                          {exportFormat.title}
                         </div>
-                      </SelectNext.Option>
-                    ))}
-                  </SelectNext>
-                </div>
-              )}
+                        <div data-testid="format-description">
+                          {exportFormat.description}
+                        </div>
+                      </div>
+                    </SelectNext.Option>
+                  ))}
+                </SelectNext>
+              </div>
             </div>
           </div>
         </>
@@ -370,16 +365,14 @@ function ExportAnnotations({
         </p>
       )}
       <CardActions>
-        {exportFormatsEnabled && (
-          <Button
-            data-testid="copy-button"
-            icon={CopyIcon}
-            onClick={copyAnnotationsExport}
-            disabled={exportableAnnotations.length === 0}
-          >
-            Copy to clipboard
-          </Button>
-        )}
+        <Button
+          data-testid="copy-button"
+          icon={CopyIcon}
+          onClick={copyAnnotationsExport}
+          disabled={exportableAnnotations.length === 0}
+        >
+          Copy to clipboard
+        </Button>
         <Button
           data-testid="export-button"
           variant="primary"

--- a/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
+++ b/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
@@ -232,20 +232,14 @@ describe('ExportAnnotations', () => {
     assert.equal(input.prop('defaultValue'), 'suggested-filename');
   });
 
-  [
-    { exportFormatsEnabled: true, expectedAmountOfSelects: 2 },
-    { exportFormatsEnabled: false, expectedAmountOfSelects: 1 },
-  ].forEach(({ exportFormatsEnabled, expectedAmountOfSelects }) => {
-    it('displays format selector when feature is enabled', async () => {
-      fakeStore.isFeatureEnabled.callsFake(
-        ff => exportFormatsEnabled || ff !== 'export_formats',
-      );
+  it('displays format selector', async () => {
+    const wrapper = createComponent();
+    const select = await waitForElement(
+      wrapper,
+      '[data-testid="export-format-select"]',
+    );
 
-      const wrapper = createComponent();
-      const selects = await waitForElement(wrapper, SelectNext);
-
-      assert.equal(selects.length, expectedAmountOfSelects);
-    });
+    assert.isDefined(select);
   });
 
   it('lists supported export formats', async () => {
@@ -464,18 +458,9 @@ describe('ExportAnnotations', () => {
   });
 
   context('when copying annotations export to clipboard', () => {
-    [true, false].forEach(exportFormatsEnabled => {
-      it('displays copy button if `export_formats` FF is enabled', () => {
-        fakeStore.isFeatureEnabled.callsFake(ff =>
-          ff === 'export_formats' ? exportFormatsEnabled : true,
-        );
-
-        const wrapper = createComponent();
-        assert.equal(
-          wrapper.exists('[data-testid="copy-button"]'),
-          exportFormatsEnabled,
-        );
-      });
+    it('displays copy button', () => {
+      const wrapper = createComponent();
+      assert.isTrue(wrapper.exists('[data-testid="copy-button"]'));
     });
 
     [
@@ -515,8 +500,6 @@ describe('ExportAnnotations', () => {
         getExpectedInvokedContentBuilder,
       }) => {
         it('copies export content as rich or plain text depending on format', async () => {
-          fakeStore.isFeatureEnabled.callsFake(ff => ff === 'export_formats');
-
           const wrapper = createComponent();
           const copyButton = wrapper.find('button[data-testid="copy-button"]');
 
@@ -541,7 +524,6 @@ describe('ExportAnnotations', () => {
     );
 
     it('adds error toast message when copying annotations fails', async () => {
-      fakeStore.isFeatureEnabled.callsFake(ff => ff === 'export_formats');
       fakeCopyPlainText.rejects(new Error('Something failed'));
 
       const wrapper = createComponent();


### PR DESCRIPTION
The `export_formats` feature has been enabled for everyone for a while, so this PR removes its references and just considers it enabled.

Once this is merged we can remove the feature from `h`.

> [!TIP]
> This PR is easier to review [ignoring whitespaces](https://github.com/hypothesis/client/pull/6321/files?w=1)