### PR TITLE
Display suggestions popover when at-mentioning

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationEditor.tsx
+++ b/src/sidebar/components/Annotation/AnnotationEditor.tsx
@@ -179,6 +179,7 @@ function AnnotationEditor({
         label={isReplyAnno ? 'Enter reply' : 'Enter comment'}
         text={text}
         onEditText={onEditText}
+        atMentionsEnabled={store.isFeatureEnabled('at_mentions')}
       />
       <TagEditor
         onAddTag={onAddTag}

--- a/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
@@ -61,6 +61,7 @@ describe('AnnotationEditor', () => {
       setDefault: sinon.stub(),
       removeDraft: sinon.stub(),
       removeAnnotations: sinon.stub(),
+      isFeatureEnabled: sinon.stub().returns(false),
     };
 
     $imports.$mock(mockImportedComponents());

--- a/src/sidebar/util/term-before-position.ts
+++ b/src/sidebar/util/term-before-position.ts
@@ -1,0 +1,9 @@
+/**
+ * Returns the "word" right before a specific position in an input string.
+ *
+ * In this context, a word is anything between a space or newline, and provided
+ * position.
+ */
+export function termBeforePosition(text: string, position: number): string {
+  return text.slice(0, position).match(/\S+$/)?.[0] ?? '';
+}

--- a/src/sidebar/util/test/term-before-position-test.js
+++ b/src/sidebar/util/test/term-before-position-test.js
@@ -1,0 +1,72 @@
+import { termBeforePosition } from '../term-before-position';
+
+describe('term-before-position', () => {
+  // To make these tests more predictable, we place the `$` sign in the position
+  // to be checked. That way it's easier to see what is the "word" preceding it.
+  // The test will then get the `$` sign index and remove it from the text
+  // before passing it to `termBeforePosition`.
+  [
+    // First and last positions
+    {
+      text: '$Hello world',
+      expectedTerm: '',
+    },
+    {
+      text: 'Hello world$',
+      expectedTerm: 'world',
+    },
+
+    // Position in the middle of words
+    {
+      text: 'Hell$o world',
+      expectedTerm: 'Hell',
+    },
+    {
+      text: 'Hello wor$ld',
+      expectedTerm: 'wor',
+    },
+
+    // Position preceded by "empty space"
+    {
+      text: 'Hello $world',
+      expectedTerm: '',
+    },
+    {
+      text: `Text with
+      multiple
+      $
+      lines
+      `,
+      expectedTerm: '',
+    },
+
+    // Position preceded by/in the middle of a word for multi-line text
+    {
+      text: `Text with$
+      multiple
+      
+      lines
+      `,
+      expectedTerm: 'with',
+    },
+    {
+      text: `Text with
+      multiple
+      
+      li$nes
+      `,
+      expectedTerm: 'li',
+    },
+  ].forEach(({ text, expectedTerm }) => {
+    it('returns the term right before provided position', () => {
+      // Get the position of the `$` sign in the text, then remove it
+      const position = text.indexOf('$');
+      const textWithoutDollarSign = text.replace('$', '');
+
+      assert.equal(
+        termBeforePosition(textWithoutDollarSign, position),
+        expectedTerm,
+      );
+    });
+  });
+});


### PR DESCRIPTION
This PR adds logic to display a suggestions popover when an `@mention` is typed in the annotations text. The popover is displayed as long as the text right before the caret looks like a mention, and hidden otherwise.

The logic takes the `at_mentions` feature flag into consideration, disabling the logic entirely otherwise.

https://github.com/user-attachments/assets/3b9a8472-8c1a-4151-b752-c6e8ad85e6d7

### Out of scope

This PR only covers the logic to decide when to show/hide the popover, but it does not:

1. Display actual user suggestions in the popover.
2. Calculate the popover position based on where the caret is.

Those will be implemented in follow-up PRs.

### Test steps

1. Go to http://localhost:5000/admin/features and enable `at_mentions`
2. Try to edit/create an annotation.
3. Type an `@mention`. The popover should be displayed under the textarea.
4. Remove the `@mention`. The popover should be closed.

> You can see other combinations in the screen recording above.

### TODO

- [x] Allow popover to be closed via <kbd>Esc</kbd> even if the caret is next to an `@mention`.
- [x] Add tests