### PR TITLE
Only apply selector filters to threads, not replies

### DIFF
--- a/src/sidebar/helpers/build-thread.ts
+++ b/src/sidebar/helpers/build-thread.ts
@@ -317,7 +317,13 @@ export function buildThread(
     });
   } else if (options.threadFilterFn) {
     // Remove threads not matching thread-level filters
-    thread.children = thread.children.filter(options.threadFilterFn);
+    const threadFilterFn = options.threadFilterFn;
+    thread.children = thread.children.filter(thread => {
+      if (hasForcedVisible && options.forcedVisible.includes(thread.id)) {
+        return true;
+      }
+      return threadFilterFn(thread);
+    });
   }
 
   // Set visibility for threads.

--- a/src/sidebar/helpers/query-parser.ts
+++ b/src/sidebar/helpers/query-parser.ts
@@ -134,6 +134,15 @@ export type Facet = {
    */
   operator: 'and' | 'or';
   terms: string[] | number[];
+
+  /**
+   * Whether this facet is relevant for replies.
+   *
+   * This is true for facets such as annotation bodies, which both annotations
+   * and replies have, but false for eg. page numbers, which only annotations
+   * have.
+   */
+  filterReplies: boolean;
 };
 
 export type ParsedQuery = Record<FilterField | 'any', Facet>;
@@ -236,38 +245,47 @@ export function parseFilterQuery(
     any: {
       terms: any,
       operator: 'and',
+      filterReplies: true,
     },
     cfi: {
       terms: cfi,
       operator: 'or',
+      filterReplies: false,
     },
     quote: {
       terms: quote,
       operator: 'and',
+      filterReplies: false,
     },
     page: {
       terms: page,
       operator: 'or',
+      filterReplies: false,
     },
     since: {
       terms: since,
       operator: 'and',
+      filterReplies: true,
     },
     tag: {
       terms: tag,
       operator: 'and',
+      filterReplies: true,
     },
     text: {
       terms: text,
       operator: 'and',
+      filterReplies: true,
     },
     uri: {
       terms: uri,
       operator: 'or',
+      filterReplies: false,
     },
     user: {
       terms: user,
       operator: 'or',
+      filterReplies: true,
     },
   };
 }

--- a/src/sidebar/helpers/test/build-thread-test.js
+++ b/src/sidebar/helpers/test/build-thread-test.js
@@ -475,16 +475,26 @@ describe('sidebar/helpers/build-thread', () => {
           text: 'note',
           target: [{ selector: undefined }],
         },
+        {
+          id: '3',
+          text: 'annotation',
+          target: [{ selector: undefined }],
+        },
       ];
 
-      it('shows only annotations matching the thread filter', () => {
+      it('shows only annotations matching the thread filter and forced-visible threads', () => {
         const thread = createThread(fixture, {
           threadFilterFn: thread => metadata.isPageNote(thread.annotation),
+          forcedVisible: ['3'],
         });
 
         assert.deepEqual(thread, [
           {
             annotation: fixture[1],
+            children: [],
+          },
+          {
+            annotation: fixture[2],
             children: [],
           },
         ]);

--- a/src/sidebar/helpers/test/query-parser-test.js
+++ b/src/sidebar/helpers/test/query-parser-test.js
@@ -117,6 +117,7 @@ describe('sidebar/helpers/query-parser', () => {
           any: {
             operator: 'and',
             terms: ['one', 'two', 'three'],
+            filterReplies: true,
           },
         },
       },
@@ -128,6 +129,7 @@ describe('sidebar/helpers/query-parser', () => {
           tag: {
             operator: 'and',
             terms: ['foo', 'bar'],
+            filterReplies: true,
           },
         },
       },
@@ -137,10 +139,12 @@ describe('sidebar/helpers/query-parser', () => {
           quote: {
             operator: 'and',
             terms: ['inthequote'],
+            filterReplies: false,
           },
           text: {
             operator: 'and',
             terms: ['inthetext'],
+            filterReplies: true,
           },
         },
       },
@@ -150,6 +154,7 @@ describe('sidebar/helpers/query-parser', () => {
           user: {
             operator: 'or',
             terms: ['john', 'james'],
+            filterReplies: true,
           },
         },
       },
@@ -159,6 +164,7 @@ describe('sidebar/helpers/query-parser', () => {
           uri: {
             operator: 'or',
             terms: ['https://example.org/article.html'],
+            filterReplies: false,
           },
         },
       },
@@ -168,6 +174,7 @@ describe('sidebar/helpers/query-parser', () => {
           page: {
             operator: 'or',
             terms: ['5-10'],
+            filterReplies: false,
           },
         },
       },
@@ -177,6 +184,7 @@ describe('sidebar/helpers/query-parser', () => {
           cfi: {
             operator: 'or',
             terms: ['/2-/4'],
+            filterReplies: false,
           },
         },
       },
@@ -188,6 +196,7 @@ describe('sidebar/helpers/query-parser', () => {
           any: {
             operator: 'and',
             terms: ['group:abcd'],
+            filterReplies: true,
           },
         },
       },
@@ -197,6 +206,7 @@ describe('sidebar/helpers/query-parser', () => {
           any: {
             operator: 'and',
             terms: ['any:foo'],
+            filterReplies: true,
           },
         },
       },
@@ -269,6 +279,7 @@ describe('sidebar/helpers/query-parser', () => {
           user: {
             operator: 'or',
             terms: ['fakeusername'],
+            filterReplies: true,
           },
         },
       },
@@ -278,6 +289,7 @@ describe('sidebar/helpers/query-parser', () => {
           page: {
             operator: 'or',
             terms: ['2-4'],
+            filterReplies: false,
           },
         },
       },
@@ -287,6 +299,7 @@ describe('sidebar/helpers/query-parser', () => {
           cfi: {
             operator: 'or',
             terms: ['/2/2-/2/6'],
+            filterReplies: false,
           },
         },
       },
@@ -298,6 +311,7 @@ describe('sidebar/helpers/query-parser', () => {
           user: {
             operator: 'or',
             terms: ['fakeusername', 'otheruser'],
+            filterReplies: true,
           },
         },
       },
@@ -308,10 +322,12 @@ describe('sidebar/helpers/query-parser', () => {
           any: {
             operator: 'and',
             terms: ['foo'],
+            filterReplies: true,
           },
           user: {
             operator: 'or',
             terms: ['fakeusername'],
+            filterReplies: true,
           },
         },
       },
@@ -322,6 +338,7 @@ describe('sidebar/helpers/query-parser', () => {
           page: {
             operator: 'or',
             terms: ['2-4', '6'],
+            filterReplies: false,
           },
         },
       },
@@ -332,6 +349,7 @@ describe('sidebar/helpers/query-parser', () => {
           cfi: {
             operator: 'or',
             terms: ['/2/2-/2/6', '/4/2-/4/4'],
+            filterReplies: false,
           },
         },
       },


### PR DESCRIPTION
Add a property to filter facets which indicate whether they apply to annotations
and replies or only top-level annotations. Use this property to apply the filter either to all
annotations or only the root annotation in a thread respectively.

Queries based on the user or annotation body for example can apply to both.
Queries based on a selector such as page number, book chapter or quote only make
sense as thread-level filters.

Fixes https://github.com/hypothesis/support/issues/158

----

**Testing:**

1. Go to http://localhost:3000/document/vitalsource-epub. Create annotations in chapter one and chapter two and add replies to both
2. Toggle the "Selected chapter" filter on/off. The filter should be applied to the threads based on whether the root annotation matches the chapter. When the root annotation is shown, replies in the thread should be shown as well.

In Step 2 there is a known issue that the "Show replies" toggle disappears when the filter is active. The reply should nevertheless be visible. In contrast on the `main` branch, then the "Selected chapter" filter is active, the reply will initially be hidden and shown under "Show N more in conversation".