### PR TITLE
Fix annotations highlights not rendered in Firefox 130

### DIFF
--- a/src/annotator/anchoring/test/pdf-test.js
+++ b/src/annotator/anchoring/test/pdf-test.js
@@ -2,6 +2,7 @@ import { delay } from '@hypothesis/frontend-testing';
 
 import { matchQuote } from '../match-quote';
 import * as pdfAnchoring from '../pdf';
+import { isTextLayerRenderingDone } from '../pdf';
 import { TextRange } from '../text-range';
 import { FakePDFViewerApplication } from './fake-pdf-viewer-application';
 
@@ -721,6 +722,37 @@ describe('annotator/anchoring/pdf', () => {
       it('returns false if PDF does not have selectable text', async () => {
         initViewer(content);
         assert.isFalse(await pdfAnchoring.documentHasText());
+      });
+    });
+  });
+
+  describe('isTextLayerRenderingDone', () => {
+    [true, false].forEach(renderingDone => {
+      it('returns renderingDone if present', () => {
+        assert.equal(
+          isTextLayerRenderingDone({ renderingDone }),
+          renderingDone,
+        );
+      });
+    });
+
+    it('returns false if neither renderingDone nor the div are set', () => {
+      assert.isFalse(isTextLayerRenderingDone({}));
+    });
+
+    [
+      { element: null, expectedResult: false },
+      { element: {}, expectedResult: true },
+    ].forEach(({ element, expectedResult }) => {
+      it('returns true if the div contains an endOfContent element', () => {
+        assert.equal(
+          isTextLayerRenderingDone({
+            div: {
+              querySelector: () => element,
+            },
+          }),
+          expectedResult,
+        );
       });
     });
   });

--- a/src/annotator/integrations/pdf.tsx
+++ b/src/annotator/integrations/pdf.tsx
@@ -19,6 +19,7 @@ import {
   canDescribe,
   describe,
   documentHasText,
+  isTextLayerRenderingDone,
 } from '../anchoring/pdf';
 import { isInPlaceholder, removePlaceholder } from '../anchoring/placeholder';
 import { TextRange } from '../anchoring/text-range';
@@ -356,7 +357,7 @@ export class PDFIntegration extends TinyEmitter implements Integration {
     const pageCount = this._pdfViewer.pagesCount;
     for (let pageIndex = 0; pageIndex < pageCount; pageIndex++) {
       const page = this._pdfViewer.getPageView(pageIndex);
-      if (!page?.textLayer?.renderingDone) {
+      if (!page?.textLayer || !isTextLayerRenderingDone(page.textLayer)) {
         continue;
       }
 

--- a/src/types/pdfjs.ts
+++ b/src/types/pdfjs.ts
@@ -192,7 +192,11 @@ export type PDFViewerApplication = {
 };
 
 export type TextLayer = {
-  renderingDone: boolean;
+  /**
+   * This prop is private in PDF.js >=4.5, so we cannot safely trust it's
+   * publicly exposed
+   */
+  renderingDone?: boolean;
   /**
    * New name for root element of text layer in PDF.js >= v3.2.146
    */


### PR DESCRIPTION
This PR fixes the loading of annotation highlights when loading the client on a PDF document using the bookmarklet in Firefox 130.

This Firefox version comes with a new PDF.js version which defines `TextLayer.renderingDone` as private, making it impossible to check it from a context other than the object itself.

I realized that this property is set to `true` only in one place, and right after that, the `TextLayer.div` object is appended with an element containing the `endOfContent` class. See https://github.com/mozilla/pdf.js/blob/1ab9ab67eed886f27127bd801bc349949af5054e/web/text_layer_builder.js#L103-L107

Since `div` is still public, we can achieve the same result by checking if it contains this element. The solution is not perfect, as it couples with internal implementation details of `TextLayer`, but so was the previous solution, so this should work for now until we can spend more time on the right approach.

Additionally, I have ensured the `renderingDone` prop is still used if accessible, for older PDF.js versions, and only fall back to the new approach otherwise.

### Testing steps

You can follow the same testing steps described in https://github.com/hypothesis/client/pull/6541, but create some annotations/highlights and see that they are rendered in the document.