### PR TITLE
Add rounded borders to moderation banner

### DIFF
--- a/src/sidebar/components/ModerationBanner.tsx
+++ b/src/sidebar/components/ModerationBanner.tsx
@@ -68,6 +68,8 @@ function ModerationBanner({
     <div
       className={classnames(
         'flex gap-x-3 bg-grey-1 text-color-text font-semibold',
+        // Match the card's border radius and hide overflow
+        'rounded-t-lg overflow-hidden',
         // FIXME: Refactor margins: where possible manage them in a parent
         'mb-2 ',
         {


### PR DESCRIPTION
When rounded corners were implemented some time ago, we forgot to apply them to the moderation banner, making it look like this:

![image](https://github.com/user-attachments/assets/0a9eccfe-59a6-4b09-923a-5a2bd8650bf8)

This PR adds roundness to the top corners, matching the one in the card:

![image](https://github.com/user-attachments/assets/0ee8e833-4849-4bbe-a2d9-ca2db739878e)