### PR TITLE
Populate list of suggestions matching @mentions

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationEditor.tsx
+++ b/src/sidebar/components/Annotation/AnnotationEditor.tsx
@@ -167,6 +167,9 @@ function AnnotationEditor({
 
   const textStyle = applyTheme(['annotationFontFamily'], settings);
 
+  const mentionsEnabled = store.isFeatureEnabled('at_mentions');
+  const usersWhoAnnotated = store.usersWhoAnnotated();
+
   return (
     /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */
     <div
@@ -179,7 +182,8 @@ function AnnotationEditor({
         label={isReplyAnno ? 'Enter reply' : 'Enter comment'}
         text={text}
         onEditText={onEditText}
-        atMentionsEnabled={store.isFeatureEnabled('at_mentions')}
+        mentionsEnabled={mentionsEnabled}
+        usersForMentions={usersWhoAnnotated}
       />
       <TagEditor
         onAddTag={onAddTag}

--- a/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
@@ -62,6 +62,7 @@ describe('AnnotationEditor', () => {
       removeDraft: sinon.stub(),
       removeAnnotations: sinon.stub(),
       isFeatureEnabled: sinon.stub().returns(false),
+      usersWhoAnnotated: sinon.stub().returns([]),
     };
 
     $imports.$mock(mockImportedComponents());

--- a/src/sidebar/components/MentionPopover.tsx
+++ b/src/sidebar/components/MentionPopover.tsx
@@ -1,0 +1,71 @@
+import { Popover } from '@hypothesis/frontend-shared';
+import type { PopoverProps } from '@hypothesis/frontend-shared/lib/components/feedback/Popover';
+import classnames from 'classnames';
+
+export type UserItem = {
+  username: string;
+  displayName: string | null;
+};
+
+export type MentionPopoverProps = Pick<
+  PopoverProps,
+  'open' | 'onClose' | 'anchorElementRef'
+> & {
+  /** List of users to suggest */
+  users: UserItem[];
+  /** Index for currently highlighted suggestion */
+  highlightedSuggestion: number;
+  /** Invoked when a user is selected */
+  onSelectUser: (selectedSuggestion: UserItem) => void;
+};
+
+/**
+ * A Popover component that displays a list of user suggestions for @mentions.
+ */
+export default function MentionPopover({
+  users,
+  onSelectUser,
+  highlightedSuggestion,
+  ...popoverProps
+}: MentionPopoverProps) {
+  return (
+    <Popover {...popoverProps} classes="p-1">
+      <ul
+        className="flex-col gap-y-0.5"
+        role="listbox"
+        aria-orientation="vertical"
+      >
+        {users.map((u, index) => (
+          // These options are indirectly handled via keyboard event
+          // handlers in the textarea, hence, we don't want to add keyboard
+          // event handlers here, but we want to handle click events.
+          // eslint-disable-next-line jsx-a11y/click-events-have-key-events
+          <li
+            key={u.username}
+            className={classnames(
+              'flex justify-between items-center',
+              'rounded p-2 hover:bg-grey-2',
+              {
+                'bg-grey-2': highlightedSuggestion === index,
+              },
+            )}
+            onClick={e => {
+              e.stopPropagation();
+              onSelectUser(u);
+            }}
+            role="option"
+            aria-selected={highlightedSuggestion === index}
+          >
+            <span className="truncate">{u.username}</span>
+            <span className="text-color-text-light">{u.displayName}</span>
+          </li>
+        ))}
+        {users.length === 0 && (
+          <li className="italic p-2" data-testid="suggestions-fallback">
+            No matches. You can still write the username
+          </li>
+        )}
+      </ul>
+    </Popover>
+  );
+}

--- a/src/sidebar/components/test/MentionSuggestionsPopover-test.js
+++ b/src/sidebar/components/test/MentionSuggestionsPopover-test.js
@@ -1,0 +1,82 @@
+import { mount } from '@hypothesis/frontend-testing';
+import { useRef } from 'preact/hooks';
+import sinon from 'sinon';
+
+import MentionPopover from '../MentionPopover';
+
+describe('MentionPopover', () => {
+  const defaultUsers = [
+    { username: 'one', displayName: 'johndoe' },
+    { username: 'two', displayName: 'johndoe' },
+    { username: 'three', displayName: 'johndoe' },
+  ];
+
+  function TestComponent(props) {
+    const anchorRef = useRef();
+    return (
+      <div>
+        <div ref={anchorRef} />
+        <MentionPopover {...props} anchorElementRef={anchorRef} />
+      </div>
+    );
+  }
+
+  function createComponent(props) {
+    return mount(
+      <TestComponent
+        users={defaultUsers}
+        highlightedSuggestion={0}
+        onSelectUser={sinon.stub()}
+        {...props}
+        open
+      />,
+      { connected: true },
+    );
+  }
+
+  function suggestionAt(wrapper, index) {
+    return wrapper.find('[role="option"]').at(index);
+  }
+
+  [
+    { users: [], shouldRenderFallback: true },
+    { users: defaultUsers, shouldRenderFallback: false },
+  ].forEach(({ users, shouldRenderFallback }) => {
+    it('shows fallback message when no users are provided', () => {
+      const wrapper = createComponent({ users });
+      assert.equal(
+        wrapper.exists('[data-testid="suggestions-fallback"]'),
+        shouldRenderFallback,
+      );
+    });
+  });
+
+  [
+    { index: 0, expectedText: 'onejohndoe' },
+    { index: 1, expectedText: 'twojohndoe' },
+    { index: 2, expectedText: 'threejohndoe' },
+  ].forEach(({ index, expectedText }) => {
+    it('shows provided users as a list', () => {
+      const wrapper = createComponent();
+      assert.equal(suggestionAt(wrapper, index).text(), expectedText);
+    });
+  });
+
+  [0, 1, 2].forEach(index => {
+    it('highlights expected suggestion', () => {
+      const wrapper = createComponent({ highlightedSuggestion: index });
+      wrapper.find('[role="option"]').forEach((el, i) => {
+        assert.equal(el.prop('aria-selected'), i === index);
+      });
+    });
+
+    it('applies a suggestion when clicked', () => {
+      const onSelectUser = sinon.stub();
+      const wrapper = createComponent({ onSelectUser });
+
+      suggestionAt(wrapper, index).simulate('click');
+
+      assert.calledWith(onSelectUser, defaultUsers[index]);
+    });
+  });
+});

--- a/src/sidebar/store/modules/test/annotations-test.js
+++ b/src/sidebar/store/modules/test/annotations-test.js
@@ -543,4 +543,54 @@ describe('sidebar/store/modules/annotations', () => {
       });
     });
   });
+
+  describe('usersWhoAnnotated', () => {
+    it('returns expected list of unique and sorted users', () => {
+      const store = createTestStore();
+
+      // Add a few annotations assigned to duplicated unordered users
+      store.addAnnotations([
+        Object.assign(fixtures.defaultAnnotation(), {
+          id: 'a1',
+          user: 'acct:jondoe@hypothes.is',
+        }),
+        Object.assign(fixtures.defaultAnnotation(), {
+          id: 'a2',
+          user: 'acct:jondoe@hypothes.is',
+        }),
+        Object.assign(fixtures.defaultAnnotation(), {
+          id: 'a3',
+          user: 'acct:janedoe@hypothes.is',
+          user_info: {
+            display_name: 'Jane Doe',
+          },
+        }),
+        Object.assign(fixtures.defaultAnnotation(), {
+          id: 'a3',
+          user: 'acct:janedoe@hypothes.is',
+          user_info: {
+            display_name: 'Jane Doe',
+          },
+        }),
+      ]);
+
+      // Only one instance of every user should be returned, and they should be
+      // sorted by username
+      assert.deepEqual(
+        [
+          {
+            user: 'acct:janedoe@hypothes.is',
+            username: 'janedoe',
+            displayName: 'Jane Doe',
+          },
+          {
+            user: 'acct:jondoe@hypothes.is',
+            username: 'jondoe',
+            displayName: null,
+          },
+        ],
+        store.usersWhoAnnotated(),
+      );
+    });
+  });
 });

--- a/src/sidebar/util/term-before-position.ts
+++ b/src/sidebar/util/term-before-position.ts
@@ -1,9 +1,43 @@
 /**
  * Returns the "word" right before a specific position in an input string.
  *
- * In this context, a word is anything between a space or newline, and provided
- * position.
+ * In this context, a word is anything between a space, newline or tab, and
+ * provided position.
  */
 export function termBeforePosition(text: string, position: number): string {
   return text.slice(0, position).match(/\S+$/)?.[0] ?? '';
+}
+
+export type WordOffsets = {
+  start: number;
+  end: number;
+};
+
+/**
+ * Returns the `start` and `end` positions for the word that overlaps with
+ * provided reference position.
+ *
+ * For example, given the text "hello hypothesis", and the reference position 9
+ * (which corresponds to the `p` character) it will return the start and end of
+ * the word `hypothesis`, hence { start: 6, end: 16 }.
+ *
+ * Useful to get the offsets of the word matching the caret position in text
+ * inputs and textareas.
+ */
+export function getContainingWordOffsets(
+  text: string,
+  referencePosition: number,
+): WordOffsets {
+  const precedingEmptyCharPos = text
+    .slice(0, referencePosition)
+    .search(/\s\S*$/);
+  const subsequentEmptyCharPos = text.slice(referencePosition).search(/\s/);
+
+  return {
+    start: (precedingEmptyCharPos === -1 ? -1 : precedingEmptyCharPos) + 1,
+    end:
+      subsequentEmptyCharPos === -1
+        ? text.length
+        : referencePosition + subsequentEmptyCharPos,
+  };
 }

--- a/src/sidebar/util/test/term-before-position-test.js
+++ b/src/sidebar/util/test/term-before-position-test.js
@@ -1,4 +1,7 @@
-import { termBeforePosition } from '../term-before-position';
+import {
+  getContainingWordOffsets,
+  termBeforePosition,
+} from '../term-before-position';
 
 describe('term-before-position', () => {
   // To make these tests more predictable, we place the `$` sign in the position
@@ -10,26 +13,31 @@ describe('term-before-position', () => {
     {
       text: '$Hello world',
       expectedTerm: '',
+      expectedOffsets: { start: 0, end: 5 },
     },
     {
       text: 'Hello world$',
       expectedTerm: 'world',
+      expectedOffsets: { start: 6, end: 11 },
     },
 
     // Position in the middle of words
     {
       text: 'Hell$o world',
       expectedTerm: 'Hell',
+      expectedOffsets: { start: 0, end: 5 },
     },
     {
       text: 'Hello wor$ld',
       expectedTerm: 'wor',
+      expectedOffsets: { start: 6, end: 11 },
     },
 
     // Position preceded by "empty space"
     {
       text: 'Hello $world',
       expectedTerm: '',
+      expectedOffsets: { start: 6, end: 11 },
     },
     {
       text: `Text with
@@ -38,34 +46,44 @@ describe('term-before-position', () => {
       lines
       `,
       expectedTerm: '',
+      expectedOffsets: { start: 31, end: 31 },
     },
 
     // Position preceded by/in the middle of a word for multi-line text
     {
       text: `Text with$
       multiple
-      
+
       lines
       `,
       expectedTerm: 'with',
+      expectedOffsets: { start: 5, end: 9 },
     },
     {
       text: `Text with
       multiple
-      
+
       li$nes
       `,
       expectedTerm: 'li',
+      expectedOffsets: { start: 32, end: 37 },
     },
-  ].forEach(({ text, expectedTerm }) => {
-    it('returns the term right before provided position', () => {
-      // Get the position of the `$` sign in the text, then remove it
-      const position = text.indexOf('$');
-      const textWithoutDollarSign = text.replace('$', '');
+  ].forEach(({ text, expectedTerm, expectedOffsets }) => {
+    // Get the position of the `$` sign in the text, then remove it
+    const position = text.indexOf('$');
+    const textWithoutDollarSign = text.replace('$', '');
 
+    it('`termBeforePosition` returns the term right before provided position', () => {
       assert.equal(
         termBeforePosition(textWithoutDollarSign, position),
         expectedTerm,
+      );
+    });
+
+    it('`getContainingWordOffsets` returns expected offsets', () => {
+      assert.deepEqual(
+        getContainingWordOffsets(textWithoutDollarSign, position),
+        expectedOffsets,
       );
     });
   });


### PR DESCRIPTION
Depends on https://github.com/hypothesis/client/pull/6727

Make the list of suggestions displayed when typing `@mentions` include matching users from those who already annotated the document and belong to the active group.

The list is sorted by username and capped at 10 items.

https://github.com/user-attachments/assets/3cdfaa5d-c5d3-4ff5-ad66-95b101f121cc

### Implementation decisions

The component needs to dynamically build a list of suggestions from the list of user that already annotated.

That list of users can be built from the list of annotations in the sidebar store. Since we had to fetch the annotations from the store somewhere, I decided to implement the list of users as a selector for the annotations store module.

It doesn't need to be accessed in many places, so it could have been a helper function on its own, but since the annotations had to be fetched from the store, it was convenient to do it this way.

### Out of scope

There are many accessibility implications regarding the suggestions popover. This PR includes a couple of those, but I will dedicate a follow-up piece of work to address that properly and do a bit of extra investigation on how others handle it.

~On top of that, I've found a small issue on the `Popover` component when it drops-up. If the contents change while it's open, causing it to get smaller, the position is not recalculated, so it ends up looking disconnected from its anchor element (the textarea in this case).~ This should be addressed by https://github.com/hypothesis/frontend-shared/pull/1855

### Test steps

1. Go to http://localhost:5000/admin/features and enable the `at_mentions` feature flag.
2. Annotate with a few different users.
3. Reload the page.
4. Then while creating/editing an annotation, you should see the suggestions popover display users matching the mention.
5. When you select one via arrow key + Enter or click, it should be applied in the right position.

### Todo

- [x] Arrow key navigation while keeping textarea focused
- [x] Select on <kbd>Enter</kbd> press while keeping textarea focused
- [x] Select on click, then focus textarea
- [x] Style items 
- [x] Add tests
- [x] Apply the mention appropriately, taking into consideration there could be other mentions already.
- [x] Preserve caret position when applying a mention