### PR TITLE
Relax call count check in `FrameObserver` tests

### DIFF
--- a/src/annotator/test/frame-observer-test.js
+++ b/src/annotator/test/frame-observer-test.js
@@ -167,6 +167,10 @@ describe('annotator/frame-observer', () => {
 
   function assertCalledOnceWithError(callback, message) {
     assert.calledOnce(callback);
+    assertCalledWithError(callback, message);
+  }
+
+  function assertCalledWithError(callback, message) {
     assert.calledWith(callback, sinon.match.instanceOf(Error));
     const error = callback.args[0][0];
     assert.equal(error.message, message);
@@ -249,11 +253,7 @@ describe('annotator/frame-observer', () => {
 
       frame.src = crossOriginURL;
       await waitForEvent(frame, 'load');
-      assertCalledOnceWithError(callback, 'Frame is cross-origin');
-
-      // Wait a moment to check that callback was only invoked once.
-      await delay(pollInterval + 1);
-      assertCalledOnceWithError(callback, 'Frame is cross-origin');
+      assertCalledWithError(callback, 'Frame is cross-origin');
     });
 
     it('invokes callback with error if frame is disconnected', async () => {


### PR DESCRIPTION
An `onDocumentReady` test was failing in current versions of Chrome, with the callback being invoked twice with the same error instead of once as expected by the test. This can happen with this sequence of events:

 1. Watched frame fires an "unload" event. This starts a polling timer.
 2. The timer fires and the callback is invoked with a cross-origin error
 3. Frame fires "load" event, and the callback is invoked a second time with a cross-origin error
 4. The test's "load" event handler is run

It is not a problem for current callers of `onDocumentReady` if the callback fires twice, so just relax the check in the tests.