### PR TITLE
Use z-10 in pending updates notification container

### DIFF
--- a/src/sidebar/components/SidebarView.tsx
+++ b/src/sidebar/components/SidebarView.tsx
@@ -132,7 +132,9 @@ function SidebarView({
       <h2 className="sr-only">Annotations</h2>
       <div
         className={classnames(
-          'fixed z-1',
+          // z-10 ensures this appears over sidebar panels, which use the same
+          // z-index but render lower in the DOM
+          'fixed z-10',
           // Setting 9px to the right instead of some standard tailwind size,
           // so that it matches the padding of the sidebar's container.
           // DEFAULT `.container` padding is defined in tailwind.conf.js


### PR DESCRIPTION
This PR fixes a rendering issue making sidebar panels to appear over the pending updates notification, due to a higher z-index.

### Testing steps

1. Open http://localhost:3000 in one browser.
2. Open http://localhost:3000 in a second browser, and create an annotation.
3. You should see the pending updates notification in the first one.
    * In this branch, you should be able to hover over the whole notification when it is collapsed, getting it uncollapsed, and allowing you to move the mouse all the way to the left of the notification without it collapsing.
    
        https://github.com/hypothesis/client/assets/2719332/df4d3b3e-71f0-4740-9d42-919573a7c592
        
    * In `main` branch, the tabs container, which grows until the close button, overlaps over the notification.
        
        https://github.com/hypothesis/client/assets/2719332/462425e1-732a-4209-80dc-3607cf1adbeb


    

