### PR TITLE
Allow draft annotations to match filters

### DIFF
--- a/src/sidebar/helpers/filter-annotations.ts
+++ b/src/sidebar/helpers/filter-annotations.ts
@@ -153,13 +153,11 @@ const fieldMatchers: Record<string, Matcher | Matcher<number>> = {
 
 /**
  * Filter a set of annotations against a parsed query.
- *
- * @return IDs of matching annotations.
  */
 export function filterAnnotations(
   annotations: Annotation[],
   filters: Record<string, Facet>,
-): string[] {
+): Annotation[] {
   const makeTermFilter = <TermType>(field: string, term: TermType) =>
     new TermFilter(
       term,
@@ -191,9 +189,5 @@ export function filterAnnotations(
 
   const rootFilter = new BooleanOpFilter('and', fieldFilters);
 
-  return annotations
-    .filter(ann => {
-      return ann.id && rootFilter.matches(ann);
-    })
-    .map(ann => ann.id!);
+  return annotations.filter(ann => rootFilter.matches(ann));
 }

--- a/src/sidebar/helpers/test/filter-annotations-test.js
+++ b/src/sidebar/helpers/test/filter-annotations-test.js
@@ -64,7 +64,7 @@ describe('sidebar/helpers/filter-annotations', () => {
 
       const result = filterAnnotations(annotations, filters);
 
-      assert.deepEqual(result, [1]);
+      assert.deepEqual(result, annotations.slice(0, 1));
     });
 
     it('requires at least one term to match for "or" operator', () => {
@@ -142,7 +142,7 @@ describe('sidebar/helpers/filter-annotations', () => {
 
       const result = filterAnnotations([annotation], filters);
 
-      assert.deepEqual(result, [1]);
+      assert.deepEqual(result, [annotation]);
     });
   });
 
@@ -171,7 +171,7 @@ describe('sidebar/helpers/filter-annotations', () => {
       ];
       const result = filterAnnotations(anns, userQuery('john'));
 
-      assert.deepEqual(result, [anns[0].id, anns[2].id]);
+      assert.deepEqual(result, [anns[0], anns[2]]);
     });
 
     it("matches user's display name if present", () => {
@@ -190,7 +190,7 @@ describe('sidebar/helpers/filter-annotations', () => {
       ];
       const result = filterAnnotations(anns, userQuery('james'));
 
-      assert.deepEqual(result, [anns[1].id, anns[2].id, anns[3].id]);
+      assert.deepEqual(result, [anns[1], anns[2], anns[3]]);
     });
 
     it('matches username and display name independently', () => {
@@ -219,7 +219,7 @@ describe('sidebar/helpers/filter-annotations', () => {
 
       const result = filterAnnotations([annotation], filters);
 
-      assert.deepEqual(result, [1]);
+      assert.deepEqual(result, [annotation]);
     });
 
     it('does not match if the annotation is older than the query', () => {
@@ -257,7 +257,7 @@ describe('sidebar/helpers/filter-annotations', () => {
     it('matches if annotation is in page range', () => {
       const filters = { page: { terms: ['4-6'], operator: 'or' } };
       const result = filterAnnotations([annotation], filters);
-      assert.deepEqual(result, [1]);
+      assert.deepEqual(result, [annotation]);
     });
 
     it('does not match if annotation is outside of page range', () => {
@@ -291,7 +291,7 @@ describe('sidebar/helpers/filter-annotations', () => {
       it('matches if annotation is in range', () => {
         const filters = { cfi: { terms: [range], operator: 'or' } };
         const result = filterAnnotations([annotation], filters);
-        assert.deepEqual(result, [1]);
+        assert.deepEqual(result, [annotation]);
       });
     });
 
@@ -331,13 +331,15 @@ describe('sidebar/helpers/filter-annotations', () => {
 
     const result = filterAnnotations([annotation], filters);
 
-    assert.deepEqual(result, [1]);
+    assert.deepEqual(result, [annotation]);
   });
 
-  it('ignores annotations (drafts) with no id', () => {
+  it('can match annotations (drafts) with no id', () => {
     const annotation = {
       tags: ['foo'],
       target: [{}],
+      text: '',
+      url: 'https://example.com',
     };
     const filters = {
       any: {
@@ -348,6 +350,6 @@ describe('sidebar/helpers/filter-annotations', () => {
 
     const result = filterAnnotations([annotation], filters);
 
-    assert.deepEqual(result, []);
+    assert.deepEqual(result, [annotation]);
   });
 });


### PR DESCRIPTION
The internal function that filters annotations returned a list of matching IDs. Unsaved annotations do not have IDs, so were excluded from the matches. Change the function to return a list of matching annotations instead, lifting this restriction.

No callers of the function had to change because currently they only test the length of the returned array.

A caveat with this change is that it only matches the data stored in the annotation object, not data stored in separate "draft" objects which are combined when rendering unsaved annotations. The result is that a filter will only match the fields of the annotation that are populated when the new annotation initially appears in the sidebar. This for example includes the user and page number, but not text added in the text field later.

**Testing:**

1. Create a new annotation locally, but don't save it
2. Click the search icon in the client and enter `user:{your_username}`

On main, the draft annotation will be hidden. On this branch it will be visible.