### PR TITLE
Ensure mentions suggestions are displayed when clicking textarea

### DIFF
--- a/src/sidebar/components/MarkdownEditor.tsx
+++ b/src/sidebar/components/MarkdownEditor.tsx
@@ -203,25 +203,26 @@ function TextArea({
 
     const textarea = textareaRef.current!;
     const listenerCollection = new ListenerCollection();
+    const checkForMentionAtCaret = () => {
+      const term = termBeforePosition(textarea.value, textarea.selectionStart);
+      setPopoverOpen(term.startsWith('@'));
+    };
 
     // We listen for `keyup` to make sure the text in the textarea reflects the
     // just-pressed key when we evaluate it
     listenerCollection.add(textarea, 'keyup', e => {
       // `Esc` key is used to close the popover. Do nothing and let users close
       // it that way, even if the caret is in a mention
-      if (e.key === 'Escape') {
-        return;
+      if (e.key !== 'Escape') {
+        checkForMentionAtCaret();
       }
-      setPopoverOpen(
-        termBeforePosition(textarea.value, textarea.selectionStart).startsWith(
-          '@',
-        ),
-      );
     });
 
-    return () => {
-      listenerCollection.removeAll();
-    };
+    // When clicking the textarea it's possible the caret is moved "into" a
+    // mention, so we check if the popover should be opened
+    listenerCollection.add(textarea, 'click', checkForMentionAtCaret);
+
+    return () => listenerCollection.removeAll();
   }, [atMentionsEnabled, popoverOpen, textareaRef]);
 
   return (

--- a/src/sidebar/components/test/MarkdownEditor-test.js
+++ b/src/sidebar/components/test/MarkdownEditor-test.js
@@ -438,7 +438,6 @@ describe('MarkdownEditor', () => {
         text,
         atMentionsEnabled: true,
       });
-
       const textarea = wrapper.find('textarea');
       const textareaDOMNode = textarea.getDOMNode();
 
@@ -471,6 +470,26 @@ describe('MarkdownEditor', () => {
       // Popover is still closed if the key is `Escape`
       typeInTextarea(wrapper, '@johndoe', 'Escape');
       assert.isFalse(wrapper.find('Popover').prop('open'));
+    });
+
+    it('opens popover when clicking textarea and moving the caret to a mention', () => {
+      const text = 'text @johndoe more text';
+      const wrapper = createConnectedComponent({
+        text,
+        atMentionsEnabled: true,
+      });
+      const textarea = wrapper.find('textarea');
+      const textareaDOMNode = textarea.getDOMNode();
+
+      // Popover is initially closed
+      assert.isFalse(wrapper.find('Popover').prop('open'));
+
+      // Move cursor to overlap with the mention
+      textareaDOMNode.selectionStart = text.indexOf('@') + 1;
+      act(() => textareaDOMNode.dispatchEvent(new MouseEvent('click')));
+      wrapper.update();
+
+      assert.isTrue(wrapper.find('Popover').prop('open'));
     });
   });
 


### PR DESCRIPTION
This PR ensures the mention suggestions popover is displayed if clicking the textarea causes the caret to move "into" an at-mention.

Previously this was checked only when the caret's position changed as a result of pressing a key.

Before:

https://github.com/user-attachments/assets/c322fa4a-bec5-4a41-8832-3d0565dd898e

After:

https://github.com/user-attachments/assets/33c06e91-cf47-4763-a887-ba0700f455d5

### Implementation rational

At first I tried to address this by listening to `selectionchange` event as suggested in [this comment](https://github.com/hypothesis/client/pull/6727#discussion_r1890129498), however, it had some problems:

1. Pressing <kbd>Backsace</kbd> does not trigger that event, so we still needed a `keyup` listener just for that particular key.
2. The popover has its own listeners to close it on clickaway. I didn't fully debug why, but using `selectionchange` caused the popover to be closed and then immediately open again.

That's why I ended up leaving the existing `keyup` listener in combination with `click`.
