### PR TITLE
Remove Flipgrid embed support

### DIFF
--- a/src/sidebar/media-embedder.ts
+++ b/src/sidebar/media-embedder.ts
@@ -228,13 +228,6 @@ const embedGenerators: Array<(link: HTMLAnchorElement) => HTMLElement | null> =
       id => `https://player.vimeo.com/video/${id}`,
     ),
 
-    // Matches URLs like https://flipgrid.com/s/030475b8ceff
-    createEmbedGenerator(
-      'flipgrid.com',
-      /^\/s\/([^/]+)$/,
-      id => `https://flipgrid.com/s/${id}?embed=true`,
-    ),
-
     /**
      * Match Internet Archive URLs
      *

--- a/src/sidebar/test/media-embedder-test.js
+++ b/src/sidebar/test/media-embedder-test.js
@@ -275,22 +275,6 @@ describe('sidebar/media-embedder', () => {
     });
   });
 
-  it('replaces Flipgrid links with iframes', () => {
-    [
-      ['https://flipgrid.com/s/abc123', 'abc123'],
-      ['https://flipgrid.com/s/def456?foo', 'def456'],
-    ].forEach(([url, id]) => {
-      const element = domElement('<a href="' + url + '">' + url + '</a>');
-
-      mediaEmbedder.replaceLinksWithEmbeds(element);
-
-      assert.equal(
-        embedUrl(element),
-        'https://flipgrid.com/s/' + id + '?embed=true',
-      );
-    });
-  });
-
   it('replaces internet archive links with iframes', () => {
     const urls = [
       // Video details page.


### PR DESCRIPTION
Flipgrid no longer exists. URLs like https://flipgrid.com/s/030475b8ceff and the embedded variant (`?embed=true`) take you to a PDF file [1] telling you about the retirement of the service.

[1] https://cdn-dynmedia-1.microsoft.com/is/content/microsoftcorp/microsoft/final/en-us/microsoft-product-and-services/microsoft-education/downloadables/flip-ms-edu.pdf