### PR TITLE
Scroll to most recent highlighted annotation

### DIFF
--- a/src/sidebar/components/test/ThreadList-test.js
+++ b/src/sidebar/components/test/ThreadList-test.js
@@ -197,9 +197,9 @@ describe('ThreadList', () => {
       fakeStore.highlightedAnnotations.returns(['t2', 't3']);
       createComponent();
 
-      // The first thread in a collection of threads at default height (200)
-      // should be at 200px.
-      assert.calledWith(fakeScrollTop, 200);
+      // The last highlighted annotation is the third in the collection of
+      // threads. At default height (200) should be at 400px.
+      assert.calledWith(fakeScrollTop, 400);
     });
   });
 


### PR DESCRIPTION
Part of https://github.com/hypothesis/client/issues/6255

After https://github.com/hypothesis/client/pull/6337, and following the suggestion from [this comment](https://github.com/hypothesis/client/pull/6337#discussion_r1565755535), this PR changes the logic to scroll to a highlighted annotation, so that we pick the last one of the list, assuming that's the most recent one.

This assumption is also made when picking the most recently created annotation, so I guess it's safe enough and we don't need to actually walk over the annotations and check their dates, which could have a small performance impact when checking which one is the most recent.

There's still room for improvement here, as we could/should scroll to the new/edited annotation which is closer to current viewport, or do nothing if there are some already in the viewport.

### Testing steps

1. Open http://localhost:3000 in two browsers.
2. Make sure there are enough annotations so that there's scroll in the sidebar.
3. In one browser, scroll more or less to the middle.
4. In the other browser create an annotation in the very top of the document, and one in the very bottom.
5. Load pending updates in the first browser. It should scroll you to the annotation that was created last in the second browser.