### PR TITLE
Remove duplicated lines in tests

### DIFF
--- a/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
+++ b/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
@@ -41,7 +41,6 @@ describe('ExportAnnotations', () => {
       { attachTo: newContainer },
     );
     wrappers.push(wrapper);
-    containers.push(newContainer);
     return wrapper;
   };
 

--- a/src/sidebar/components/ShareDialog/test/ImportAnnotations-test.js
+++ b/src/sidebar/components/ShareDialog/test/ImportAnnotations-test.js
@@ -62,7 +62,6 @@ describe('ImportAnnotations', () => {
       { attachTo: newContainer },
     );
     wrappers.push(wrapper);
-    containers.push(newContainer);
     return wrapper;
   }
 


### PR DESCRIPTION
In https://github.com/hypothesis/client/pull/6662/commits/2a1441012893c041ba57095db38aba1dcf9f0e78, I added duplicated lines in a couple tests by mistake.

They don't break the tests, but make no sense and will be confusing in future, so I'm removing them.