### PR TITLE
Use different MenuItem props for plain text and rich text labels

### DIFF
--- a/src/sidebar/components/GroupList/GroupListItem.tsx
+++ b/src/sidebar/components/GroupList/GroupListItem.tsx
@@ -127,7 +127,8 @@ function GroupListItem({
       isExpanded={hasActionMenu ? isExpanded : false}
       isSelected={isSelected}
       isSubmenuVisible={hasActionMenu ? isExpanded : undefined}
-      label={
+      label={group.name}
+      richLabel={
         <div className="grow flex items-center justify-between gap-x-2">
           {group.name}
           <GroupIcon type={group.type} />

--- a/src/sidebar/components/MenuItem.tsx
+++ b/src/sidebar/components/MenuItem.tsx
@@ -101,7 +101,17 @@ export type MenuItemProps = {
    */
   isSubmenuVisible?: boolean;
 
-  label: ComponentChildren;
+  /**
+   * Main text of the menu item.
+   * This is also used as part of the submenu toggle's title, if any.
+   */
+  label: string;
+
+  /**
+   * An alternative to `label`, in case you need to render more complex/rich
+   * content in this item.
+   */
+  richLabel?: ComponentChildren;
 
   /**
    * Optional content to render into a left channel. This accommodates small
@@ -146,6 +156,7 @@ export default function MenuItem({
   isSubmenuItem,
   isSubmenuVisible,
   label,
+  richLabel = label,
   leftChannelContent,
   onClick,
   onToggleSubmenu,
@@ -214,7 +225,7 @@ export default function MenuItem({
         </div>
       )}
       <span className="flex items-center grow whitespace-nowrap px-1">
-        {label}
+        {richLabel}
       </span>
       {hasRightContent && (
         <div


### PR DESCRIPTION
This is an attempt to fix https://github.com/hypothesis/client/issues/6740.

The issue described there was caused when the `label` prop was changed from `string` to `ComponentChildren` in https://github.com/hypothesis/client/pull/6667.

The `label` prop is used used for both the menu content and the submenu toggle button title, and it was changed to `ComponentChildren` so that a new icon could be added without breaking the existing icon logic. However, for the toggle title it needs to be a string.

The solution proposed here involves adding a new optional `richLabel` prop, with type `ComponentChildren`, and make `label` be `string`.

If `richLabel` is not provided, `label` is used everywhere, as before #6667 was merged, but if it is provided, then it is used for the menu content, while `label` is still used for the toggle title.

### Drawbacks

This solution is not perfect, as it requires leaking some internal details (the fact that `label` is used as a title, and therefore it needs to be a string). Furthermore, if both `richLabel` and `label` are provided for a menu item without a submenu, the `label` is not even used, but it's required, which is confusing.

However, this was the simplest solution, considering MenuItem's props API is relatively complex.

### Alternatives

Some other alternatives I considered are:

* Use `react-render-to-string` or some other way to stringify the `label` prop, so that we can "extract" the part we need from it for the title, while we keep it as `ComponentChildren`. However, this seemed hacky, and there's no way to know what's going to be the structure, so it's also a bit brittle.
    Ultimately, it was hard to remove html tags when stringifying, so I discarded this approach.
* Change the MenuItem props so that the problem originally solved by https://github.com/hypothesis/client/pull/6667 could be solved differently. I thought it would be ok to add an optional `icon` prop and keep `label` as `string`, but then I realized that prop already exists.
    Then I thought we could maybe deprecate `icon` and replace it with `leftIcon` and `rightIcon`, but then I realized the `icon` conditionally renders on the left side for top-level menu items, and on the right side when they are part of a submenu, so this would also be quite convoluted to achieve.