### PR TITLE
Display error when loading dashboard auth token fails

### DIFF
--- a/src/sidebar/components/OpenDashboardMenuItem.tsx
+++ b/src/sidebar/components/OpenDashboardMenuItem.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'preact/hooks';
+import { useCallback, useEffect, useState } from 'preact/hooks';
 
 import { withServices } from '../service-context';
 import type { DashboardService } from '../services/dashboard';
+import type { ToastMessengerService } from '../services/toast-messenger';
 import MenuItem from './MenuItem';
 
 export type OpenDashboardMenuItemProps = {
@@ -9,36 +10,54 @@ export type OpenDashboardMenuItemProps = {
 
   // Injected
   dashboard: DashboardService;
+  toastMessenger: ToastMessengerService;
 };
 
 function OpenDashboardMenuItem({
   dashboard,
   isMenuOpen,
+  toastMessenger,
 }: OpenDashboardMenuItemProps) {
-  const [authToken, setAuthToken] = useState<string>();
+  const [authTokenOrError, setAuthTokenOrError] = useState<string | Error>();
+  // Token is loading until we get it or an error occurs
+  const loading = !authTokenOrError;
+
+  const onClick = useCallback(() => {
+    if (typeof authTokenOrError === 'string') {
+      dashboard.open(authTokenOrError);
+      return;
+    }
+
+    if (authTokenOrError) {
+      toastMessenger.error("Can't open dashboard: You must reload the page.", {
+        autoDismiss: false,
+      });
+    }
+  }, [authTokenOrError, dashboard, toastMessenger]);
+
   useEffect(() => {
     // Fetch a new auth token every time the menu containing this item is open,
     // to make sure we always have an up-to-date one
     if (isMenuOpen) {
       dashboard
         .getAuthToken()
-        .then(setAuthToken)
-        .catch(error =>
-          console.warn('An error occurred while getting auth token', error),
-        );
+        .then(setAuthTokenOrError)
+        .catch(error => {
+          console.warn('An error occurred while getting auth token', error);
+          setAuthTokenOrError(error);
+        });
     }
 
-    // Discard previous token just before trying to fetch a new one
-    return () => setAuthToken(undefined);
+    // Discard previous token and error, just before trying to fetch a new one
+    return () => setAuthTokenOrError(undefined);
   }, [dashboard, isMenuOpen]);
 
   return (
-    <MenuItem
-      label="Open dashboard"
-      isDisabled={!authToken}
-      onClick={() => authToken && dashboard.open(authToken)}
-    />
+    <MenuItem label="Open dashboard" isDisabled={loading} onClick={onClick} />
   );
 }
 
-export default withServices(OpenDashboardMenuItem, ['dashboard']);
+export default withServices(OpenDashboardMenuItem, [
+  'dashboard',
+  'toastMessenger',
+]);

--- a/src/sidebar/components/test/OpenDashboardMenuItem-test.js
+++ b/src/sidebar/components/test/OpenDashboardMenuItem-test.js
@@ -6,11 +6,15 @@ import OpenDashboardMenuItem from '../OpenDashboardMenuItem';
 
 describe('OpenDashboardMenuItem', () => {
   let fakeDashboard;
+  let fakeToastMessenger;
 
   beforeEach(() => {
     fakeDashboard = {
       getAuthToken: sinon.stub().resolves('auth_token'),
       open: sinon.stub(),
+    };
+    fakeToastMessenger = {
+      error: sinon.stub(),
     };
   });
 
@@ -19,8 +23,21 @@ describe('OpenDashboardMenuItem', () => {
       <OpenDashboardMenuItem
         isMenuOpen={isMenuOpen}
         dashboard={fakeDashboard}
+        toastMessenger={fakeToastMessenger}
       />,
     );
+  }
+
+  async function createOpenComponent() {
+    const wrapper = createComponent({ isMenuOpen: true });
+
+    // Wait for an enabled menu item, which means loading the auth token finished
+    await waitFor(() => {
+      wrapper.update();
+      return wrapper.exists('MenuItem[isDisabled=false]');
+    });
+
+    return wrapper;
   }
 
   context('when menu is closed', () => {
@@ -39,20 +56,11 @@ describe('OpenDashboardMenuItem', () => {
 
       wrapper.find('MenuItem').props().onClick();
       assert.notCalled(fakeDashboard.open);
+      assert.notCalled(fakeToastMessenger.error);
     });
   });
 
   context('when menu is open', () => {
-    async function createOpenComponent() {
-      const wrapper = createComponent({ isMenuOpen: true });
-
-      // Wait for an enabled menu item, which means the auth token was loaded
-      await waitFor(() => wrapper.find('MenuItem[isDisabled=false]'));
-      wrapper.update();
-
-      return wrapper;
-    }
-
     it('loads auth token', async () => {
       await createOpenComponent();
       assert.called(fakeDashboard.getAuthToken);
@@ -68,33 +76,61 @@ describe('OpenDashboardMenuItem', () => {
 
       wrapper.find('MenuItem').props().onClick();
       assert.calledWith(fakeDashboard.open, 'auth_token');
+      assert.notCalled(fakeToastMessenger.error);
     });
+  });
 
-    it('logs error if getting auth token fails', async () => {
-      const error = new Error('Error loading auth token');
+  context('when menu opening changes', () => {
+    it('goes back to loading state', async () => {
+      const wrapper = await createOpenComponent();
+
+      assert.isFalse(wrapper.find('MenuItem').prop('isDisabled'));
+      wrapper.setProps({ isMenuOpen: false });
+      assert.isTrue(wrapper.find('MenuItem').prop('isDisabled'));
+    });
+  });
+
+  context('when loading auth token fails', () => {
+    const error = new Error('Error loading auth token');
+
+    beforeEach(() => {
       fakeDashboard.getAuthToken.rejects(error);
       sinon.stub(console, 'warn');
+    });
 
-      try {
-        createOpenComponent();
+    afterEach(() => console.warn.restore());
 
-        assert.called(fakeDashboard.getAuthToken);
+    it('logs error if getting auth token fails', async () => {
+      createOpenComponent();
 
-        await waitFor(() => {
-          const { lastCall } = console.warn;
-          if (!lastCall) {
-            return false;
-          }
+      assert.called(fakeDashboard.getAuthToken);
 
-          const { args } = lastCall;
-          return (
-            args[0] === 'An error occurred while getting auth token' &&
-            args[1] === error
-          );
-        });
-      } finally {
-        console.warn.restore();
-      }
+      await waitFor(() => {
+        const { lastCall } = console.warn;
+        if (!lastCall) {
+          return false;
+        }
+
+        const { args } = lastCall;
+        return (
+          args[0] === 'An error occurred while getting auth token' &&
+          args[1] === error
+        );
+      });
+    });
+
+    it('shows toast message when trying to open dashboard', async () => {
+      const wrapper = await createOpenComponent();
+      const menuItem = wrapper.find('MenuItem');
+
+      menuItem.props().onClick();
+
+      assert.notCalled(fakeDashboard.open);
+      assert.calledWith(
+        fakeToastMessenger.error,
+        "Can't open dashboard: You must reload the page.",
+        { autoDismiss: false },
+      );
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/orgs/hypothesis/projects/135/views/1?pane=issue&itemId=59550806

Display an error toast message when clicking "Open dashboard" menu item if loading the auth token via RPC failed.

https://github.com/hypothesis/client/assets/2719332/e68787f3-41f8-43a2-9703-5ff69244929c

> We need to think on the right error message.

### Testing steps

1. Check out this branch.
2. Go to http://localhost:8001/admin/instance/8/settings and enable the instructor dashboard
3. Go to https://hypothesis.instructure.com/courses/125/assignments/873 and log in as a teacher.
4. Click the user menu in the sidebar, then click "Open dashboard". The dashboard should be normally opened
5. Apply this diff in your locally-running LMS project, to mimic an error fetching the token.
    ```diff
    diff --git a/lms/static/scripts/frontend_apps/services/client-rpc.ts b/lms/static/scripts/frontend_apps/services/client-rpc.ts
    index 03029c1d..a6716c45 100644
    --- a/lms/static/scripts/frontend_apps/services/client-rpc.ts
    +++ b/lms/static/scripts/frontend_apps/services/client-rpc.ts
    @@ -138,7 +138,7 @@ export class ClientRPC extends TinyEmitter {
        );
    
        // Expose current auth token via RPC
    -    this._server.register('requestAuthToken', () => authToken);
    +    // this._server.register('requestAuthToken', () => authToken);
    
        this._resolveGroups = () => {};
        const groups = new Promise(resolve => {
    ```
6. Repeat step 4, but this time you should see an error toast message like in the screen recording above.
