### PR TITLE
Disable MessagePort workaround under Safari >= 16

### DIFF
--- a/src/shared/messaging/port-rpc.ts
+++ b/src/shared/messaging/port-rpc.ts
@@ -114,16 +114,36 @@ export function installPortCloseWorkaroundForSafari(
  * Test whether this browser needs the workaround for https://bugs.webkit.org/show_bug.cgi?id=231167.
  */
 function shouldUseSafariWorkaround(userAgent: string) {
+  // Test whether this is a WebKit-based browser.
   const webkitVersionMatch = userAgent.match(/\bAppleWebKit\/([0-9]+)\b/);
   if (!webkitVersionMatch) {
     return false;
   }
-  const version = parseInt(webkitVersionMatch[1]);
+  const webkitVersion = parseInt(webkitVersionMatch[1]);
 
   // Chrome's user agent contains the token "AppleWebKit/537.36", where the
   // version number is frozen. This corresponds to a version of Safari from 2013,
   // which is older than all supported Safari versions.
-  if (version <= 537) {
+  if (webkitVersion <= 537) {
+    return false;
+  }
+
+  // The bug was fixed in Safari 16, which according to
+  // https://github.com/mdn/browser-compat-data/blob/main/browsers/safari.json
+  // corresponds to WebKit 614.* and later. However, the WebKit version was
+  // frozen before then, so we instead need to check the `Version` token.
+  // This identifies the _browser_, not the engine.
+  const versionMatch = userAgent.match(/\bVersion\/([0-9]+)\b/);
+  if (!versionMatch) {
+    // If no version info, we guess that the browser is a new version of
+    // WebKit which is not affected.
+    return false;
+  }
+
+  const version = parseInt(versionMatch[1]);
+
+  // The bug was fixed in Safari 16.
+  if (version >= 16) {
     return false;
   }
 

--- a/src/shared/messaging/test/port-rpc-test.js
+++ b/src/shared/messaging/test/port-rpc-test.js
@@ -375,6 +375,13 @@ describe('PortRPC', () => {
 
     // Firefox 96
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:96.0) Gecko/20100101 Firefox/96.0',
+
+    // Safari >= 16
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 13_5_2) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.5 Safari/605.1.15',
+
+    // WebKit user agent, but with major version of Safari missing.
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 13_5_2) AppleWebKit/605.1.15 (KHTML, like Gecko) Safari/605.1.15',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 13_5_2) AppleWebKit/605.1.15 (KHTML, like Gecko)',
   ].forEach(userAgent => {
     it('does not use workaround in unaffected browsers', () => {
       sinon.stub(window, 'addEventListener');


### PR DESCRIPTION
The bug described in https://bugs.webkit.org/show_bug.cgi?id=231167 was fixed in Safari 16. The workaround for Safari <= 15 is triggering an error in VitalSource LMS assignments [1]. Fix the issue for Safari >= 16 by disabling the workaround in browsers where it is not required.

[1] https://github.com/hypothesis/support/issues/161#issuecomment-2407558020