### PR TITLE
Allow an AbortSignal to be passed to api calls

### DIFF
--- a/src/sidebar/services/test/api-test.js
+++ b/src/sidebar/services/test/api-test.js
@@ -354,4 +354,19 @@ describe('APIService', () => {
       assert.equal(error.message, 'Missing API route: profile.read');
     });
   });
+
+  it('passes abort signal to `fetch` if provided', async () => {
+    expectCall('post', 'analytics/events');
+
+    const { signal } = new AbortController();
+
+    await api.analytics.events.create(
+      {},
+      { event: 'client.realtime.apply_updates' },
+      signal,
+    );
+
+    const [, options] = fetchMock.lastCall();
+    assert.equal(options.signal, signal);
+  });
 });


### PR DESCRIPTION
Extend our API abstraction so that we can pass an AbortSignal that is propagated to the `fetch` call. This can be useful to cancel in flight calls if they become irrelevant before finishing.

The first use case for this is [loading group members](https://github.com/hypothesis/client/pull/6756), where not only members could not have finished loading before the focused group changes, but we also load them in batches, which makes it potentially more likely for this to happen.

### Implementation decisions

Our API calls have a signature like `(params: Params, body?: Body) => Promise<Result>`, and I'm adding the abort signal as an optional third parameter `(params: Params, body?: Body, signal?: AbortSignal) => Promise<Result>`.

This has the drawback that we have to pass `undefined` for methods where we want to pass the signal but don't expect a body. For example, `api.group.read({ id, expand: expandParam }, undefined, signal)`.

However, a deeper signature change (perhaps something like `(params: Params, { body?: Body; signal?: AbortSignal } = {}) => Promise<Result>`) would require a bigger refactoring of all existing calls.