### PR TITLE
Allow custom toggle title to be passed to MenuItems

### DIFF
--- a/src/sidebar/components/GroupList/GroupListItem.tsx
+++ b/src/sidebar/components/GroupList/GroupListItem.tsx
@@ -136,6 +136,7 @@ function GroupListItem({
       leftChannelContent={leftChannelContent}
       onClick={isSelectable ? focusGroup : toggleSubmenu}
       onToggleSubmenu={toggleSubmenu}
+      submenuToggleTitle={`Show actions for ${group.name}`}
       submenu={
         <>
           <ul>

--- a/src/sidebar/components/MenuItem.tsx
+++ b/src/sidebar/components/MenuItem.tsx
@@ -112,6 +112,7 @@ export type MenuItemProps = {
 
   onClick?: (e: Event) => void;
   onToggleSubmenu?: (e: Event) => void;
+
   /**
    * Contents of the submenu for this item.  This is typically a list of
    * `MenuItem` components with the `isSubmenuItem` prop set to `true`, but can
@@ -119,6 +120,12 @@ export type MenuItemProps = {
    * `isSubmenuVisible` is `true`.
    */
   submenu?: ComponentChildren;
+
+  /**
+   * Custom title for the submenu toggle button.
+   * Omit this prop if there is no submenu.
+   */
+  submenuToggleTitle?: string;
 };
 
 /**
@@ -150,6 +157,7 @@ export default function MenuItem({
   onClick,
   onToggleSubmenu,
   submenu,
+  submenuToggleTitle,
 }: MenuItemProps) {
   const menuItemRef = useRef<HTMLAnchorElement | HTMLDivElement | null>(null);
 
@@ -226,7 +234,12 @@ export default function MenuItem({
       )}
       {hasSubmenuVisible && (
         <SubmenuToggle
-          title={`Show actions for ${label}`}
+          title={
+            submenuToggleTitle ??
+            (typeof label === 'string'
+              ? `Show actions for ${label}`
+              : `Toggle submenu`)
+          }
           isExpanded={isSubmenuVisible}
           onToggleSubmenu={onToggleSubmenu}
         />

--- a/src/sidebar/components/test/MenuItem-test.js
+++ b/src/sidebar/components/test/MenuItem-test.js
@@ -267,6 +267,35 @@ describe('MenuItem', () => {
       }
       // no assert needed
     });
+
+    [
+      {
+        label: 'The label',
+        submenuToggleTitle: 'Explicit title',
+        expectedTitle: 'Explicit title',
+      },
+      {
+        label: <span>Rich label</span>,
+        submenuToggleTitle: 'Explicit title',
+        expectedTitle: 'Explicit title',
+      },
+      { label: 'The label', expectedTitle: 'Show actions for The label' },
+      { label: <span>Rich label</span>, expectedTitle: 'Toggle submenu' },
+    ].forEach(({ label, submenuToggleTitle, expectedTitle }) => {
+      it('shows right title in SubmenuToggle', () => {
+        const wrapper = createMenuItem({
+          label,
+          submenuToggleTitle,
+          isSubmenuVisible: true,
+          submenu: <div role="menuitem">Submenu content</div>,
+        });
+
+        assert.equal(
+          wrapper.find('SubmenuToggle').prop('title'),
+          expectedTitle,
+        );
+      });
+    });
   });
 
   it(


### PR DESCRIPTION
Another attempt at fixing https://github.com/hypothesis/client/issues/6740.

As opposed to https://github.com/hypothesis/client/pull/6752, this PR keep MenuItem's `label` as `ComponentChildren`, but adds a new optional `submenuToggleTitle` string prop which is used as the submenu toggle title, if there's a submenu at all.

For backwards compatibility, if this prop is not provided, we still try to infer the title by templating `` `Show actions for ${label}` ``, but only if `label` is a string, to avoid the bug that we are trying to fix to still happen accidentally.

> Closes https://github.com/hypothesis/client/issues/6740