### PR TITLE
Scroll to first highlighted annotation when loaded

### DIFF
--- a/src/sidebar/components/ThreadList.tsx
+++ b/src/sidebar/components/ThreadList.tsx
@@ -209,6 +209,18 @@ export default function ThreadList({ threads }: ThreadListProps) {
     }
   }, [store, newAnnotationTag]);
 
+  const editing = store.countDrafts() > 0;
+  const highlightedAnnotations = store.highlightedAnnotations();
+
+  // Scroll to the first highlighted annotation, unless creating/editing another
+  // annotation
+  useEffect(() => {
+    const [firstHighlightedAnnotation] = highlightedAnnotations;
+    if (!editing && firstHighlightedAnnotation) {
+      setScrollToId(firstHighlightedAnnotation);
+    }
+  }, [editing, highlightedAnnotations]);
+
   // Effect to scroll a particular thread into view. This is mainly used to
   // scroll a newly created annotation into view.
   useEffect(() => {

--- a/src/sidebar/components/test/ThreadList-test.js
+++ b/src/sidebar/components/test/ThreadList-test.js
@@ -4,6 +4,7 @@ import {
 } from '@hypothesis/frontend-testing';
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
+import sinon from 'sinon';
 
 import ThreadList from '../ThreadList';
 import { $imports } from '../ThreadList';
@@ -54,6 +55,8 @@ describe('ThreadList', () => {
     fakeStore = {
       setForcedVisible: sinon.stub(),
       unsavedAnnotations: sinon.stub().returns([]),
+      countDrafts: sinon.stub().returns(0),
+      highlightedAnnotations: sinon.stub().returns([]),
     };
 
     fakeTopThread = {
@@ -177,9 +180,26 @@ describe('ThreadList', () => {
       addNewAnnotation(wrapper, fakeTopThread.children[3].annotation);
 
       // The third thread in a collection of threads at default height (200)
-      // should be at 600px. This setting of `scrollTop` is the only externally-
-      // observable thing that happens here...
+      // should be at 600px. This setting of `scrollTop` is the only
+      // externally-observable thing that happens here...
       assert.calledWith(fakeScrollTop, 600);
+    });
+
+    it('should do nothing for highlighted annotations while creating/editing', () => {
+      fakeStore.highlightedAnnotations.returns(['t2', 't3']);
+      fakeStore.countDrafts.returns(10);
+      createComponent();
+
+      assert.notCalled(fakeScrollTop);
+    });
+
+    it('should set the scroll container `scrollTop` to first highlighted annotation', () => {
+      fakeStore.highlightedAnnotations.returns(['t2', 't3']);
+      createComponent();
+
+      // The first thread in a collection of threads at default height (200)
+      // should be at 200px.
+      assert.calledWith(fakeScrollTop, 200);
     });
   });
 


### PR DESCRIPTION
Part of https://github.com/hypothesis/client/issues/6255

This PR updates `ThereadList` so that it scrolls to the first highlighted annotation once pending updates have been loaded, as long as the user does not have any draft.

This is a simple approach to scroll into just-loaded annotations, however, we should probably scroll into the closest one based on the active scroll. I will try to address that separately.

### Testing steps

1. Open http://localhost:3000 in two browsers
2. Make sure there's enough annotations so that the sidebar renders a scrollbar.
3. Scroll the sidebar to the very top or bottom in one browser.
4. Create or edit one or more annotations in the opposite edge of the sidebar, in the second browser.
5. Click the "load pending updates" notification in the first browser. You should get scrolled into the first one of those annotations.

If you do the same while editing/creaating an annotation, the scrolling should not happen, unless you cancel all drafts before the 5-second timeout where annotations are highlighted, is finished.