### PR TITLE
Make groups.loadFocusedGroupMembers implicitly load for focused group

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationEditor.tsx
+++ b/src/sidebar/components/Annotation/AnnotationEditor.tsx
@@ -178,14 +178,13 @@ function AnnotationEditor({
   const mentionsEnabled = store.isFeatureEnabled('at_mentions');
   const usersWhoAnnotated = store.usersWhoAnnotated();
   const focusedGroupMembers = store.getFocusedGroupMembers();
-  const focusedGroupId = store.focusedGroupId();
 
   useEffect(() => {
     // Load members for focused group only if not yet loaded
-    if (mentionsEnabled && focusedGroupId && focusedGroupMembers === null) {
-      groupsService.loadFocusedGroupMembers(focusedGroupId);
+    if (mentionsEnabled && focusedGroupMembers === null) {
+      groupsService.loadFocusedGroupMembers();
     }
-  }, [focusedGroupId, focusedGroupMembers, groupsService, mentionsEnabled]);
+  }, [focusedGroupMembers, groupsService, mentionsEnabled]);
 
   return (
     /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */

--- a/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
@@ -70,7 +70,6 @@ describe('AnnotationEditor', () => {
       isFeatureEnabled: sinon.stub().returns(false),
       usersWhoAnnotated: sinon.stub().returns([]),
       getFocusedGroupMembers: sinon.stub(),
-      focusedGroupId: sinon.stub().returns(null),
     };
 
     $imports.$mock(mockImportedComponents());
@@ -416,56 +415,38 @@ describe('AnnotationEditor', () => {
   describe('loading focused group members', () => {
     [
       {
-        atMentionsEnabled: true,
+        mentionsEnabled: true,
         focusedGroupMembers: null,
-        focusedGroupId: 'group_id',
         shouldLoadMembers: true,
       },
       {
-        atMentionsEnabled: true,
+        mentionsEnabled: false,
         focusedGroupMembers: null,
-        focusedGroupId: null,
         shouldLoadMembers: false,
       },
       {
-        atMentionsEnabled: false,
-        focusedGroupMembers: null,
-        focusedGroupId: 'group_id',
-        shouldLoadMembers: false,
-      },
-      {
-        atMentionsEnabled: true,
+        mentionsEnabled: true,
         focusedGroupMembers: [],
-        focusedGroupId: 'group_id',
         shouldLoadMembers: false,
       },
       {
-        atMentionsEnabled: false,
-        focusedGroupMembers: [],
-        focusedGroupId: 'group_id',
+        mentionsEnabled: true,
+        focusedGroupMembers: 'loading',
         shouldLoadMembers: false,
       },
-    ].forEach(
-      ({
-        atMentionsEnabled,
-        focusedGroupMembers,
-        focusedGroupId,
-        shouldLoadMembers,
-      }) => {
-        it('loads focused group members when mounted', () => {
-          fakeStore.isFeatureEnabled.returns(atMentionsEnabled);
-          fakeStore.getFocusedGroupMembers.returns(focusedGroupMembers);
-          fakeStore.focusedGroupId.returns(focusedGroupId);
+    ].forEach(({ mentionsEnabled, focusedGroupMembers, shouldLoadMembers }) => {
+      it('loads focused group members when mounted', () => {
+        fakeStore.isFeatureEnabled.returns(mentionsEnabled);
+        fakeStore.getFocusedGroupMembers.returns(focusedGroupMembers);
 
-          createComponent();
+        createComponent();
 
-          assert.equal(
-            fakeGroupsService.loadFocusedGroupMembers.called,
-            shouldLoadMembers,
-          );
-        });
-      },
-    );
+        assert.equal(
+          fakeGroupsService.loadFocusedGroupMembers.called,
+          shouldLoadMembers,
+        );
+      });
+    });
   });
 
   it(

--- a/src/sidebar/services/groups.ts
+++ b/src/sidebar/services/groups.ts
@@ -492,20 +492,23 @@ export class GroupsService {
   }
 
   /**
-   * Fetch members for a group from the API and load them into the store as the
-   * members of the focused group.
+   * Fetch members for focused group from the API and load them into the store.
    */
-  async loadFocusedGroupMembers(groupId: string): Promise<void> {
+  async loadFocusedGroupMembers(): Promise<void> {
+    const groupId = this._store.focusedGroupId();
+    if (!groupId) {
+      return;
+    }
+
     // Abort previous loading, if any
     this._focusedMembersController?.abort();
 
     this._focusedMembersController = new AbortController();
     const { signal } = this._focusedMembersController;
 
+    this._store.startLoadingFocusedGroupMembers();
     const members = await this._fetchAllMembers(groupId, signal);
-    if (!signal?.aborted) {
-      this._store.loadFocusedGroupMembers(members);
-    }
+    this._store.loadFocusedGroupMembers(signal?.aborted ? null : members);
   }
 
   private async _fetchAllMembers(

--- a/src/sidebar/store/modules/groups.ts
+++ b/src/sidebar/store/modules/groups.ts
@@ -7,6 +7,13 @@ import type { State as SessionState } from './session';
 
 type GroupID = Group['id'];
 
+/**
+ * `null`: Members not yet loaded for currently focused group
+ * 'loading': Members being currently loaded
+ * GroupMember[]: Members already loaded
+ */
+type FocusedGroupMembers = null | 'loading' | GroupMember[];
+
 export type State = {
   /**
    * When there are entries, only `groups` with `id`s included in this list
@@ -20,7 +27,7 @@ export type State = {
   focusedGroupId: string | null;
 
   /** Members of currently selected group */
-  focusedGroupMembers: GroupMember[] | null;
+  focusedGroupMembers: FocusedGroupMembers;
 };
 
 const initialState: State = {
@@ -100,7 +107,7 @@ const reducers = {
 
   LOAD_FOCUSED_GROUP_MEMBERS(
     state: State,
-    action: { focusedGroupMembers: GroupMember[] },
+    action: { focusedGroupMembers: FocusedGroupMembers },
   ) {
     if (!state.focusedGroupId) {
       throw new Error('A group needs to be focused before loading its members');
@@ -146,9 +153,18 @@ function loadGroups(groups: Group[]) {
 }
 
 /**
+ * Indicate lading members for focused group has started.
+ */
+function startLoadingFocusedGroupMembers() {
+  return makeAction(reducers, 'LOAD_FOCUSED_GROUP_MEMBERS', {
+    focusedGroupMembers: 'loading',
+  });
+}
+
+/**
  * Update members for focused group.
  */
-function loadFocusedGroupMembers(focusedGroupMembers: GroupMember[]) {
+function loadFocusedGroupMembers(focusedGroupMembers: GroupMember[] | null) {
   return makeAction(reducers, 'LOAD_FOCUSED_GROUP_MEMBERS', {
     focusedGroupMembers,
   });
@@ -158,7 +174,7 @@ function loadFocusedGroupMembers(focusedGroupMembers: GroupMember[]) {
  * Return list of members for focused group.
  * Null is returned if members are being loaded or a group is not focused.
  */
-function getFocusedGroupMembers(state: State): GroupMember[] | null {
+function getFocusedGroupMembers(state: State): FocusedGroupMembers {
   return state.focusedGroupMembers;
 }
 
@@ -270,6 +286,7 @@ export const groupsModule = createStoreModule(initialState, {
     filterGroups,
     focusGroup,
     loadGroups,
+    startLoadingFocusedGroupMembers,
     loadFocusedGroupMembers,
     clearGroups,
   },

--- a/src/sidebar/store/modules/test/groups-test.js
+++ b/src/sidebar/store/modules/test/groups-test.js
@@ -194,6 +194,24 @@ describe('sidebar/store/modules/groups', () => {
     });
   });
 
+  describe('startLoadingFocusedGroupMembers', () => {
+    it('throws if trying to set group members before focusing a group', () => {
+      assert.throws(
+        () => store.startLoadingFocusedGroupMembers(),
+        'A group needs to be focused before loading its members',
+      );
+    });
+
+    it('sets loading state of group members', () => {
+      store.loadGroups([privateGroup]);
+      store.focusGroup(privateGroup.id);
+
+      assert.isNull(store.getState().groups.focusedGroupMembers);
+      store.startLoadingFocusedGroupMembers();
+      assert.equal(store.getState().groups.focusedGroupMembers, 'loading');
+    });
+  });
+
   describe('loadFocusedGroupMembers', () => {
     it('throws if trying to set group members before focusing a group', () => {
       assert.throws(
@@ -205,8 +223,9 @@ describe('sidebar/store/modules/groups', () => {
     it('sets group members', () => {
       store.loadGroups([privateGroup]);
       store.focusGroup(privateGroup.id);
-      store.loadFocusedGroupMembers([]);
 
+      assert.isNull(store.getState().groups.focusedGroupMembers);
+      store.loadFocusedGroupMembers([]);
       assert.deepEqual(store.getState().groups.focusedGroupMembers, []);
     });
   });


### PR DESCRIPTION
Part of https://github.com/orgs/hypothesis/projects/153/views/1?pane=issue&itemId=93470936

During https://github.com/hypothesis/client/pull/6756, a new `GroupsService.loadFocusedGroupMembers` method was created, which fetches members for a group, and sets them in the store, as the members of currently focused group.

It was implemented this way so that the component invoking this method from a side effect could depend on the focused group ID, and fetch members again if it changed, but this implementation means it's technically possible to load members of a group other than the focused one and set them in the `focusedGroupMembers` store prop, which is confusing.

This PR changes the logic so that `GroupsService.loadFocusedGroupMembers` receives no arguments, and instead implicitly fetches members for currently focused group ID.

The side effect dependency issue described above has been solved by evolving `focusedGroupMembers` to be typed as `null | 'loading' | GroupMember[]`, making sure it transitions from `null` to `'loading'` right before starting to load group members.

If the focused group changes before loading members from the previous one, and that one is aborted, the `focusedGroupMembers` store prop will still transition from `null` to `'loading'` and then back to `null`, triggering a re-render of the component, and the side effect callback.

> We discussed the `null | 'loading' | GroupMember[]` type signature for `focusedGroupMembers` [in slack](https://hypothes-is.slack.com/archives/C1M8NH76X/p1737629219692089), and it was going to be part of https://github.com/hypothesis/client/pull/6756, but at some point I ended up concluding it was not needed.
> This PR brings that back.

### Testing steps

If you follow the testing steps from https://github.com/hypothesis/client/pull/6756, everything should continue working as described there.