### PR TITLE
Whenever an iframe changes location Hypothesis needs to be injected again

### DIFF
--- a/src/annotator/frame-observer.ts
+++ b/src/annotator/frame-observer.ts
@@ -69,6 +69,9 @@ export class FrameObserver {
       frameWindow!.addEventListener('unload', () => {
         this._removeFrame(frame);
       });
+      frame.addEventListener('load', () => {
+        this._addFrame(frame);
+      });
       this._onFrameAdded(frame);
     } catch (e) {
       console.warn(


### PR DESCRIPTION
When enabling annotations on an iframe with the `enable-annotation` attribute, it appears the client is only injected once. This leads to issues when the frame navigates to another page. I haven't checked whether the issue exists for all types of navigation (for example if it matters if the parent or the frame itself is causing the navigation). In this particular case the frame was initialised with `about:blank`.

I have found that reattaching the frame on the `load` event on the `frame` solves the issue. I am open for better suggestions fixing this.

Fixes #6475