### PR TITLE
Remove workaround for pywb's wombat.js bug

### DIFF
--- a/src/annotator/sidebar.tsx
+++ b/src/annotator/sidebar.tsx
@@ -70,7 +70,7 @@ export type SidebarContainerConfig = {
 /**
  * Create the iframe that will load the sidebar application.
  */
-export function createSidebarIframe(config: SidebarConfig): HTMLIFrameElement {
+function createSidebarIframe(config: SidebarConfig): HTMLIFrameElement {
   const sidebarURL = config.sidebarAppUrl;
   const sidebarAppSrc = addConfigFragment(
     sidebarURL,
@@ -87,15 +87,7 @@ export function createSidebarIframe(config: SidebarConfig): HTMLIFrameElement {
   // the clipboard.
   sidebarFrame.allow = 'fullscreen; clipboard-write';
 
-  // In viahtml, pywb uses wombat.js, which monkey-patches some JS methods.
-  // One of those causes the `allow` attribute to be overwritten, so we want to
-  // define a noop setter to preserve the permissions we set above.
-  // We can remove this workaround once pywb has been updated to use the latest
-  // version of wombat.js, which includes a fix for this.
-  // See https://github.com/webrecorder/wombat/pull/134
-  return Object.defineProperty(sidebarFrame, 'allow', {
-    set: () => {},
-  });
+  return sidebarFrame;
 }
 
 type GestureState = {

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -1,7 +1,7 @@
 import { TinyEmitter } from 'tiny-emitter';
 
 import { addConfigFragment } from '../../shared/config-fragment';
-import { Sidebar, MIN_RESIZE, $imports, createSidebarIframe } from '../sidebar';
+import { Sidebar, MIN_RESIZE, $imports } from '../sidebar';
 import { Emitter } from '../util/emitter';
 
 const DEFAULT_WIDTH = 350;
@@ -1136,17 +1136,6 @@ describe('Sidebar', () => {
       onSelectAnnotations(tags, toggle);
 
       assert.calledWith(guestRPC().call, 'selectAnnotations', tags, true);
-    });
-  });
-
-  describe('createSidebarIframe', () => {
-    it('does not let `allow` attribute to be overwritten', () => {
-      const iframe = createSidebarIframe({ sidebarAppUrl: 'https://foo.com' });
-      const initialAllow = iframe.allow;
-
-      iframe.allow = 'something else';
-
-      assert.equal(iframe.allow, initialAllow);
     });
   });
 });


### PR DESCRIPTION
This PR reverts the changes introduced in https://github.com/hypothesis/client/pull/6119 and https://github.com/hypothesis/client/pull/6227, which were meant to work around https://github.com/webrecorder/wombat/issues/133

That bug was fixed in https://github.com/webrecorder/wombat/pull/134 and is now part of latest pywb, and already part of viahtml after merging https://github.com/hypothesis/viahtml/pull/657.

### Testing steps

1. Check out this branch
2. Open viahtml locally, and run `python ./bin/build_static.py`. This will copy and expose pywb static assets, including wombat.js
3. Go to http://localhost:9083/https://www.example.com/ and open the "Version" tab of the help panel.
  ![image](https://github.com/hypothesis/client/assets/2719332/f656bec9-2203-41d4-b964-f31e9c22e061)
4. Click "Copy version details". You should see a success toast message.

> [!NOTE]  
> We are not using GitHub revert functionality, because changes were applied in two different PRs, and that would require doing the revert in two steps.