### PR TITLE
Update browser support baseline

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "typescript": "^5.0.2",
     "wrap-text": "^1.0.7"
   },
-  "browserslist": "chrome 70, firefox 70, safari 11.1",
+  "browserslist": "chrome 92, firefox 90, safari 14.1",
   "prettier": {
     "arrowParens": "avoid",
     "singleQuote": true,

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -6,14 +6,14 @@
     "allowSyntheticDefaultImports": true,
 
     "checkJs": true,
-    "lib": ["es2020", "dom", "dom.iterable"],
+    "lib": ["es2021", "dom", "dom.iterable"],
     "jsx": "react-jsx",
     "jsxImportSource": "preact",
     "module": "es2020",
     "moduleResolution": "node",
     "noEmit": true,
     "strict": true,
-    "target": "ES2020",
+    "target": "ES2021",
 
     // Let argument to catch statement be `any` rather than `unknown`.
     "useUnknownInCatchVariables": false,


### PR DESCRIPTION
Update the browser support baseline to versions of the major browsers that were released approximately 3 years ago. This covers 99.7% of requests to the LMS app in the last day.


Slack thread: https://hypothes-is.slack.com/archives/C1M8NH76X/p1720084365150269.