### PR TITLE
Update browser baseline for boot script

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "babel-plugin-inject-args": "^1.0.0",
     "babel-plugin-istanbul": "^7.0.0",
     "babel-plugin-mockable-imports": "^2.0.1",
-    "babel-plugin-transform-async-to-promises": "^0.8.6",
     "chai": "^5.0.0",
     "chance": "^1.0.13",
     "classnames": "^2.2.4",

--- a/src/boot/.babelrc
+++ b/src/boot/.babelrc
@@ -3,14 +3,10 @@
     "@babel/preset-typescript",
     ["@babel/preset-env", {
        "targets": {
-         "chrome": "40",
-         "firefox": "38",
-         "safari": "9",
-         "ie": "11"
+         "chrome": "55",
+         "firefox": "52",
+         "safari": "11"
       }
     }]
-  ],
-  "plugins": [
-    "transform-async-to-promises"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5231,13 +5231,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-transform-async-to-promises@npm:^0.8.6":
-  version: 0.8.18
-  resolution: "babel-plugin-transform-async-to-promises@npm:0.8.18"
-  checksum: dcc345359eb33f55c42c49894166c9a5c65635e1a6e0518a00beef4f1ead7dec3409f5b3050844c1870470627b21248b0947ee884835881961b731b638156377
-  languageName: node
-  linkType: hard
-
 "bach@npm:^2.0.1":
   version: 2.0.1
   resolution: "bach@npm:2.0.1"
@@ -8692,7 +8685,6 @@ __metadata:
     babel-plugin-inject-args: ^1.0.0
     babel-plugin-istanbul: ^7.0.0
     babel-plugin-mockable-imports: ^2.0.1
-    babel-plugin-transform-async-to-promises: ^0.8.6
     chai: ^5.0.0
     chance: ^1.0.13
     classnames: ^2.2.4


### PR DESCRIPTION
The client's boot script supports older browsers than the rest of the client so it can log a warning if it can't start in "somewhat" older browsers.

Update the boot script's supported officially browsers from ~2013 (IE 11) to ~2017 (Safari 11), although the code will probably still run in older browsers. This allows dropping an async/await Babel plugin, although async is not actually used in the current boot script.