### PR TITLE
Add logic to load focused group members

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationEditor.tsx
+++ b/src/sidebar/components/Annotation/AnnotationEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'preact/hooks';
+import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
 
 import type { Annotation } from '../../../types/api';
 import type { SidebarSettings } from '../../../types/config';
@@ -11,6 +11,7 @@ import {
 import { applyTheme } from '../../helpers/theme';
 import { withServices } from '../../service-context';
 import type { AnnotationsService } from '../../services/annotations';
+import type { GroupsService } from '../../services/groups';
 import type { TagsService } from '../../services/tags';
 import type { ToastMessengerService } from '../../services/toast-messenger';
 import { useSidebarStore } from '../../store';
@@ -28,6 +29,7 @@ type AnnotationEditorProps = {
 
   // Injected
   annotationsService: AnnotationsService;
+  groups: GroupsService;
   settings: SidebarSettings;
   toastMessenger: ToastMessengerService;
   tags: TagsService;
@@ -40,6 +42,7 @@ function AnnotationEditor({
   annotation,
   draft,
   annotationsService,
+  groups: groupsService,
   settings,
   tags: tagsService,
   toastMessenger,
@@ -174,6 +177,15 @@ function AnnotationEditor({
 
   const mentionsEnabled = store.isFeatureEnabled('at_mentions');
   const usersWhoAnnotated = store.usersWhoAnnotated();
+  const focusedGroupMembers = store.getFocusedGroupMembers();
+  const focusedGroupId = store.focusedGroupId();
+
+  useEffect(() => {
+    // Load members for focused group only if not yet loaded
+    if (mentionsEnabled && focusedGroupId && focusedGroupMembers === null) {
+      groupsService.loadFocusedGroupMembers(focusedGroupId);
+    }
+  }, [focusedGroupId, focusedGroupMembers, groupsService, mentionsEnabled]);
 
   return (
     /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */
@@ -214,6 +226,7 @@ function AnnotationEditor({
 
 export default withServices(AnnotationEditor, [
   'annotationsService',
+  'groups',
   'settings',
   'tags',
   'toastMessenger',

--- a/src/sidebar/services/api.ts
+++ b/src/sidebar/services/api.ts
@@ -4,6 +4,7 @@ import type {
   RouteMap,
   RouteMetadata,
   Profile,
+  GroupMembers,
 } from '../../types/api';
 import { stripInternalProperties } from '../helpers/strip-internal-properties';
 import type { SidebarStore } from '../store';
@@ -218,6 +219,17 @@ export class APIService {
     member: {
       delete: APICall<{ pubid: string; userid: string }>;
     };
+    members: {
+      read: APICall<
+        {
+          pubid: string;
+          'page[number]'?: number;
+          'page[size]'?: number;
+        },
+        void,
+        GroupMembers
+      >;
+    };
     read: APICall<{ id: string; expand: string[] }, void, Group>;
   };
   groups: {
@@ -286,6 +298,17 @@ export class APIService {
           pubid: string;
           userid: string;
         }>,
+      },
+      members: {
+        read: apiCall('group.members.read') as APICall<
+          {
+            pubid: string;
+            'page[number]'?: number;
+            'page[size]'?: number;
+          },
+          void,
+          GroupMembers
+        >,
       },
       read: apiCall('group.read') as APICall<
         { id: string; expand: string[] },

--- a/src/sidebar/services/test/api-index.json
+++ b/src/sidebar/services/test/api-index.json
@@ -30,6 +30,13 @@
           "desc": "Remove the current user from a group."
         }
       },
+      "members": {
+        "read": {
+          "url": "https://example.com/api/groups/:pubid/members",
+          "method": "GET",
+          "desc": "Fetch a list of all members of a group"
+        }
+      },
       "read": {
         "url": "https://example.com/api/groups/:id",
         "method": "GET",

--- a/src/sidebar/services/test/api-test.js
+++ b/src/sidebar/services/test/api-test.js
@@ -124,6 +124,26 @@ describe('APIService', () => {
     return api.group.member.delete({ pubid: 'an-id', userid: 'me' });
   });
 
+  it('gets group members', () => {
+    const groupMembers = {
+      meta: {
+        page: { total: 0 },
+      },
+      data: [],
+    };
+    expectCall(
+      'get',
+      `groups/an-id/members?${encodeURIComponent('page[number]')}=1&${encodeURIComponent('page[size]')}=100`,
+      200,
+      groupMembers,
+    );
+    return api.group.members.read({
+      pubid: 'an-id',
+      'page[number]': 1,
+      'page[size]': 100,
+    });
+  });
+
   it('gets a group by provided group id', () => {
     const group = { id: 'group-id', name: 'Group' };
     expectCall('get', 'groups/group-id', 200, group);

--- a/src/sidebar/store/modules/test/groups-test.js
+++ b/src/sidebar/store/modules/test/groups-test.js
@@ -134,6 +134,33 @@ describe('sidebar/store/modules/groups', () => {
       assert.notCalled(console.error);
     });
 
+    it('unsets the focused group members if valid', () => {
+      store.loadGroups([publicGroup, privateGroup]);
+
+      // We need to initially focus a group so that we can set its members
+      store.focusGroup(publicGroup.id);
+      store.loadFocusedGroupMembers([]);
+      assert.isNotNull(store.getState().groups.focusedGroupMembers);
+
+      // Once we switch to focus another group, members are unset
+      store.focusGroup(privateGroup.id);
+      assert.isNull(store.getState().groups.focusedGroupMembers);
+    });
+
+    it('does not update focused group members if focused group is the same', () => {
+      store.loadGroups([publicGroup, privateGroup]);
+
+      store.focusGroup(publicGroup.id);
+      store.loadFocusedGroupMembers([]);
+      const prevMembers = store.getState().groups.focusedGroupMembers;
+
+      store.focusGroup(publicGroup.id);
+      assert.deepEqual(
+        store.getState().groups.focusedGroupMembers,
+        prevMembers,
+      );
+    });
+
     it('does not update focused group if not valid', () => {
       store.loadGroups([publicGroup]);
 
@@ -164,6 +191,23 @@ describe('sidebar/store/modules/groups', () => {
       store.loadGroups([publicGroup, privateGroup]);
 
       assert.equal(store.getState().groups.focusedGroupId, publicGroup.id);
+    });
+  });
+
+  describe('loadFocusedGroupMembers', () => {
+    it('throws if trying to set group members before focusing a group', () => {
+      assert.throws(
+        () => store.loadFocusedGroupMembers([]),
+        'A group needs to be focused before loading its members',
+      );
+    });
+
+    it('sets group members', () => {
+      store.loadGroups([privateGroup]);
+      store.focusGroup(privateGroup.id);
+      store.loadFocusedGroupMembers([]);
+
+      assert.deepEqual(store.getState().groups.focusedGroupMembers, []);
     });
   });
 
@@ -243,6 +287,20 @@ describe('sidebar/store/modules/groups', () => {
       store.loadGroups([privateGroup]);
       store.focusGroup(privateGroup.id);
       assert.equal(store.focusedGroupId(), privateGroup.id);
+    });
+  });
+
+  describe('getFocusedGroupMembers', () => {
+    it('returns `null` if no group members have been loaded', () => {
+      assert.equal(store.getFocusedGroupMembers(), null);
+    });
+
+    it('returns list of members if they have been loaded', () => {
+      store.loadGroups([privateGroup]);
+      store.focusGroup(privateGroup.id);
+      store.loadFocusedGroupMembers([]);
+
+      assert.deepEqual(store.getFocusedGroupMembers(), []);
     });
   });
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -295,6 +295,34 @@ export type Group = {
 export type GroupIdentifier = NonNullable<Group['id'] | Group['groupid']>;
 
 /**
+ * Generic type for endpoints that return paginated lists of items.
+ */
+export type PaginatedResponse<Item> = {
+  meta: {
+    page: {
+      total: number;
+    };
+  };
+  data: Item[];
+};
+
+export type GroupMember = {
+  authority: string;
+  userid: string;
+  username: string;
+  display_name: string | null;
+  roles: string[];
+  actions: string[];
+  created: string;
+  updated: string;
+};
+
+/**
+ * Response to a GET /api/groups/{id}/members api call
+ */
+export type GroupMembers = PaginatedResponse<GroupMember>;
+
+/**
  * Query parameters for an `/api/search` API call.
  *
  * This type currently includes params that we've actually used.


### PR DESCRIPTION
Implement logic to call [members API](https://h.readthedocs.io/en/latest/api-reference/v1/#tag/memberships/paths/~1groups~1{id}~1members/get) for focused group, and load all its members in the store.

The loaded members are not used yet. They will be used in a follow-up PR to improve the `@mentions` suggestions.

Members loading is deferred until an annotation is created/edited for the first time after a group is focused, assuming they are not needed before that.

In future, if we decide to use group members for some different purpose, we may need to move the loading to a different point in the user journey.

### Considerations

The group members API is paginated, so we load members in batches. This has some implications:

1. We have to set a maximum number of calls, to avoid shooting ourselves in the foot. I randomly choose a maximum amount of 10 pages, with 100 members loaded per page.
    I'll try to [check some real numbers](https://github.com/orgs/hypothesis/projects/153/views/1?pane=issue&itemId=95315302) of groups in production, to adjust this based on that.
2. Membership calls are currently done sequentially. We first load the first page to see what's the total amount of members, then one call at a time until all are loaded or the limit mentioned above is reached.
    We could probably parallelize these calls, loading 3 or 4 pages at a time. I'll explore this option separately, once I have the numbers.
3. Due to how pagination works in membership API (page number + size instead of cursor), if a user is removed/added while the loading is in progress, we could end up with an incorrect dataset, where some user is missing or duplicated.

### Test steps

1. Check out this branch
2. Enable `at_mentions` feature in http://localhost:5000/admin/features
3. Open the browser console, in the network tab.
4. Open the sidebar and try to create/edit an annotation. You should see a request in the network tab, to load members for currently focused group.
5. Try to create/edit a different annotation. There should be no new requests for currently focused group.
6. Changed focused group. Steps 4 and 5 should work again as described.
7. Change focused group while the annotation editor is open. It should load the group members immediately every time.

### TODO

- [x] Abort loading members when focused group changes before finishing previous load.