### PR TITLE
Add configuration settings to disable help panel, share panel and account menu

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationEditor.tsx
+++ b/src/sidebar/components/Annotation/AnnotationEditor.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from 'preact/hooks';
 
 import type { Annotation } from '../../../types/api';
 import type { SidebarSettings } from '../../../types/config';
+import { serviceConfig } from '../../config/service-config';
 import {
   annotationRole,
   isReply,
@@ -52,6 +53,10 @@ function AnnotationEditor({
 
   const shouldShowLicense =
     !draft.isPrivate && group && group.type !== 'private';
+
+  // When the Help panel is disabled, also hide other help links in the app
+  // which link to external websites.
+  const showHelpLink = serviceConfig(settings)?.enableHelpPanel ?? true;
 
   const tags = draft.tags;
   const text = draft.text;
@@ -184,6 +189,7 @@ function AnnotationEditor({
         onEditText={onEditText}
         mentionsEnabled={mentionsEnabled}
         usersForMentions={usersWhoAnnotated}
+        showHelpLink={showHelpLink}
       />
       <TagEditor
         onAddTag={onAddTag}

--- a/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
@@ -386,6 +386,25 @@ describe('AnnotationEditor', () => {
     assert.isFalse(wrapper.find('AnnotationLicense').exists());
   });
 
+  [true, false].forEach(enableHelpPanel => {
+    it('hides help links if Help panel is disabled', () => {
+      fakeSettings = {
+        services: [
+          {
+            enableHelpPanel,
+          },
+        ],
+      };
+
+      const wrapper = createComponent();
+
+      assert.equal(
+        wrapper.find('MarkdownEditor').prop('showHelpLink'),
+        enableHelpPanel,
+      );
+    });
+  });
+
   it(
     'should pass a11y checks',
     checkAccessibility([

--- a/src/sidebar/components/MarkdownEditor.tsx
+++ b/src/sidebar/components/MarkdownEditor.tsx
@@ -380,6 +380,8 @@ type ToolbarProps = {
   /** Callback invoked when a toolbar button is clicked */
   onCommand: (command: Command) => void;
 
+  showHelpLink: boolean;
+
   /** Callback invoked when the "Preview" toggle button is clicked */
   onTogglePreview: () => void;
 };
@@ -392,7 +394,12 @@ type ToolbarProps = {
  * Canonical example
  * https://www.w3.org/TR/wai-aria-practices/examples/toolbar/toolbar.html
  */
-function Toolbar({ isPreviewing, onCommand, onTogglePreview }: ToolbarProps) {
+function Toolbar({
+  isPreviewing,
+  onCommand,
+  onTogglePreview,
+  showHelpLink,
+}: ToolbarProps) {
   const toolbarContainer = useRef(null);
   useArrowKeyNavigation(toolbarContainer);
 
@@ -468,25 +475,27 @@ function Toolbar({ isPreviewing, onCommand, onTogglePreview }: ToolbarProps) {
         title="Bulleted list"
       />
       <div className="grow flex justify-end">
-        <Link
-          classes="text-grey-7 hover:!text-grey-7"
-          href="https://web.hypothes.is/help/formatting-annotations-with-markdown/"
-          target="_blank"
-          title="Formatting help"
-          aria-label="Formatting help"
-          underline="none"
-          variant="custom"
-        >
-          <div
-            className={classnames(
-              'flex justify-center items-center',
-              'touch:h-touch-minimum touch:w-touch-minimum',
-              'px-2 py-2.5 touch:p-0',
-            )}
+        {showHelpLink && (
+          <Link
+            classes="text-grey-7 hover:!text-grey-7"
+            href="https://web.hypothes.is/help/formatting-annotations-with-markdown/"
+            target="_blank"
+            title="Formatting help"
+            aria-label="Formatting help"
+            underline="none"
+            variant="custom"
           >
-            <HelpIcon className="w-2.5 h-2.5" />
-          </div>
-        </Link>
+            <div
+              className={classnames(
+                'flex justify-center items-center',
+                'touch:h-touch-minimum touch:w-touch-minimum',
+                'px-2 py-2.5 touch:p-0',
+              )}
+            >
+              <HelpIcon className="w-2.5 h-2.5" />
+            </div>
+          </Link>
+        )}
 
         <ToolbarButton
           label={isPreviewing ? 'Write' : 'Preview'}
@@ -515,6 +524,9 @@ export type MarkdownEditorProps = {
 
   onEditText?: (text: string) => void;
 
+  /** Whether to display the formatting help link in the toolbar. */
+  showHelpLink?: boolean;
+
   /**
    * Base list of users used to populate the @mentions suggestions, when
    * `mentionsEnabled` is `true`.
@@ -534,6 +546,7 @@ export default function MarkdownEditor({
   onEditText = () => {},
   text,
   textStyle = {},
+  showHelpLink = true,
   usersForMentions,
 }: MarkdownEditorProps) {
   // Whether the preview mode is currently active.
@@ -577,6 +590,7 @@ export default function MarkdownEditor({
         onCommand={handleCommand}
         isPreviewing={preview}
         onTogglePreview={togglePreview}
+        showHelpLink={showHelpLink}
       />
       {preview ? (
         <MarkdownView

--- a/src/sidebar/components/TopBar.tsx
+++ b/src/sidebar/components/TopBar.tsx
@@ -32,6 +32,26 @@ export type TopBarProps = {
   settings: SidebarSettings;
 };
 
+type ControlName = 'share' | 'account' | 'help';
+
+function controlEnabled(settings: SidebarSettings, name: ControlName) {
+  const config = serviceConfig(settings);
+  if (!config) {
+    return true;
+  }
+  switch (name) {
+    case 'share':
+      return config.enableShareImportExportPanel ?? true;
+    case 'account':
+      return config.enableAccountMenu ?? true;
+    case 'help':
+      return config.enableHelpPanel ?? true;
+    /* istanbul ignore next: unused default */
+    default:
+      return true;
+  }
+}
+
 /**
  * The toolbar which appears at the top of the sidebar providing actions
  * to switch groups, view account information, sort/filter annotations etc.
@@ -94,26 +114,32 @@ function TopBar({
             <>
               <SearchIconButton />
               <SortMenu />
-              <TopBarToggleButton
-                icon={ShareIcon}
-                expanded={isAnnotationsPanelOpen}
-                pressed={isAnnotationsPanelOpen}
-                onClick={toggleSharePanel}
-                title="Share annotations on this page"
-                data-testid="share-icon-button"
-              />
+              {controlEnabled(settings, 'share') && (
+                <TopBarToggleButton
+                  icon={ShareIcon}
+                  expanded={isAnnotationsPanelOpen}
+                  pressed={isAnnotationsPanelOpen}
+                  onClick={toggleSharePanel}
+                  title="Share annotations on this page"
+                  data-testid="share-icon-button"
+                />
+              )}
             </>
           )}
-          <TopBarToggleButton
-            icon={HelpIcon}
-            expanded={isHelpPanelOpen}
-            pressed={isHelpPanelOpen}
-            onClick={requestHelp}
-            title="Help"
-            data-testid="help-icon-button"
-          />
+          {controlEnabled(settings, 'help') && (
+            <TopBarToggleButton
+              icon={HelpIcon}
+              expanded={isHelpPanelOpen}
+              pressed={isHelpPanelOpen}
+              onClick={requestHelp}
+              title="Help"
+              data-testid="help-icon-button"
+            />
+          )}
           {isLoggedIn ? (
-            <UserMenu onLogout={onLogout} />
+            controlEnabled(settings, 'account') && (
+              <UserMenu onLogout={onLogout} />
+            )
           ) : (
             <div
               className="flex items-center text-md font-medium space-x-1 pl-1"

--- a/src/sidebar/components/test/MarkdownEditor-test.js
+++ b/src/sidebar/components/test/MarkdownEditor-test.js
@@ -389,6 +389,14 @@ describe('MarkdownEditor', () => {
     assert.deepEqual(wrapper.find('MarkdownView').prop('style'), textStyle);
   });
 
+  [true, false].forEach(showHelpLink => {
+    it('hides help menu when `showHelpLink` is false', () => {
+      const wrapper = createComponent({ showHelpLink });
+      const helpLink = wrapper.find('Link[aria-label="Formatting help"]');
+      assert.equal(helpLink.exists(), showHelpLink);
+    });
+  });
+
   context('when @mentions are enabled', () => {
     function keyDownInTextarea(wrapper, key) {
       const textarea = wrapper.find('textarea');

--- a/src/sidebar/components/test/TopBar-test.js
+++ b/src/sidebar/components/test/TopBar-test.js
@@ -25,7 +25,7 @@ describe('TopBar', () => {
       notifyHost: sinon.stub(),
     };
 
-    fakeServiceConfig = sinon.stub().returns({});
+    fakeServiceConfig = sinon.stub().returns(null);
 
     fakeStreamer = {
       applyPendingUpdates: sinon.stub(),
@@ -102,6 +102,13 @@ describe('TopBar', () => {
         });
       });
     });
+
+    it('hides Help control if disabled', () => {
+      fakeServiceConfig.returns({ enableHelpPanel: false });
+      const wrapper = createTopBar();
+      const helpButton = getButton(wrapper, 'help-icon-button');
+      assert.isFalse(helpButton.exists());
+    });
   });
 
   describe('login/account actions', () => {
@@ -146,6 +153,18 @@ describe('TopBar', () => {
       assert.isTrue(userMenu.exists());
       assert.include(userMenu.props(), { onLogout });
     });
+
+    it('hides user menu if disabled', () => {
+      fakeStore.hasFetchedProfile.returns(true);
+      fakeStore.isLoggedIn.returns(true);
+      fakeServiceConfig.returns({
+        enableAccountMenu: false,
+      });
+
+      const onLogout = sinon.stub();
+      const wrapper = createTopBar({ onLogout });
+      assert.isFalse(wrapper.exists('UserMenu'));
+    });
   });
 
   context('when using a first-party service', () => {
@@ -153,6 +172,15 @@ describe('TopBar', () => {
       const wrapper = createTopBar();
       assert.isTrue(wrapper.exists('[title="Share annotations on this page"]'));
     });
+  });
+
+  it('hides share menu if disabled', () => {
+    fakeServiceConfig.returns({
+      enableShareImportExportPanel: false,
+    });
+    const wrapper = createTopBar();
+    const shareButton = getButton(wrapper, 'share-icon-button');
+    assert.isFalse(shareButton.exists());
   });
 
   it('toggles the share annotations panel when "Share" is clicked', () => {

--- a/src/sidebar/helpers/session.ts
+++ b/src/sidebar/helpers/session.ts
@@ -24,12 +24,21 @@ export function shouldAutoDisplayTutorial(
   profile: Profile,
   settings: SidebarSettings,
 ): boolean {
+  if (!isSidebar) {
+    return false;
+  }
+
   const shouldShowBasedOnProfile =
     typeof profile.preferences === 'object' &&
     !!profile.preferences.show_sidebar_tutorial;
+  if (!shouldShowBasedOnProfile) {
+    return false;
+  }
 
-  const service = serviceConfig(settings) || { onHelpRequestProvided: false };
-  return (
-    isSidebar && !service.onHelpRequestProvided && shouldShowBasedOnProfile
-  );
+  const config = serviceConfig(settings);
+  if (config?.onHelpRequestProvided || config?.enableHelpPanel === false) {
+    return false;
+  }
+
+  return true;
 }

--- a/src/sidebar/helpers/test/session-test.js
+++ b/src/sidebar/helpers/test/session-test.js
@@ -57,6 +57,19 @@ describe('sidebar/helpers/session', () => {
         settings: { services: [{ onHelpRequestProvided: true }] },
         expected: false,
       },
+      {
+        description: 'help panel is disabled',
+        isSidebar: true,
+        sessionState: {},
+        settings: {
+          services: [
+            {
+              enableHelpPanel: false,
+            },
+          ],
+        },
+        expected: false,
+      },
     ].forEach(fixture => {
       it(`should calculate auto-display to be ${fixture.expected} when ${fixture.description}`, () => {
         const shouldDisplay = sessionUtil.shouldAutoDisplayTutorial(

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -20,9 +20,25 @@ export type Service = {
    * replaced with a promise to represent the result.
    */
   groups?: string[] | Promise<string[]> | '$rpc:requestGroups';
+
+  /** Allow the user to flag annotations for moderation. */
   allowFlagging?: boolean;
+
+  /** Allow the user to leave groups. */
   allowLeavingGroups?: boolean;
+
+  /** Enable share links on annotation cards. */
   enableShareLinks?: boolean;
+
+  /** Enable or disable the Share / Import / Export panel. */
+  enableShareImportExportPanel?: boolean;
+
+  /** Enable or disable user account menu. */
+  enableAccountMenu?: boolean;
+
+  /** Enable or disable the Help / Version panel. */
+  enableHelpPanel?: boolean;
+
   onHelpRequest?: () => void;
   onHelpRequestProvided?: boolean;
   onLoginRequest?: () => void;


### PR DESCRIPTION
Add configuration options for annotation services to hide additional controls:

- `enableHelpPanel` allows hiding the Help panel. This also disables automatic display of the tutorial on first run and removes the Help link in the annotation toolbar.
- `enableShareImportExportPanel` allows hiding the Share menu in the toolbar which contains the Share, Import and Export panels
- `enableAccountMenu` allows hiding the user account menu

With all of these controls disabled, the client looks like this:

<img width="485" alt="controls-disabled" src="https://github.com/user-attachments/assets/7cbfa1dc-390e-44fe-9ffe-ff42f639d0c9" />

Fixes https://github.com/hypothesis/client/issues/6782.

This can be tested with the exam-notes app using https://github.com/hypothesis/exam-notes/pull/23.
