### PR TITLE
Add @mocha/types to improve IDE intellisense in test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@types/dompurify": "^3.0.0",
     "@types/escape-html": "^1.0.1",
     "@types/katex": "^0.16.0",
+    "@types/mocha": "^10.0.10",
     "@types/retry": "^0.12.1",
     "@types/scroll-into-view": "^1.16.0",
     "@types/shallowequal": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4310,6 +4310,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/mocha@npm:^10.0.10":
+  version: 10.0.10
+  resolution: "@types/mocha@npm:10.0.10"
+  checksum: 17a56add60a8cc8362d3c62cb6798be3f89f4b6ccd5b9abd12b46e31ff299be21ff2faebf5993de7e0099559f58ca5a3b49a505d302dfa5d65c5a4edfc089195
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:*":
   version: 14.14.43
   resolution: "@types/node@npm:14.14.43"
@@ -8516,6 +8523,7 @@ __metadata:
     "@types/dompurify": ^3.0.0
     "@types/escape-html": ^1.0.1
     "@types/katex": ^0.16.0
+    "@types/mocha": ^10.0.10
     "@types/retry": ^0.12.1
     "@types/scroll-into-view": ^1.16.0
     "@types/shallowequal": ^1.1.1


### PR DESCRIPTION
This PR adds the `@types/mocha` package as a dev dependency, to improve IDE instellisense/autocompletion around mocha global symbols (`describe`, `it`, `beforeEach`, etc).

We don't type-check our test files, so this won't help actually catching incorrect usage of those symbols, it's just an affordance for editors.

This is how it looks in WebStorm without the package installed:

https://github.com/user-attachments/assets/b1436a57-0457-44fa-b95f-5a7f2b061372

And this is with the package:

https://github.com/user-attachments/assets/cf5bd049-c4b2-4d6e-bdd5-6d11e9dc8c6d