### PR TITLE
Update to new lock icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.16.7",
     "@hypothesis/frontend-build": "^3.0.0",
-    "@hypothesis/frontend-shared": "^8.7.0",
+    "@hypothesis/frontend-shared": "^8.10.0",
     "@hypothesis/frontend-testing": "^1.2.0",
     "@npmcli/arborist": "^8.0.0",
     "@octokit/rest": "^21.0.0",

--- a/src/sidebar/components/Annotation/AnnotationHeader.tsx
+++ b/src/sidebar/components/Annotation/AnnotationHeader.tsx
@@ -113,10 +113,10 @@ function AnnotationHeader({
 
   return (
     <header>
-      <div className="flex gap-x-1 items-baseline flex-wrap-reverse">
+      <div className="flex gap-x-1 items-center flex-wrap-reverse">
         {isPrivate(annotation.permissions) && !isEditing && (
           <LockIcon
-            className="w-[10px] h-[10px]"
+            className="w-[12px] h-[12px]"
             title="This annotation is visible only to you"
           />
         )}

--- a/src/sidebar/components/ShareDialog/ShareAnnotations.tsx
+++ b/src/sidebar/components/ShareDialog/ShareAnnotations.tsx
@@ -94,7 +94,7 @@ function ShareAnnotations({ toastMessenger }: ShareAnnotationsProps) {
             )}{' '}
             <span>
               Private (
-              <LockIcon className="inline w-em h-em ml-0.5 -mt-0.5" />{' '}
+              <LockIcon className="inline w-[14px] h-[14px] -mt-0.5" />{' '}
               <em>Only Me</em>) annotations are only visible to you.
             </span>
           </p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2435,15 +2435,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^8.7.0":
-  version: 8.9.0
-  resolution: "@hypothesis/frontend-shared@npm:8.9.0"
+"@hypothesis/frontend-shared@npm:^8.10.0":
+  version: 8.10.0
+  resolution: "@hypothesis/frontend-shared@npm:8.10.0"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.4.0
-  checksum: bfe04718494b870a429c6ab7d1be8a656e13424b08e2cd1f9377a4622c1a16867ef7a450cccbfe37d8cc36236802db2babe13b93ca5da6feb19bc661d73f6728
+  checksum: 049b51651a8c74111638af3158e1572db446b448d07b154c30453d6fd7904c365d8f50aceaae6b387befb1dae2bf1900cbac69b909ba08c571c98178bec40c2d
   languageName: node
   linkType: hard
 
@@ -8753,7 +8753,7 @@ __metadata:
     "@babel/preset-react": ^7.0.0
     "@babel/preset-typescript": ^7.16.7
     "@hypothesis/frontend-build": ^3.0.0
-    "@hypothesis/frontend-shared": ^8.7.0
+    "@hypothesis/frontend-shared": ^8.10.0
     "@hypothesis/frontend-testing": ^1.2.0
     "@npmcli/arborist": ^8.0.0
     "@octokit/rest": ^21.0.0


### PR DESCRIPTION
> Part of https://github.com/hypothesis/product-backlog/issues/1597

Update to frontend-shared 8.10, which brings a new lock icon.

Additionally, apply a few style adjustments. You can see more details and screenshots in https://github.com/hypothesis/frontend-shared/pull/1774 