### PR TITLE
Add typescript-eslint to eslint dependabot package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
       eslint:
         patterns:
           - 'eslint*'
-          - '@typescript-eslint/*'
+          - 'typescript-eslint'
       rollup:
         patterns:
           - 'rollup'


### PR DESCRIPTION
Since we [migrated to ESLint 9](https://github.com/hypothesis/client/pull/6615/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L41-L42), no longer depend on `@typescript-eslint/...` packages directly, but on the `typescript-eslint` package instead.

This PR updates the dependabot eslint group to reflect that.