### PR TITLE
Copy KaTeX fonts as binary rather than text files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -81,7 +81,10 @@ gulp.task('build-fonts', () => {
   // Fonts are located in a subdirectory of `build/styles` so that we can reuse
   // KaTeX's CSS bundle directly without any URL rewriting.
   const fontsDir = 'build/styles/fonts';
-  return gulp.src(fontFiles).pipe(changed(fontsDir)).pipe(gulp.dest(fontsDir));
+  return gulp
+    .src(fontFiles, { encoding: false })
+    .pipe(changed(fontsDir))
+    .pipe(gulp.dest(fontsDir));
 });
 
 gulp.task(


### PR DESCRIPTION
Set the `encoding` option to `false` [1] when copying KaTeX fonts so they are treated as binary rather than text. This fixes an issue where the fonts were corrupted in the process.

[1] https://gulpjs.com/docs/en/api/src/#options

Fixes https://github.com/hypothesis/client/issues/6526