### PR TITLE
Remove pointer and hover on disabled menu items

### DIFF
--- a/src/sidebar/components/MenuItem.tsx
+++ b/src/sidebar/components/MenuItem.tsx
@@ -239,10 +239,11 @@ export default function MenuItem({
   const wrapperClasses = classnames(
     'focus-visible-ring ring-inset',
     'w-full min-w-[150px] flex items-center select-none',
-    'rounded-none cursor-pointer',
+    'rounded-none',
     {
       'focus-visible:rounded-lg': !isSelected,
       'focus-visible:rounded-r-lg': isSelected,
+      'cursor-pointer': !isDisabled,
     },
     // Set this container as a "group" so that children may style based on its
     // layout state.
@@ -251,8 +252,10 @@ export default function MenuItem({
     {
       'min-h-[30px] font-normal': isSubmenuItem,
       'min-h-[40px] font-medium': !isSubmenuItem,
-      'bg-grey-1 hover:bg-grey-3': isSubmenuItem || isExpanded,
-      'bg-white hover:bg-grey-1': !isSubmenuItem && !isExpanded,
+      'bg-grey-1': isSubmenuItem || isExpanded,
+      'hover:bg-grey-3': !isDisabled && (isSubmenuItem || isExpanded),
+      'bg-white': !isSubmenuItem && !isExpanded,
+      'hover:bg-grey-1': !isDisabled && !isSubmenuItem && !isExpanded,
       // visual "padding" on the right is part of SubmenuToggle when rendered,
       // but when not rendering a SubmenuToggle, we need to add some padding here
       'pr-1': !hasSubmenuVisible,


### PR DESCRIPTION
Modify some styles in `MenuItem`s, so that it doesn't seem you can interact with them when they are in fact disabled.

The changes introduced here are only visual, mainly focused on removing the pointer cursor and the background color changing on hover.

Before:

https://github.com/hypothesis/client/assets/2719332/83a5bc92-911c-401d-8412-930c42b19a42

After:

https://github.com/hypothesis/client/assets/2719332/78e6b5d0-f0ad-4925-83b0-eee77088a77b

However, there's still a few more things we could decide to handle and I have left out of this specific PR:

* The `onClick` callback is still invoked if the item is clicked. This is actually a documented behavior, so I was worried something could break, but it feels counterintuitive.
  ![image](https://github.com/hypothesis/client/assets/2719332/7916c800-ef83-4eef-8c1f-1e2e199b20bf)
  On top of that, it would require introducing a few extra pieces of logic, as this callback is also invoked when certain keys are pressed and that would also need to be handled.
* The item can still be focused. Changing this would require modifying how these items are rendered to have something which actually makes them disabled (perhaps adding a `disabled` attribute) so that they can be excluded from the `useArrowKeyNavigation` hook selector.