### PR TITLE
Replace remaining `require` in `serve-package.js`

### DIFF
--- a/dev-server/serve-package.js
+++ b/dev-server/serve-package.js
@@ -31,7 +31,7 @@ export function servePackage(port) {
   });
 
   const serveBootScript = function (req, res) {
-    const entryPath = require.resolve('../');
+    const entryPath = `${__dirname}/../build/boot.js`;
     const entryScript = readFileSync(entryPath).toString('utf-8');
     res.append('Content-Type', 'application/javascript; charset=utf-8');
     res.send(entryScript);


### PR DESCRIPTION
This was missed in 7308187e15f992e6cdbfabaf105e787dbf211f6d. This used to rely on `require` determining the boot script URL from the `main` field in package.json, but the indirection is a bit confusing, so just reference the output URL of the boot script directly.