### PR TITLE
Normalize lock icon size in groups list

### DIFF
--- a/src/sidebar/components/GroupList/GroupListItem.tsx
+++ b/src/sidebar/components/GroupList/GroupListItem.tsx
@@ -34,7 +34,7 @@ function GroupIcon({ type }: { type: GroupType }) {
     >
       {type === 'open' && <GlobeAltIcon />}
       {type === 'restricted' && <GlobeAltLockIcon />}
-      {type === 'private' && <LockIcon />}
+      {type === 'private' && <LockIcon width={16} />}
     </div>
   );
 }


### PR DESCRIPTION
For some reason, when I created the lock icon, I set it as `width="18" height"18"`, when most of the other icons are set as `width="16" height"16"`.

That makes the icon look slightly vertically misaligned in the groups list.

![image](https://github.com/user-attachments/assets/9e80d1c4-b1cd-4bac-82a8-b4c05f9b03d4)

This PR hardcodes `width="16"` in the lock icon when used in the groups list, so that all icons have the same width.

![aligned](https://github.com/user-attachments/assets/9f340358-db86-450c-860c-e87d267b03fd)

Next, I'll go check why this icon was set with a different size in frontend-shared, and if I can change that in a backwards compatible way now.