### PR TITLE
Fix failure to fetch groups in VitalSource

### DIFF
--- a/src/sidebar/services/groups.ts
+++ b/src/sidebar/services/groups.ts
@@ -83,7 +83,7 @@ export class GroupsService {
    * the site that the user is on.
    */
   private _mainURI(): string | null {
-    return this._store.mainFrame()?.uri ?? null;
+    return this._store.defaultContentFrame()?.uri ?? null;
   }
 
   /**

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -81,7 +81,7 @@ describe('GroupsService', () => {
         focusedGroup() {
           return this.getState().groups.focusedGroup;
         },
-        mainFrame() {
+        defaultContentFrame() {
           return this.getState().frames[0];
         },
         setDefault: sinon.stub(),


### PR DESCRIPTION
Before loading groups the client waits for the main document frame to connect in order to be able to fetch groups associated with that frame's URL. In VitalSource however there is no "main frame", only the current content frame, so `GroupsService._loadGroupsForUserAndDocument` waited indefinitely.

This failure to fetch groups did not happen on the initial launch due to a different bug in `GroupsService._loadGroupsForUserAndDocument`. The `this_store.route()` call returned `null` during startup and hence the code did not wait for the main frame to connect. After a subsequent login/logout however, the `route` call returned "sidebar" and the code did wait for the main frame.

This problem also did not happen in the LMS environment because there the client loads a set of groups specified by our LMS app, instead of fetching groups based on the logged-in user and current document.

Solve the first problem by using the `defaultContentFrame` method to get the frame instead of `mainFrame`. `defaultContentFrame` returns the main frame if there is one, or the first content frame that connected otherwise.

Fixes https://github.com/hypothesis/product-backlog/issues/1547

----

**Testing:**

- Visit http://localhost:3000/document/vitalsource-epub and login/logout of the client

On `main` the groups will fail to load after login/logout. On this branch they will load as normal.