### PR TITLE
Add proper accessibility attributes for at-mentions

### DIFF
--- a/src/sidebar/components/MarkdownEditor.tsx
+++ b/src/sidebar/components/MarkdownEditor.tsx
@@ -22,6 +22,7 @@ import type { Ref, JSX } from 'preact';
 import {
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -280,6 +281,29 @@ function TextArea({
     [onEditText, textareaRef],
   );
 
+  const usersListboxId = useId();
+  const accessibilityAttributes = useMemo((): JSX.TextareaHTMLAttributes => {
+    if (!popoverOpen) {
+      return {};
+    }
+
+    const selectedSuggestion = userSuggestions[highlightedSuggestion];
+    const activeDescendant = selectedSuggestion
+      ? `${usersListboxId}-${selectedSuggestion.username}`
+      : undefined;
+
+    return {
+      // These attributes follow the MDN instructions for aria-autocomplete
+      // See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-autocomplete
+      role: 'combobox',
+      'aria-controls': usersListboxId,
+      'aria-expanded': true,
+      'aria-autocomplete': 'list',
+      'aria-haspopup': 'listbox',
+      'aria-activedescendant': activeDescendant,
+    };
+  }, [highlightedSuggestion, usersListboxId, popoverOpen, userSuggestions]);
+
   return (
     <div className="relative">
       <textarea
@@ -332,6 +356,7 @@ function TextArea({
           checkForMentionAtCaret(e.target as HTMLTextAreaElement);
         }}
         ref={textareaRef}
+        {...accessibilityAttributes}
       />
       {mentionsEnabled && (
         <MentionPopover
@@ -341,6 +366,7 @@ function TextArea({
           users={userSuggestions}
           highlightedSuggestion={highlightedSuggestion}
           onSelectUser={insertMention}
+          usersListboxId={usersListboxId}
         />
       )}
     </div>

--- a/src/sidebar/components/MentionPopover.tsx
+++ b/src/sidebar/components/MentionPopover.tsx
@@ -17,6 +17,8 @@ export type MentionPopoverProps = Pick<
   highlightedSuggestion: number;
   /** Invoked when a user is selected */
   onSelectUser: (selectedSuggestion: UserItem) => void;
+  /** Element ID for the user suggestions listbox */
+  usersListboxId: string;
 };
 
 /**
@@ -26,6 +28,7 @@ export default function MentionPopover({
   users,
   onSelectUser,
   highlightedSuggestion,
+  usersListboxId,
   ...popoverProps
 }: MentionPopoverProps) {
   return (
@@ -34,6 +37,7 @@ export default function MentionPopover({
         className="flex-col gap-y-0.5"
         role="listbox"
         aria-orientation="vertical"
+        id={usersListboxId}
       >
         {users.map((u, index) => (
           // These options are indirectly handled via keyboard event
@@ -42,6 +46,7 @@ export default function MentionPopover({
           // eslint-disable-next-line jsx-a11y/click-events-have-key-events
           <li
             key={u.username}
+            id={`${usersListboxId}-${u.username}`}
             className={classnames(
               'flex justify-between items-center',
               'rounded p-2 hover:bg-grey-2',

--- a/src/sidebar/components/test/MarkdownEditor-test.js
+++ b/src/sidebar/components/test/MarkdownEditor-test.js
@@ -61,6 +61,16 @@ describe('MarkdownEditor', () => {
     );
   }
 
+  function typeInTextarea(wrapper, text, key = undefined) {
+    const textarea = wrapper.find('textarea');
+    const textareaDOMNode = textarea.getDOMNode();
+
+    textareaDOMNode.value = text;
+    textareaDOMNode.selectionStart = text.length;
+
+    textarea.simulate('keyup', { key });
+  }
+
   const commands = [
     {
       command: 'Bold',
@@ -380,18 +390,6 @@ describe('MarkdownEditor', () => {
   });
 
   context('when @mentions are enabled', () => {
-    function typeInTextarea(wrapper, text, key = undefined) {
-      const textarea = wrapper.find('textarea');
-      const textareaDOMNode = textarea.getDOMNode();
-
-      textareaDOMNode.value = text;
-      textareaDOMNode.selectionStart = text.length;
-      act(() =>
-        textareaDOMNode.dispatchEvent(new KeyboardEvent('keyup', { key })),
-      );
-      wrapper.update();
-    }
-
     function keyDownInTextarea(wrapper, key) {
       const textarea = wrapper.find('textarea');
       textarea.simulate('keydown', { key });
@@ -637,6 +635,31 @@ describe('MarkdownEditor', () => {
             .find('button')
             .filterWhere(el => el.text() === 'Preview');
           previewButton.simulate('click');
+
+          return wrapper;
+        },
+      },
+      {
+        name: 'Suggestions popover',
+        content: () => {
+          $imports.$restore({
+            // We need to render MentionPopover, as some aria attributes
+            // reference elements rendered by it
+            './MentionPopover': true,
+          });
+
+          const wrapper = createComponent(
+            {
+              mentionsEnabled: true,
+              usersForMentions: [
+                { username: 'one', displayName: 'johndoe' },
+                { username: 'two', displayName: 'johndoe' },
+                { username: 'three', displayName: 'johndoe' },
+              ],
+            },
+            { connected: true },
+          );
+          typeInTextarea(wrapper, '@johndoe');
 
           return wrapper;
         },


### PR DESCRIPTION
Closes https://github.com/orgs/hypothesis/projects/153/views/1?pane=issue&itemId=94011574

Add required accessibility attributes to annotations textarea when the mentions popover is displayed, so that it implements the [combobox](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/) pattern.

Among other things, these attributes indicate screen readers the textarea controls the suggestions listbox inside the popover, and how many suggestions are there.

The attributes are dynamically added only while the popover is open. This is how GitHub does it for their mentions capability.

### TODO

- [ ] ~Make sure changes in the amount of suggestions are announced by screen readers.~ I have decided not to do this, as only GitHub seems to behave like this. Other services announce the amount of elements only once.