### PR TITLE
Update `allowLeavingGroups` docs to match reality

### DIFF
--- a/docs/publishers/config.rst
+++ b/docs/publishers/config.rst
@@ -187,7 +187,7 @@ loads.
       
       ``boolean``. A flag indicating whether users should be able to leave groups 
       of which they are a member. When `false`, the controls for users to leave
-      groups will not be provided. (Default: `true`).
+      groups will not be provided. (Default: `false`).
 
    .. option:: enableShareLinks
 


### PR DESCRIPTION
Update the documentation to match the current behavior. As noted in https://github.com/hypothesis/client/pull/6638, the code comments and behavior were inconsistent. Since changing the behavior is potentially disruptive, that PR changed the comments instead. This commit updates the publisher-facing documentation.