### PR TITLE
Use `mount`/`unmountAll` from @hypothesis/frontend-testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@babel/preset-typescript": "^7.16.7",
     "@hypothesis/frontend-build": "^3.0.0",
     "@hypothesis/frontend-shared": "^8.10.2",
-    "@hypothesis/frontend-testing": "^1.2.0",
+    "@hypothesis/frontend-testing": "^1.3.1",
     "@npmcli/arborist": "^8.0.0",
     "@octokit/rest": "^21.0.0",
     "@rollup/plugin-babel": "^6.0.0",

--- a/src/annotator/components/test/AdderToolbar-test.js
+++ b/src/annotator/components/test/AdderToolbar-test.js
@@ -1,4 +1,4 @@
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import AdderToolbar from '../AdderToolbar';
 

--- a/src/annotator/components/test/Buckets-test.js
+++ b/src/annotator/components/test/Buckets-test.js
@@ -1,5 +1,5 @@
 import { checkAccessibility } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import Buckets from '../Buckets';
 

--- a/src/annotator/components/test/ClusterToolbar-test.js
+++ b/src/annotator/components/test/ClusterToolbar-test.js
@@ -1,4 +1,4 @@
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import {
   highlightStyles,

--- a/src/annotator/components/test/ContentInfoBanner-test.js
+++ b/src/annotator/components/test/ContentInfoBanner-test.js
@@ -1,4 +1,4 @@
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import ContentInfoBanner from '../ContentInfoBanner';
 

--- a/src/annotator/components/test/ModalDialog-test.js
+++ b/src/annotator/components/test/ModalDialog-test.js
@@ -1,31 +1,11 @@
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import ModalDialog from '../ModalDialog';
 
 describe('ModalDialog', () => {
-  let components;
-
   const createComponent = props => {
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-
-    const component = mount(<ModalDialog open {...props} />, {
-      attachTo: container,
-    });
-    components.push([component, container]);
-    return component;
+    return mount(<ModalDialog open {...props} />, { connected: true });
   };
-
-  beforeEach(() => {
-    components = [];
-  });
-
-  afterEach(() => {
-    components.forEach(([component, container]) => {
-      component.unmount();
-      container.remove();
-    });
-  });
 
   context('when native modal dialog is not supported', () => {
     let fakeDocument;

--- a/src/annotator/components/test/NotebookModal-test.js
+++ b/src/annotator/components/test/NotebookModal-test.js
@@ -1,4 +1,4 @@
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import { act } from 'preact/test-utils';
 
 import { addConfigFragment } from '../../../shared/config-fragment';
@@ -8,29 +8,22 @@ import NotebookModal, { $imports } from '../NotebookModal';
 describe('NotebookModal', () => {
   const notebookURL = 'https://test.hypothes.is/notebook';
 
-  let container;
-  let components;
   let eventBus;
   let emitter;
 
   const outerSelector = 'dialog[data-testid="notebook-outer"]';
 
   const createComponent = config => {
-    const component = mount(
+    return mount(
       <NotebookModal
         eventBus={eventBus}
         config={{ notebookAppUrl: notebookURL, ...config }}
       />,
-      { attachTo: container },
+      { connected: true },
     );
-    components.push(component);
-    return component;
   };
 
   beforeEach(() => {
-    container = document.createElement('div');
-    document.body.append(container);
-    components = [];
     eventBus = new EventBus();
     emitter = eventBus.createEmitter();
 
@@ -46,8 +39,6 @@ describe('NotebookModal', () => {
   });
 
   afterEach(() => {
-    components.forEach(component => component.unmount());
-    container.remove();
     $imports.$restore();
   });
 

--- a/src/annotator/components/test/ProfileModal-test.js
+++ b/src/annotator/components/test/ProfileModal-test.js
@@ -1,4 +1,4 @@
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import { act } from 'preact/test-utils';
 
 import { EventBus } from '../../util/emitter';
@@ -7,36 +7,24 @@ import ProfileModal from '../ProfileModal';
 describe('ProfileModal', () => {
   const profileURL = 'https://test.hypothes.is/user-profile';
 
-  let container;
-  let components;
   let eventBus;
   let emitter;
 
   const outerSelector = '[data-testid="profile-outer"]';
 
   const createComponent = config => {
-    const component = mount(
+    return mount(
       <ProfileModal
         eventBus={eventBus}
         config={{ profileAppUrl: profileURL, ...config }}
       />,
-      { attachTo: container },
+      { connected: true },
     );
-    components.push(component);
-    return component;
   };
 
   beforeEach(() => {
-    container = document.createElement('div');
-    document.body.append(container);
-    components = [];
     eventBus = new EventBus();
     emitter = eventBus.createEmitter();
-  });
-
-  afterEach(() => {
-    components.forEach(component => component.unmount());
-    container.remove();
   });
 
   it('does not render anything while the modal is closed', () => {

--- a/src/annotator/components/test/ToastMessages-test.js
+++ b/src/annotator/components/test/ToastMessages-test.js
@@ -1,4 +1,4 @@
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import EventEmitter from 'tiny-emitter';
 
 import { Emitter } from '../../util/emitter';

--- a/src/annotator/components/test/Toolbar-test.js
+++ b/src/annotator/components/test/Toolbar-test.js
@@ -1,5 +1,5 @@
 import { checkAccessibility } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import Toolbar from '../Toolbar';
 

--- a/src/sidebar/components/Annotation/test/Annotation-test.js
+++ b/src/sidebar/components/Annotation/test/Annotation-test.js
@@ -2,7 +2,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import sinon from 'sinon';
 
 import * as fixtures from '../../../test/annotation-fixtures';

--- a/src/sidebar/components/Annotation/test/AnnotationActionBar-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationActionBar-test.js
@@ -3,7 +3,7 @@ import {
   mockImportedComponents,
   waitFor,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import { act } from 'preact/test-utils';
 
 import * as fixtures from '../../../test/annotation-fixtures';

--- a/src/sidebar/components/Annotation/test/AnnotationBody-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationBody-test.js
@@ -2,7 +2,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import { act } from 'preact/test-utils';
 
 import * as fixtures from '../../../test/annotation-fixtures';

--- a/src/sidebar/components/Annotation/test/AnnotationDocumentInfo-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationDocumentInfo-test.js
@@ -1,5 +1,5 @@
 import { checkAccessibility } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import AnnotationDocumentInfo from '../AnnotationDocumentInfo';
 

--- a/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
@@ -3,7 +3,7 @@ import {
   mockImportedComponents,
   waitFor,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import { act } from 'preact/test-utils';
 
 import * as fixtures from '../../../test/annotation-fixtures';

--- a/src/sidebar/components/Annotation/test/AnnotationGroupInfo-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationGroupInfo-test.js
@@ -2,7 +2,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import AnnotationGroupInfo, { $imports } from '../AnnotationGroupInfo';
 

--- a/src/sidebar/components/Annotation/test/AnnotationHeader-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationHeader-test.js
@@ -2,7 +2,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import * as fixtures from '../../../test/annotation-fixtures';
 import AnnotationHeader, { $imports } from '../AnnotationHeader';

--- a/src/sidebar/components/Annotation/test/AnnotationPublishControl-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationPublishControl-test.js
@@ -3,7 +3,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import AnnotationPublishControl, {
   $imports,

--- a/src/sidebar/components/Annotation/test/AnnotationQuote-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationQuote-test.js
@@ -2,7 +2,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import AnnotationQuote, { $imports } from '../AnnotationQuote';
 

--- a/src/sidebar/components/Annotation/test/AnnotationReplyToggle-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationReplyToggle-test.js
@@ -1,5 +1,5 @@
 import { checkAccessibility } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import { act } from 'preact/test-utils';
 
 import AnnotationReplyToggle from '../AnnotationReplyToggle';

--- a/src/sidebar/components/Annotation/test/AnnotationShareControl-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationShareControl-test.js
@@ -2,7 +2,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import { act } from 'preact/test-utils';
 
 import AnnotationShareControl, { $imports } from '../AnnotationShareControl';
@@ -18,8 +18,6 @@ describe('AnnotationShareControl', () => {
   let fakeIsIOS;
   let fakeStore;
 
-  let container;
-
   const getIconButton = (wrapper, iconName) => {
     return wrapper
       .find('IconButton')
@@ -34,7 +32,7 @@ describe('AnnotationShareControl', () => {
         shareUri={fakeShareUri}
         {...props}
       />,
-      { attachTo: container },
+      { connected: true },
     );
   }
 
@@ -53,11 +51,6 @@ describe('AnnotationShareControl', () => {
   }
 
   beforeEach(() => {
-    // This extra element is necessary to test automatic `focus`-ing
-    // of the component's `input` element
-    container = document.createElement('div');
-    document.body.appendChild(container);
-
     fakeAnnotation = {
       group: 'fakegroup',
       permissions: {},
@@ -102,7 +95,6 @@ describe('AnnotationShareControl', () => {
 
   afterEach(() => {
     $imports.$restore();
-    container.remove();
   });
 
   it('does not render component if annotation group is not available', () => {

--- a/src/sidebar/components/Annotation/test/AnnotationTimestamps-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationTimestamps-test.js
@@ -1,5 +1,5 @@
 import { checkAccessibility } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import { act } from 'preact/test-utils';
 
 import AnnotationTimestamps, { $imports } from '../AnnotationTimestamps';

--- a/src/sidebar/components/Annotation/test/AnnotationUser-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationUser-test.js
@@ -1,5 +1,5 @@
 import { checkAccessibility } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import AnnotationUser from '../AnnotationUser';
 

--- a/src/sidebar/components/Annotation/test/EmptyAnnotation-test.js
+++ b/src/sidebar/components/Annotation/test/EmptyAnnotation-test.js
@@ -2,7 +2,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import EmptyAnnotation, { $imports } from '../EmptyAnnotation';
 

--- a/src/sidebar/components/GroupList/test/GroupList-test.js
+++ b/src/sidebar/components/GroupList/test/GroupList-test.js
@@ -1,5 +1,5 @@
 import { mockImportedComponents } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import { act } from 'preact/test-utils';
 
 import GroupList, { $imports } from '../GroupList';

--- a/src/sidebar/components/GroupList/test/GroupListItem-test.js
+++ b/src/sidebar/components/GroupList/test/GroupListItem-test.js
@@ -1,5 +1,5 @@
 import { delay } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import { act } from 'preact/test-utils';
 
 import GroupListItem, { $imports } from '../GroupListItem';

--- a/src/sidebar/components/GroupList/test/GroupListSection-test.js
+++ b/src/sidebar/components/GroupList/test/GroupListSection-test.js
@@ -1,5 +1,5 @@
 import { mockImportedComponents } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import GroupListSection, { $imports } from '../GroupListSection';
 

--- a/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
+++ b/src/sidebar/components/ShareDialog/test/ExportAnnotations-test.js
@@ -4,7 +4,7 @@ import {
   mockImportedComponents,
   waitForElement,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import { act } from 'preact/test-utils';
 
 import * as fixtures from '../../../test/annotation-fixtures';
@@ -18,8 +18,6 @@ describe('ExportAnnotations', () => {
   let fakeSuggestedFilename;
   let fakeCopyPlainText;
   let fakeCopyHTML;
-  let wrappers;
-  let containers;
 
   const fakePrivateGroup = {
     type: 'private',
@@ -28,25 +26,17 @@ describe('ExportAnnotations', () => {
   };
 
   const createComponent = props => {
-    const newContainer = document.createElement('div');
-    containers.push(newContainer);
-    document.body.appendChild(newContainer);
-
-    const wrapper = mount(
+    return mount(
       <ExportAnnotations
         annotationsExporter={fakeAnnotationsExporter}
         toastMessenger={fakeToastMessenger}
         {...props}
       />,
-      { attachTo: newContainer },
+      { connected: true },
     );
-    wrappers.push(wrapper);
-    return wrapper;
   };
 
   beforeEach(() => {
-    wrappers = [];
-    containers = [];
     fakeAnnotationsExporter = {
       buildJSONExportContent: sinon.stub().returns({}),
       buildTextExportContent: sinon.stub().returns(''),
@@ -102,8 +92,6 @@ describe('ExportAnnotations', () => {
   });
 
   afterEach(() => {
-    wrappers.forEach(w => w.unmount());
-    containers.forEach(c => c.remove());
     $imports.$restore();
   });
 

--- a/src/sidebar/components/ShareDialog/test/FileInput-test.js
+++ b/src/sidebar/components/ShareDialog/test/FileInput-test.js
@@ -1,21 +1,13 @@
 import { checkAccessibility } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import FileInput from '../FileInput';
 
 describe('FileInput', () => {
-  let container;
   let fakeOnFileSelected;
 
   beforeEach(() => {
-    container = document.createElement('div');
-    document.body.appendChild(container);
-
     fakeOnFileSelected = sinon.stub();
-  });
-
-  afterEach(() => {
-    container.remove();
   });
 
   const createFile = name => new File([name], `${name}.json`);
@@ -37,7 +29,7 @@ describe('FileInput', () => {
   const createInput = (disabled = undefined) => {
     const wrapper = mount(
       <FileInput onFileSelected={fakeOnFileSelected} disabled={disabled} />,
-      { attachTo: container },
+      { connected: true },
     );
 
     // Stub "click" method on the native input, so it doesn't show a real file

--- a/src/sidebar/components/ShareDialog/test/ImportAnnotations-test.js
+++ b/src/sidebar/components/ShareDialog/test/ImportAnnotations-test.js
@@ -4,7 +4,7 @@ import {
   waitFor,
   waitForElement,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import ImportAnnotations, { $imports } from '../ImportAnnotations';
 
@@ -12,13 +12,8 @@ describe('ImportAnnotations', () => {
   let fakeImportAnnotationsService;
   let fakeReadExportFile;
   let fakeStore;
-  let wrappers;
-  let containers;
 
   beforeEach(() => {
-    wrappers = [];
-    containers = [];
-
     fakeReadExportFile = sinon.stub().rejects(new Error('Failed to read file'));
 
     fakeImportAnnotationsService = {
@@ -44,25 +39,17 @@ describe('ImportAnnotations', () => {
   });
 
   afterEach(() => {
-    wrappers.forEach(w => w.unmount());
-    containers.forEach(c => c.remove());
     $imports.$restore();
   });
 
   function createImportAnnotations() {
-    const newContainer = document.createElement('div');
-    containers.push(newContainer);
-    document.body.appendChild(newContainer);
-
-    const wrapper = mount(
+    return mount(
       <ImportAnnotations
         store={fakeStore}
         importAnnotationsService={fakeImportAnnotationsService}
       />,
-      { attachTo: newContainer },
+      { connected: true },
     );
-    wrappers.push(wrapper);
-    return wrapper;
   }
 
   function getImportButton(wrapper) {

--- a/src/sidebar/components/ShareDialog/test/ShareAnnotations-test.js
+++ b/src/sidebar/components/ShareDialog/test/ShareAnnotations-test.js
@@ -2,7 +2,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import ShareAnnotations from '../ShareAnnotations';
 import { $imports } from '../ShareAnnotations';

--- a/src/sidebar/components/ShareDialog/test/ShareDialog-test.js
+++ b/src/sidebar/components/ShareDialog/test/ShareDialog-test.js
@@ -3,7 +3,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import ShareDialog from '../ShareDialog';
 import { $imports } from '../ShareDialog';

--- a/src/sidebar/components/hooks/test/use-filter-options-test.js
+++ b/src/sidebar/components/hooks/test/use-filter-options-test.js
@@ -1,4 +1,4 @@
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import { useUserFilterOptions, $imports } from '../use-filter-options';
 

--- a/src/sidebar/components/hooks/test/use-root-thread-test.js
+++ b/src/sidebar/components/hooks/test/use-root-thread-test.js
@@ -1,4 +1,4 @@
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import { useRootThread, $imports } from '../use-root-thread';
 

--- a/src/sidebar/components/search/test/FilterControls-test.js
+++ b/src/sidebar/components/search/test/FilterControls-test.js
@@ -1,4 +1,4 @@
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import FilterControls, { $imports } from '../FilterControls';
 

--- a/src/sidebar/components/search/test/SearchField-test.js
+++ b/src/sidebar/components/search/test/SearchField-test.js
@@ -2,19 +2,15 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import SearchField, { $imports } from '../SearchField';
 
 describe('SearchField', () => {
   let fakeStore;
-  let container;
-  let wrappers;
 
   const createSearchField = (props = {}) => {
-    const wrapper = mount(<SearchField {...props} />, { attachTo: container });
-    wrappers.push(wrapper);
-    return wrapper;
+    return mount(<SearchField {...props} />, { connected: true });
   };
 
   function typeQuery(wrapper, query) {
@@ -28,9 +24,6 @@ describe('SearchField', () => {
   }
 
   beforeEach(() => {
-    wrappers = [];
-    container = document.createElement('div');
-    document.body.appendChild(container);
     fakeStore = { isLoading: sinon.stub().returns(false) };
 
     $imports.$mock(mockImportedComponents());
@@ -40,8 +33,6 @@ describe('SearchField', () => {
   });
 
   afterEach(() => {
-    wrappers.forEach(wrapper => wrapper.unmount());
-    container.remove();
     $imports.$restore();
   });
 

--- a/src/sidebar/components/search/test/SearchPanel-test.js
+++ b/src/sidebar/components/search/test/SearchPanel-test.js
@@ -1,5 +1,5 @@
 import { mockImportedComponents } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import SearchPanel, { $imports } from '../SearchPanel';
 

--- a/src/sidebar/components/search/test/StreamSearchInput-test.js
+++ b/src/sidebar/components/search/test/StreamSearchInput-test.js
@@ -1,5 +1,5 @@
 import { mockImportedComponents } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import { act } from 'preact/test-utils';
 
 import StreamSearchInput, { $imports } from '../StreamSearchInput';

--- a/src/sidebar/components/test/AnnotationView-test.js
+++ b/src/sidebar/components/test/AnnotationView-test.js
@@ -1,5 +1,5 @@
 import { mockImportedComponents, waitFor } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import AnnotationView, { $imports } from '../AnnotationView';
 

--- a/src/sidebar/components/test/AutocompleteList-test.js
+++ b/src/sidebar/components/test/AutocompleteList-test.js
@@ -2,7 +2,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import AutocompleteList, { $imports } from '../AutocompleteList';
 

--- a/src/sidebar/components/test/CircularProgress-test.js
+++ b/src/sidebar/components/test/CircularProgress-test.js
@@ -1,4 +1,4 @@
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import CircularProgress from '../CircularProgress';
 

--- a/src/sidebar/components/test/Excerpt-test.js
+++ b/src/sidebar/components/test/Excerpt-test.js
@@ -1,5 +1,5 @@
 import { checkAccessibility } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import { act } from 'preact/test-utils';
 
 import Excerpt, { $imports } from '../Excerpt';
@@ -13,7 +13,6 @@ describe('Excerpt', () => {
   );
   const DEFAULT_CONTENT = <span className="the-content">default content</span>;
 
-  let container;
   let fakeObserveElementSize;
 
   function createExcerpt(props = {}, content = DEFAULT_CONTENT) {
@@ -27,15 +26,12 @@ describe('Excerpt', () => {
       >
         {content}
       </Excerpt>,
-      { attachTo: container },
+      { connected: true },
     );
   }
 
   beforeEach(() => {
     fakeObserveElementSize = sinon.stub();
-    container = document.createElement('div');
-    document.body.appendChild(container);
-
     $imports.$mock({
       '../util/observe-element-size': {
         observeElementSize: fakeObserveElementSize,
@@ -45,7 +41,6 @@ describe('Excerpt', () => {
 
   afterEach(() => {
     $imports.$restore();
-    container.remove();
   });
 
   function getExcerptHeight(wrapper) {

--- a/src/sidebar/components/test/FilterSelect-test.js
+++ b/src/sidebar/components/test/FilterSelect-test.js
@@ -3,7 +3,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import FilterSelect, { $imports } from '../FilterSelect';
 

--- a/src/sidebar/components/test/HelpPanel-test.js
+++ b/src/sidebar/components/test/HelpPanel-test.js
@@ -3,7 +3,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import { act } from 'preact/test-utils';
 
 import HelpPanel, { $imports } from '../HelpPanel';

--- a/src/sidebar/components/test/HypothesisApp-test.js
+++ b/src/sidebar/components/test/HypothesisApp-test.js
@@ -1,5 +1,5 @@
 import { mockImportedComponents } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import HypothesisApp, { $imports } from '../HypothesisApp';
 

--- a/src/sidebar/components/test/LaunchErrorPanel-test.js
+++ b/src/sidebar/components/test/LaunchErrorPanel-test.js
@@ -1,4 +1,4 @@
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import LaunchErrorPanel from '../LaunchErrorPanel';
 

--- a/src/sidebar/components/test/LoggedOutMessage-test.js
+++ b/src/sidebar/components/test/LoggedOutMessage-test.js
@@ -2,7 +2,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import LoggedOutMessage, { $imports } from '../LoggedOutMessage';
 

--- a/src/sidebar/components/test/LoginPromptPanel-test.js
+++ b/src/sidebar/components/test/LoginPromptPanel-test.js
@@ -2,7 +2,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import LoginPromptPanel, { $imports } from '../LoginPromptPanel';
 

--- a/src/sidebar/components/test/MarkdownEditor-test.js
+++ b/src/sidebar/components/test/MarkdownEditor-test.js
@@ -2,7 +2,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import { render } from 'preact';
 import { act } from 'preact/test-utils';
 
@@ -298,19 +298,12 @@ describe('MarkdownEditor', () => {
   });
 
   describe('keyboard navigation', () => {
-    let newContainer;
     let wrapper;
 
     beforeEach(() => {
-      newContainer = document.createElement('div');
-      document.body.appendChild(newContainer);
       wrapper = mount(<MarkdownEditor label="Test editor" text="test" />, {
-        attachTo: newContainer,
+        connected: true,
       });
-    });
-
-    afterEach(() => {
-      newContainer.remove();
     });
 
     const pressKey = key =>

--- a/src/sidebar/components/test/MarkdownView-test.js
+++ b/src/sidebar/components/test/MarkdownView-test.js
@@ -1,5 +1,5 @@
 import { checkAccessibility } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import MarkdownView, { $imports } from '../MarkdownView';
 

--- a/src/sidebar/components/test/Menu-test.js
+++ b/src/sidebar/components/test/Menu-test.js
@@ -2,15 +2,13 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import { act } from 'preact/test-utils';
 
 import Menu from '../Menu';
 import { $imports } from '../Menu';
 
 describe('Menu', () => {
-  let container;
-
   const menuSelector = '[data-testid="menu-container"]';
   const contentSelector = '[data-testid="menu-content"]';
   const toggleSelector = 'button[data-testid="menu-toggle-button"]';
@@ -19,13 +17,11 @@ describe('Menu', () => {
   const TestMenuItem = () => 'Test item';
 
   const createMenu = props => {
-    // Use `mount` rather than `shallow` rendering in order to supporting
-    // testing of clicking outside the element.
     return mount(
       <Menu {...props} label={<TestLabel />} title="Test menu">
         <TestMenuItem />
       </Menu>,
-      { attachTo: container },
+      { connected: true },
     );
   };
 
@@ -34,15 +30,11 @@ describe('Menu', () => {
   }
 
   beforeEach(() => {
-    container = document.createElement('div');
-    document.body.appendChild(container);
-
     $imports.$mock(mockImportedComponents());
   });
 
   afterEach(() => {
     $imports.$restore();
-    container.remove();
   });
 
   it('opens and closes when the toggle button is clicked', () => {

--- a/src/sidebar/components/test/MenuArrow-test.js
+++ b/src/sidebar/components/test/MenuArrow-test.js
@@ -1,5 +1,5 @@
 import { mockImportedComponents } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import MenuArrow, { $imports } from '../MenuArrow';
 

--- a/src/sidebar/components/test/MenuItem-test.js
+++ b/src/sidebar/components/test/MenuItem-test.js
@@ -3,19 +3,15 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import { act } from 'preact/test-utils';
 
 import MenuItem, { $imports } from '../MenuItem';
 
 describe('MenuItem', () => {
-  let containers = [];
   const createMenuItem = props => {
-    const newContainer = document.createElement('div');
-    containers.push(newContainer);
-    document.body.appendChild(newContainer);
     return mount(<MenuItem label="Test item" {...props} />, {
-      attachTo: newContainer,
+      connected: true,
     });
   };
 
@@ -27,10 +23,6 @@ describe('MenuItem', () => {
 
   afterEach(() => {
     $imports.$restore();
-    containers.forEach(container => {
-      container.remove();
-    });
-    containers = [];
   });
 
   describe('link menu items', () => {

--- a/src/sidebar/components/test/MenuKeyboardNavigation-test.js
+++ b/src/sidebar/components/test/MenuKeyboardNavigation-test.js
@@ -2,19 +2,15 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import MenuKeyboardNavigation, { $imports } from '../MenuKeyboardNavigation';
 
 describe('MenuKeyboardNavigation', () => {
   let fakeCloseMenu;
   let clock;
-  let containers = [];
 
   const createMenuItem = props => {
-    const newContainer = document.createElement('div');
-    containers.push(newContainer);
-    document.body.appendChild(newContainer);
     return mount(
       <MenuKeyboardNavigation
         closeMenu={fakeCloseMenu}
@@ -27,7 +23,7 @@ describe('MenuKeyboardNavigation', () => {
         <button role="menuitem">Item 3</button>
       </MenuKeyboardNavigation>,
       {
-        attachTo: newContainer,
+        connected: true,
       },
     );
   };
@@ -39,10 +35,6 @@ describe('MenuKeyboardNavigation', () => {
 
   afterEach(() => {
     $imports.$restore();
-    containers.forEach(container => {
-      container.remove();
-    });
-    containers = [];
   });
 
   it('renders the provided class name', () => {

--- a/src/sidebar/components/test/MenuSection-test.js
+++ b/src/sidebar/components/test/MenuSection-test.js
@@ -2,7 +2,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import MenuSection from '../MenuSection';
 import { $imports } from '../MenuSection';

--- a/src/sidebar/components/test/ModerationBanner-test.js
+++ b/src/sidebar/components/test/ModerationBanner-test.js
@@ -2,7 +2,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import * as fixtures from '../../test/annotation-fixtures';
 import ModerationBanner, { $imports } from '../ModerationBanner';

--- a/src/sidebar/components/test/NotebookFilters-test.js
+++ b/src/sidebar/components/test/NotebookFilters-test.js
@@ -1,6 +1,6 @@
 import { ProfileIcon } from '@hypothesis/frontend-shared';
 import { mockImportedComponents } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import NotebookFilters from '../NotebookFilters';
 import { $imports } from '../NotebookFilters';

--- a/src/sidebar/components/test/NotebookResultCount-test.js
+++ b/src/sidebar/components/test/NotebookResultCount-test.js
@@ -1,5 +1,5 @@
 import { checkAccessibility } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import NotebookResultCount, { $imports } from '../NotebookResultCount';
 

--- a/src/sidebar/components/test/NotebookView-test.js
+++ b/src/sidebar/components/test/NotebookView-test.js
@@ -2,7 +2,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import { act } from 'preact/test-utils';
 
 import { ResultSizeError } from '../../search-client';

--- a/src/sidebar/components/test/OpenDashboardMenuItem-test.js
+++ b/src/sidebar/components/test/OpenDashboardMenuItem-test.js
@@ -1,5 +1,5 @@
 import { waitFor } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import sinon from 'sinon';
 
 import OpenDashboardMenuItem from '../OpenDashboardMenuItem';

--- a/src/sidebar/components/test/PaginatedThreadList-test.js
+++ b/src/sidebar/components/test/PaginatedThreadList-test.js
@@ -1,5 +1,5 @@
 import { mockImportedComponents } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import PaginatedThreadList, { $imports } from '../PaginatedThreadList';
 

--- a/src/sidebar/components/test/PaginationNavigation-test.js
+++ b/src/sidebar/components/test/PaginationNavigation-test.js
@@ -1,5 +1,5 @@
 import { checkAccessibility } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import { act } from 'preact/test-utils';
 
 import PaginationNavigation, { $imports } from '../PaginationNavigation';

--- a/src/sidebar/components/test/PendingUpdatesNotification-test.js
+++ b/src/sidebar/components/test/PendingUpdatesNotification-test.js
@@ -1,4 +1,4 @@
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import sinon from 'sinon';
 
 import { promiseWithResolvers } from '../../../shared/promise-with-resolvers';
@@ -38,7 +38,7 @@ describe('PendingUpdatesNotification', () => {
     $imports.$restore();
   });
 
-  function createComponent(container) {
+  function createComponent() {
     return mount(
       <PendingUpdatesNotification
         streamer={fakeStreamer}
@@ -46,7 +46,7 @@ describe('PendingUpdatesNotification', () => {
         setTimeout_={fakeSetTimeout}
         clearTimeout_={fakeClearTimeout}
       />,
-      { attachTo: container },
+      { connected: true },
     );
   }
 
@@ -123,27 +123,16 @@ describe('PendingUpdatesNotification', () => {
   [true, false].forEach(hasPendingUpdates => {
     it('applies updates when "l" is pressed', () => {
       fakeStore.hasPendingUpdatesOrDeletions.returns(hasPendingUpdates);
-      let wrapper;
-      const container = document.createElement('div');
-      document.body.append(container);
 
-      try {
-        wrapper = createComponent(container);
+      createComponent();
 
-        assert.notCalled(fakeStreamer.applyPendingUpdates);
-        assert.notCalled(fakeAnalytics.trackEvent);
-        document.documentElement.dispatchEvent(
-          new KeyboardEvent('keydown', { key: 'l' }),
-        );
-        assert.equal(
-          fakeStreamer.applyPendingUpdates.called,
-          hasPendingUpdates,
-        );
-        assert.equal(fakeAnalytics.trackEvent.called, hasPendingUpdates);
-      } finally {
-        wrapper?.unmount();
-        container.remove();
-      }
+      assert.notCalled(fakeStreamer.applyPendingUpdates);
+      assert.notCalled(fakeAnalytics.trackEvent);
+      document.documentElement.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'l' }),
+      );
+      assert.equal(fakeStreamer.applyPendingUpdates.called, hasPendingUpdates);
+      assert.equal(fakeAnalytics.trackEvent.called, hasPendingUpdates);
     });
   });
 });

--- a/src/sidebar/components/test/ProfileView-test.js
+++ b/src/sidebar/components/test/ProfileView-test.js
@@ -1,4 +1,4 @@
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import ProfileView, { $imports } from '../ProfileView';
 

--- a/src/sidebar/components/test/ShareLinks-test.js
+++ b/src/sidebar/components/test/ShareLinks-test.js
@@ -2,7 +2,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import ShareLinks, { $imports } from '../ShareLinks';
 

--- a/src/sidebar/components/test/SidebarContentError-test.js
+++ b/src/sidebar/components/test/SidebarContentError-test.js
@@ -2,7 +2,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import SidebarContentError from '../SidebarContentError';
 import { $imports } from '../SidebarContentError';

--- a/src/sidebar/components/test/SidebarPanel-test.js
+++ b/src/sidebar/components/test/SidebarPanel-test.js
@@ -3,7 +3,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import SidebarPanel, { $imports } from '../SidebarPanel';
 

--- a/src/sidebar/components/test/SidebarTabs-test.js
+++ b/src/sidebar/components/test/SidebarTabs-test.js
@@ -2,7 +2,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import SidebarTabs, { $imports } from '../SidebarTabs';
 

--- a/src/sidebar/components/test/SidebarView-test.js
+++ b/src/sidebar/components/test/SidebarView-test.js
@@ -2,7 +2,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import SidebarView, { $imports } from '../SidebarView';
 

--- a/src/sidebar/components/test/SortMenu-test.js
+++ b/src/sidebar/components/test/SortMenu-test.js
@@ -1,5 +1,5 @@
 import { mockImportedComponents } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import SortMenu from '../SortMenu';
 import { $imports } from '../SortMenu';

--- a/src/sidebar/components/test/StreamView-test.js
+++ b/src/sidebar/components/test/StreamView-test.js
@@ -1,5 +1,5 @@
 import { mockImportedComponents, waitFor } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import StreamView, { $imports } from '../StreamView';
 

--- a/src/sidebar/components/test/TagEditor-test.js
+++ b/src/sidebar/components/test/TagEditor-test.js
@@ -2,7 +2,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import { act } from 'preact/test-utils';
 
 import AutocompleteList from '../AutocompleteList';
@@ -10,7 +10,6 @@ import TagEditor from '../TagEditor';
 import { $imports } from '../TagEditor';
 
 describe('TagEditor', () => {
-  let containers = [];
   const fakeTags = ['tag1', 'tag2'];
   let fakeTagsService;
   let fakeServiceUrl;
@@ -19,11 +18,6 @@ describe('TagEditor', () => {
   let fakeOnTagInput;
 
   function createComponent(props) {
-    // Use an array of containers so we can test more
-    // than one component at a time.
-    const newContainer = document.createElement('div');
-    containers.push(newContainer);
-    document.body.appendChild(newContainer);
     return mount(
       <TagEditor
         // props
@@ -36,7 +30,7 @@ describe('TagEditor', () => {
         tags={fakeTagsService}
         {...props}
       />,
-      { attachTo: newContainer },
+      { connected: true },
     );
   }
 
@@ -52,10 +46,6 @@ describe('TagEditor', () => {
   });
 
   afterEach(() => {
-    containers.forEach(container => {
-      container.remove();
-    });
-    containers = [];
     $imports.$restore();
   });
 

--- a/src/sidebar/components/test/TagListItem-test.js
+++ b/src/sidebar/components/test/TagListItem-test.js
@@ -1,5 +1,5 @@
 import { checkAccessibility } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import TagList from '../TagList';
 import TagListItem from '../TagListItem';

--- a/src/sidebar/components/test/Thread-test.js
+++ b/src/sidebar/components/test/Thread-test.js
@@ -2,7 +2,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import { act } from 'preact/test-utils';
 
 import Thread from '../Thread';

--- a/src/sidebar/components/test/ThreadCard-test.js
+++ b/src/sidebar/components/test/ThreadCard-test.js
@@ -2,12 +2,11 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import ThreadCard, { $imports } from '../ThreadCard';
 
 describe('ThreadCard', () => {
-  let container;
   let fakeDebounce;
   let fakeFrameSync;
   let fakeStore;
@@ -18,14 +17,11 @@ describe('ThreadCard', () => {
   function createComponent(props) {
     return mount(
       <ThreadCard frameSync={fakeFrameSync} thread={fakeThread} {...props} />,
-      { attachTo: container },
+      { connected: true },
     );
   }
 
   beforeEach(() => {
-    container = document.createElement('div');
-    document.body.append(container);
-
     fakeDebounce = sinon.stub().returnsArg(0);
     fakeFrameSync = {
       hoverAnnotation: sinon.stub(),
@@ -53,7 +49,6 @@ describe('ThreadCard', () => {
 
   afterEach(() => {
     $imports.$restore();
-    container.remove();
   });
 
   it('renders a `Thread` for the passed `thread`', () => {
@@ -122,9 +117,8 @@ describe('ThreadCard', () => {
       it('does not focus thread if there is no matching focus request', () => {
         fakeStore.annotationFocusRequest.returns(focusRequest);
 
-        createComponent();
-
-        const threadCard = container.querySelector(threadCardSelector);
+        const wrapper = createComponent();
+        const threadCard = wrapper.find(threadCardSelector).getDOMNode();
 
         assert.notEqual(document.activeElement, threadCard);
         assert.notCalled(fakeStore.clearAnnotationFocusRequest);
@@ -134,9 +128,9 @@ describe('ThreadCard', () => {
     it('gives focus to the thread if there is a matching focus request', () => {
       fakeStore.annotationFocusRequest.returns('t1');
 
-      createComponent();
+      const wrapper = createComponent();
 
-      const threadCard = container.querySelector(threadCardSelector);
+      const threadCard = wrapper.find(threadCardSelector).getDOMNode();
       assert.equal(document.activeElement, threadCard);
       assert.called(fakeStore.clearAnnotationFocusRequest);
     });

--- a/src/sidebar/components/test/ToastMessages-test.js
+++ b/src/sidebar/components/test/ToastMessages-test.js
@@ -1,5 +1,5 @@
 import { mockImportedComponents } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import ToastMessages, { $imports } from '../ToastMessages';
 

--- a/src/sidebar/components/test/TopBar-test.js
+++ b/src/sidebar/components/test/TopBar-test.js
@@ -2,7 +2,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import TopBar, { $imports } from '../TopBar';
 

--- a/src/sidebar/components/test/Tutorial-test.js
+++ b/src/sidebar/components/test/Tutorial-test.js
@@ -2,7 +2,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import Tutorial, { $imports } from '../Tutorial';
 

--- a/src/sidebar/components/test/UserMenu-test.js
+++ b/src/sidebar/components/test/UserMenu-test.js
@@ -1,5 +1,5 @@
 import { mockImportedComponents } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import { act } from 'preact/test-utils';
 
 import UserMenu, { $imports } from '../UserMenu';

--- a/src/sidebar/components/test/VersionInfo-test.js
+++ b/src/sidebar/components/test/VersionInfo-test.js
@@ -2,7 +2,7 @@ import {
   checkAccessibility,
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 
 import VersionInfo from '../VersionInfo';
 import { $imports } from '../VersionInfo';

--- a/src/sidebar/store/test/use-store-test.js
+++ b/src/sidebar/store/test/use-store-test.js
@@ -1,4 +1,4 @@
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import { act } from 'preact/test-utils';
 
 import { createStore, createStoreModule } from '../create-store';

--- a/src/sidebar/test/bootstrap.js
+++ b/src/sidebar/test/bootstrap.js
@@ -1,3 +1,4 @@
+import { unmountAll } from '@hypothesis/frontend-testing';
 import { assert } from 'chai';
 import { configure } from 'enzyme';
 import { Adapter } from 'enzyme-adapter-preact-pure';
@@ -17,6 +18,11 @@ globalThis.sinon = sinon;
 
 // Configure Enzyme for UI tests.
 configure({ adapter: new Adapter() });
+
+// Unmount all UI components after each test.
+afterEach(() => {
+  unmountAll();
+});
 
 // Ensure that uncaught exceptions between tests result in the tests failing.
 // This works around an issue with mocha / karma-mocha, see

--- a/src/sidebar/test/integration/threading-test.js
+++ b/src/sidebar/test/integration/threading-test.js
@@ -1,4 +1,4 @@
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import { useReducer } from 'preact/hooks';
 import { act } from 'preact/test-utils';
 

--- a/src/sidebar/test/service-context-test.js
+++ b/src/sidebar/test/service-context-test.js
@@ -1,4 +1,4 @@
-import { mount } from 'enzyme';
+import { mount } from '@hypothesis/frontend-testing';
 import { render } from 'preact';
 
 import { ServiceContext, withServices, useService } from '../service-context';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2447,14 +2447,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-testing@npm:^1.2.0":
-  version: 1.2.2
-  resolution: "@hypothesis/frontend-testing@npm:1.2.2"
+"@hypothesis/frontend-testing@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@hypothesis/frontend-testing@npm:1.3.1"
   dependencies:
     axe-core: ^4.8.2
     enzyme: ^3.11.0
     preact: ^10.18.1
-  checksum: b3892f6f1db87387aa60a420f0d2a7c89c5031a1375273cce6777aba335f5d01b223a5fee499f1fbf418044eea6c85684d8488647e8b353d9637c05ba29d15de
+  checksum: 36f814e13d164cf55bf3f2ea21f0522fa1cbe5464a010a520de0506e9a8116a7d514807f38a257cade0ba442e0d0c00b8093658e17698b8c23a044a9f55c0be1
   languageName: node
   linkType: hard
 
@@ -8648,7 +8648,7 @@ __metadata:
     "@babel/preset-typescript": ^7.16.7
     "@hypothesis/frontend-build": ^3.0.0
     "@hypothesis/frontend-shared": ^8.10.2
-    "@hypothesis/frontend-testing": ^1.2.0
+    "@hypothesis/frontend-testing": ^1.3.1
     "@npmcli/arborist": ^8.0.0
     "@octokit/rest": ^21.0.0
     "@rollup/plugin-babel": ^6.0.0


### PR DESCRIPTION
Change the client to use the new `mount`/`unmountAll` functions from @hypothesis/frontend-testing to simplify cleanup after tests run. This follows the same pattern as https://github.com/hypothesis/h/pull/9125.