### PR TITLE
Treat empty strings as unparsable instead of open page ranges

### DIFF
--- a/src/sidebar/util/page-range.ts
+++ b/src/sidebar/util/page-range.ts
@@ -2,9 +2,20 @@
  * Parse a page number or range into a `[start, end]` integer pair. The `start`
  * or `end` may be `null` if the range is open.
  *
+ * Ranges can be specified as:
+ *
+ *  - A single number. This is treated as a range that starts and ends on the
+ *    same page.
+ *  - A range that may be closed ("5-10"), half-open ("5-" or "-5") or fully
+ *    open ("-").
+ *
  * Returns `null` if the page range could not be parsed.
  */
 function parseRange(range: string): [number | null, number | null] | null {
+  if (!range) {
+    return null;
+  }
+
   const [start, end] = range.includes('-') ? range.split('-') : [range, range];
 
   let startInt = null;

--- a/src/sidebar/util/test/page-range-test.js
+++ b/src/sidebar/util/test/page-range-test.js
@@ -92,6 +92,20 @@ describe('pageLabelInRange', () => {
       range: 'foo-bar',
       match: false,
     },
+
+    // Empty label
+    {
+      label: '',
+      range: '1-2',
+      match: false,
+    },
+
+    // Empty range
+    {
+      label: '1',
+      range: '',
+      match: false,
+    },
   ].forEach(({ label, range, match }) => {
     it('returns true if the label is in the page range', () => {
       assert.equal(pageLabelInRange(label, range), match);


### PR DESCRIPTION
Previously `pageLabelInRange` treated an empty label like a fully-open page range ("-"). Since a fully open range overlaps all other ranges, the function would always return true. Now it treats an empty string as an unparsable range and returns false.

When filtering annotations, this change means that a page range filter will no longer match annotations without a page range.

This is related to https://github.com/hypothesis/support/issues/158.