### PR TITLE
[PoC] Support creating mentions as part of annotation creation

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationBody.tsx
+++ b/src/sidebar/components/Annotation/AnnotationBody.tsx
@@ -105,6 +105,7 @@ function AnnotationBody({ annotation, settings }: AnnotationBodyProps) {
               'p-redacted-text': isHidden(annotation),
             })}
             style={textStyle}
+            mentions={annotation.mentions}
           />
         </Excerpt>
       )}

--- a/src/sidebar/components/MarkdownEditor.tsx
+++ b/src/sidebar/components/MarkdownEditor.tsx
@@ -538,6 +538,14 @@ export type MarkdownEditorProps = {
 };
 
 /**
+ * Replace all mentions wrapped in the special `<a data-hyp-mention />`tag with
+ * their corresponding plain-text representation
+ */
+function unwrapMentions(text: string) {
+  return text.replace(/<a[^>]*data-hyp-mention[^>]*>([^<]*)<\/a>/g, '$1');
+}
+
+/**
  * Viewer/editor for the body of an annotation in markdown format.
  */
 export default function MarkdownEditor({
@@ -554,6 +562,8 @@ export default function MarkdownEditor({
 
   // The input element where the user inputs their comment.
   const input = useRef<HTMLTextAreaElement>(null);
+
+  const textWithoutMentionTags = useMemo(() => unwrapMentions(text), [text]);
 
   useEffect(() => {
     if (!preview) {
@@ -613,7 +623,7 @@ export default function MarkdownEditor({
           containerRef={input}
           onKeyDown={handleKeyDown}
           onEditText={onEditText}
-          value={text}
+          value={textWithoutMentionTags}
           style={textStyle}
           mentionsEnabled={mentionsEnabled}
           usersForMentions={usersForMentions}

--- a/src/sidebar/components/MarkdownEditor.tsx
+++ b/src/sidebar/components/MarkdownEditor.tsx
@@ -29,6 +29,7 @@ import {
 } from 'preact/hooks';
 
 import { isMacOS } from '../../shared/user-agent';
+import { unwrapMentions } from '../helpers/mentions';
 import {
   LinkType,
   convertSelectionToLink,
@@ -536,14 +537,6 @@ export type MarkdownEditorProps = {
    */
   usersForMentions: UserItem[];
 };
-
-/**
- * Replace all mentions wrapped in the special `<a data-hyp-mention />`tag with
- * their corresponding plain-text representation
- */
-function unwrapMentions(text: string) {
-  return text.replace(/<a[^>]*data-hyp-mention[^>]*>([^<]*)<\/a>/g, '$1');
-}
 
 /**
  * Viewer/editor for the body of an annotation in markdown format.

--- a/src/sidebar/components/MarkdownView.tsx
+++ b/src/sidebar/components/MarkdownView.tsx
@@ -49,30 +49,29 @@ export default function MarkdownView({
     const listenerCollection = new ListenerCollection();
     const foundMentions = renderMentionTags(content.current!, mentions);
 
-    // listenerCollection.add(content.current!, 'mouseenter', ({ target }) => {
-    //   const element = target as HTMLElement;
-    //   const mention = foundMentions.get(element) ?? null;
-    //
-    //   if (mention) {
-    //     setActiveMention(mention);
-    //     mentionsPopoverAnchorRef.current = element;
-    //   }
-    // });
-    // listenerCollection.add(content.current!, 'mouseleave', () => {
-    //   setActiveMention(null);
-    //   mentionsPopoverAnchorRef.current = null;
-    // });
+    listenerCollection.add(
+      content.current!,
+      'mouseenter',
+      ({ target }) => {
+        const element = target as HTMLElement;
+        const mention = foundMentions.get(element) ?? null;
 
-    for (const [element, mention] of foundMentions.entries()) {
-      listenerCollection.add(element, 'mouseenter', () => {
-        setActiveMention(mention);
-        mentionsPopoverAnchorRef.current = element;
-      });
-      listenerCollection.add(element, 'mouseleave', () => {
+        if (mention) {
+          setActiveMention(mention);
+          mentionsPopoverAnchorRef.current = element;
+        }
+      },
+      { capture: true },
+    );
+    listenerCollection.add(
+      content.current!,
+      'mouseleave',
+      () => {
         setActiveMention(null);
         mentionsPopoverAnchorRef.current = null;
-      });
-    }
+      },
+      { capture: true },
+    );
 
     return () => listenerCollection.removeAll();
   }, [html, mentions]);

--- a/src/sidebar/components/MarkdownView.tsx
+++ b/src/sidebar/components/MarkdownView.tsx
@@ -46,6 +46,10 @@ export default function MarkdownView({
   }, [markdown]);
 
   useEffect(() => {
+    if (!hasMentions) {
+      return () => {};
+    }
+
     const listenerCollection = new ListenerCollection();
     const foundMentions = renderMentionTags(content.current!, mentions);
 
@@ -74,7 +78,7 @@ export default function MarkdownView({
     );
 
     return () => listenerCollection.removeAll();
-  }, [html, mentions]);
+  }, [hasMentions, html, mentions]);
 
   // NB: The following could be implemented by setting attribute props directly
   // on `StyledText` (which renders a `div` itself), versus introducing a child
@@ -102,9 +106,17 @@ export default function MarkdownView({
             open={!!activeMention}
             onClose={() => setActiveMention(null)}
             anchorElementRef={mentionsPopoverAnchorRef}
-            classes="p-2"
           >
-            {activeMention?.display_name ?? activeMention?.username}
+            <div className="flex flex-col gap-y-1.5 px-3 py-2">
+              <div className="text-md font-bold">
+                @{activeMention?.username}
+              </div>
+              {activeMention?.display_name && (
+                <div className="text-color-text-light">
+                  {activeMention.display_name}
+                </div>
+              )}
+            </div>
           </Popover>
         )}
       </StyledText>

--- a/src/sidebar/components/MarkdownView.tsx
+++ b/src/sidebar/components/MarkdownView.tsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 
 import type { Mention } from '../../types/api';
+import type { InvalidUsername } from '../helpers/mentions';
 import { renderMentionTags } from '../helpers/mentions';
 import { replaceLinksWithEmbeds } from '../media-embedder';
 import { renderMathAndMarkdown } from '../render-markdown';
@@ -44,9 +45,9 @@ export default function MarkdownView({
   const content = useRef<HTMLDivElement | null>(null);
 
   const hasMentions = !!mentions?.length;
-  const [popoverContent, setPopoverContent] = useState<Mention | string | null>(
-    null,
-  );
+  const [popoverContent, setPopoverContent] = useState<
+    Mention | InvalidUsername | null
+  >(null);
   const mentionsPopoverAnchorRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {

--- a/src/sidebar/components/MarkdownView.tsx
+++ b/src/sidebar/components/MarkdownView.tsx
@@ -16,6 +16,17 @@ export type MarkdownViewProps = {
   mentions?: Mention[];
 };
 
+function MentionPopoverContent({ mention }: { mention: Mention }) {
+  return (
+    <div className="flex flex-col gap-y-1.5">
+      <div className="text-md font-bold">@{mention.username}</div>
+      {mention.display_name && (
+        <div className="text-color-text-light">{mention.display_name}</div>
+      )}
+    </div>
+  );
+}
+
 /**
  * A component which renders markdown as HTML and replaces recognized links
  * with embedded video/audio.
@@ -33,7 +44,9 @@ export default function MarkdownView({
   const content = useRef<HTMLDivElement | null>(null);
 
   const hasMentions = !!mentions?.length;
-  const [activeMention, setActiveMention] = useState<Mention | null>(null);
+  const [popoverContent, setPopoverContent] = useState<Mention | string | null>(
+    null,
+  );
   const mentionsPopoverAnchorRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
@@ -61,7 +74,7 @@ export default function MarkdownView({
         const mention = foundMentions.get(element) ?? null;
 
         if (mention) {
-          setActiveMention(mention);
+          setPopoverContent(mention);
           mentionsPopoverAnchorRef.current = element;
         }
       },
@@ -71,7 +84,7 @@ export default function MarkdownView({
       content.current!,
       'mouseleave',
       () => {
-        setActiveMention(null);
+        setPopoverContent(null);
         mentionsPopoverAnchorRef.current = null;
       },
       { capture: true },
@@ -103,20 +116,20 @@ export default function MarkdownView({
         />
         {hasMentions && (
           <Popover
-            open={!!activeMention}
-            onClose={() => setActiveMention(null)}
+            open={!!popoverContent}
+            onClose={() => setPopoverContent(null)}
             anchorElementRef={mentionsPopoverAnchorRef}
+            classes="px-3 py-2"
           >
-            <div className="flex flex-col gap-y-1.5 px-3 py-2">
-              <div className="text-md font-bold">
-                @{activeMention?.username}
-              </div>
-              {activeMention?.display_name && (
-                <div className="text-color-text-light">
-                  {activeMention.display_name}
-                </div>
-              )}
-            </div>
+            {typeof popoverContent === 'string' && (
+              <>
+                No user with username{' '}
+                <span className="font-bold">{popoverContent}</span> exists
+              </>
+            )}
+            {popoverContent !== null && typeof popoverContent === 'object' && (
+              <MentionPopoverContent mention={popoverContent} />
+            )}
           </Popover>
         )}
       </StyledText>

--- a/src/sidebar/components/MarkdownView.tsx
+++ b/src/sidebar/components/MarkdownView.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useRef } from 'preact/hooks';
+import { ListenerCollection, Popover } from '@hypothesis/frontend-shared';
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 
 import type { Mention } from '../../types/api';
 import { replaceLinksWithEmbeds } from '../media-embedder';
@@ -13,10 +14,16 @@ export type MarkdownViewProps = {
   mentions?: Mention[];
 };
 
-function replaceMentionTags(element: HTMLElement, mentions: Mention[] = []) {
+function replaceMentionTags(
+  element: HTMLElement,
+  mentions: Mention[] = [],
+): Array<[Mention, HTMLElement]> {
   const mentionLinks = element.querySelectorAll('a[data-hyp-mention]');
+  const foundMentions: Array<[Mention, HTMLElement]> = [];
+
   for (const mentionLink of mentionLinks) {
-    const mentionUserId = (mentionLink as HTMLElement).dataset.userid;
+    const htmlMentionLink = mentionLink as HTMLElement;
+    const mentionUserId = htmlMentionLink.dataset.userid;
     const mention =
       mentionUserId && mentions.find(m => m.userid === mentionUserId);
 
@@ -25,6 +32,8 @@ function replaceMentionTags(element: HTMLElement, mentions: Mention[] = []) {
       // the user profile
       mentionLink.setAttribute('href', mention.link);
       mentionLink.setAttribute('target', '_blank');
+
+      foundMentions.push([mention, htmlMentionLink]);
     } else {
       // If it doesn't, convert it to "plain text"
       const plainTextMention = document.createElement('span');
@@ -34,6 +43,8 @@ function replaceMentionTags(element: HTMLElement, mentions: Mention[] = []) {
       mentionLink.parentElement?.replaceChild(plainTextMention, mentionLink);
     }
   }
+
+  return foundMentions;
 }
 
 /**
@@ -52,6 +63,10 @@ export default function MarkdownView({
   );
   const content = useRef<HTMLDivElement | null>(null);
 
+  const hasMentions = !!mentions?.length;
+  const [activeMention, setActiveMention] = useState<Mention | null>(null);
+  const mentionsPopoverAnchorRef = useRef<HTMLElement | null>(null);
+
   useEffect(() => {
     replaceLinksWithEmbeds(content.current!, {
       // Make embeds the full width of the sidebar, unless the sidebar has been
@@ -62,7 +77,21 @@ export default function MarkdownView({
   }, [markdown]);
 
   useEffect(() => {
-    replaceMentionTags(content.current!, mentions);
+    const listenerCollection = new ListenerCollection();
+    const foundMentions = replaceMentionTags(content.current!, mentions);
+
+    for (const [mention, element] of foundMentions) {
+      listenerCollection.add(element, 'mouseenter', () => {
+        setActiveMention(mention);
+        mentionsPopoverAnchorRef.current = element;
+      });
+      listenerCollection.add(element, 'mouseleave', () => {
+        setActiveMention(null);
+        mentionsPopoverAnchorRef.current = null;
+      });
+    }
+
+    return () => listenerCollection.removeAll();
   }, [html, mentions]);
 
   // NB: The following could be implemented by setting attribute props directly
@@ -72,7 +101,7 @@ export default function MarkdownView({
   // a review in the future.
   return (
     <div className="w-full break-anywhere cursor-text">
-      <StyledText>
+      <StyledText classes="relative">
         <div
           className={classes}
           data-testid="markdown-text"
@@ -80,6 +109,16 @@ export default function MarkdownView({
           dangerouslySetInnerHTML={{ __html: html }}
           style={style}
         />
+        {hasMentions && (
+          <Popover
+            open={!!activeMention}
+            onClose={() => setActiveMention(null)}
+            anchorElementRef={mentionsPopoverAnchorRef}
+            classes="p-2"
+          >
+            {activeMention?.display_name ?? activeMention?.username}
+          </Popover>
+        )}
       </StyledText>
     </div>
   );

--- a/src/sidebar/components/MarkdownView.tsx
+++ b/src/sidebar/components/MarkdownView.tsx
@@ -1,4 +1,5 @@
 import { ListenerCollection, Popover } from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 
 import type { Mention } from '../../types/api';
@@ -101,7 +102,13 @@ export default function MarkdownView({
   // a review in the future.
   return (
     <div className="w-full break-anywhere cursor-text">
-      <StyledText classes="relative">
+      <StyledText
+        classes={classnames(
+          // A `relative` wrapper around the `Popover` component is needed for
+          // when the native Popover API is not supported.
+          'relative',
+        )}
+      >
         <div
           className={classes}
           data-testid="markdown-text"

--- a/src/sidebar/helpers/mentions.ts
+++ b/src/sidebar/helpers/mentions.ts
@@ -33,20 +33,23 @@ export function unwrapMentions(text: string) {
   return tmp.innerHTML;
 }
 
+type InvalidUsername = string;
+
 /**
  * Searches for mention tags inside an HTML element, and tries to match them
  * with a provided list of mentions.
  * Those that are valid are rendered as links, and those that are not are styled
  * in a way that it's possible to visually identify them.
  *
- * @return - Map of HTML elements with their corresponding mention
+ * @return - Map of HTML elements that matched, with their corresponding mention
+ *           or invalid username
  */
 export function renderMentionTags(
   element: HTMLElement,
   mentions: Mention[],
-): Map<HTMLElement, Mention> {
+): Map<HTMLElement, Mention | InvalidUsername> {
   const mentionLinks = element.querySelectorAll('a[data-hyp-mention]');
-  const foundMentions = new Map<HTMLElement, Mention>();
+  const foundMentions = new Map<HTMLElement, Mention | string>();
 
   for (const mentionLink of mentionLinks) {
     const htmlMentionLink = mentionLink as HTMLElement;
@@ -63,10 +66,14 @@ export function renderMentionTags(
     } else {
       // If it doesn't, convert it to "plain text"
       const invalidMentionElement = document.createElement('span');
-      invalidMentionElement.textContent = mentionLink.textContent;
+      const invalidUsername = mentionLink.textContent ?? '';
+
+      invalidMentionElement.textContent = invalidUsername;
       invalidMentionElement.style.fontStyle = 'italic';
       invalidMentionElement.style.borderBottom = 'dotted';
       mentionLink.replaceWith(invalidMentionElement);
+
+      foundMentions.set(invalidMentionElement, invalidUsername);
     }
   }
 

--- a/src/sidebar/helpers/mentions.ts
+++ b/src/sidebar/helpers/mentions.ts
@@ -1,3 +1,5 @@
+import type { Mention } from '../../types/api';
+
 /**
  * Wrap all occurrences of @mentions in provided text into the corresponding
  * special tag, as long as they are surrounded by "empty" space (space, tab, new
@@ -29,4 +31,45 @@ export function unwrapMentions(text: string) {
     node.replaceWith(node.textContent ?? '');
   }
   return tmp.innerHTML;
+}
+
+/**
+ * Searches for mention tags inside an HTML element, and tries to match them
+ * with a provided list of mentions.
+ * Those that are valid are rendered as links, and those that are not are styled
+ * so that it is possible to identify them.
+ *
+ * @return - Map of HTML elements with their corresponding mention
+ */
+export function renderMentionTags(
+  element: HTMLElement,
+  mentions: Mention[] = [],
+): Map<HTMLElement, Mention> {
+  const mentionLinks = element.querySelectorAll('a[data-hyp-mention]');
+  const foundMentions = new Map<HTMLElement, Mention>();
+
+  for (const mentionLink of mentionLinks) {
+    const htmlMentionLink = mentionLink as HTMLElement;
+    const mentionUserId = htmlMentionLink.dataset.userid;
+    const mention =
+      mentionUserId && mentions.find(m => m.userid === mentionUserId);
+
+    if (mention) {
+      // If the mention exists in the list of mentions, render it as a link to
+      // the user profile
+      mentionLink.setAttribute('href', mention.link);
+      mentionLink.setAttribute('target', '_blank');
+
+      foundMentions.set(htmlMentionLink, mention);
+    } else {
+      // If it doesn't, convert it to "plain text"
+      const plainTextMention = document.createElement('span');
+      plainTextMention.textContent = mentionLink.textContent;
+      plainTextMention.style.fontStyle = 'italic';
+      plainTextMention.style.borderBottom = 'dotted';
+      mentionLink.parentElement?.replaceChild(plainTextMention, mentionLink);
+    }
+  }
+
+  return foundMentions;
 }

--- a/src/sidebar/helpers/mentions.ts
+++ b/src/sidebar/helpers/mentions.ts
@@ -36,13 +36,13 @@ export function unwrapMentions(text: string) {
 type InvalidUsername = string;
 
 /**
- * Searches for mention tags inside an HTML element, and tries to match them
- * with a provided list of mentions.
+ * Search for mention tags inside an HTML element, and try to match them with a
+ * provided list of mentions.
  * Those that are valid are rendered as links, and those that are not are styled
  * in a way that it's possible to visually identify them.
  *
- * @return - Map of HTML elements that matched, with their corresponding mention
- *           or invalid username
+ * @return - Map of HTML elements that matched a mention tag, with their
+ *           corresponding mention or invalid username
  */
 export function renderMentionTags(
   element: HTMLElement,

--- a/src/sidebar/helpers/mentions.ts
+++ b/src/sidebar/helpers/mentions.ts
@@ -22,7 +22,7 @@ export function wrapMentions(text: string, authority: string): string {
 
 /**
  * Replace all mentions wrapped in the special `<a data-hyp-mention />` tag with
- * their corresponding plain-text representation
+ * their plain-text representation.
  */
 export function unwrapMentions(text: string) {
   const tmp = document.createElement('div');
@@ -33,7 +33,7 @@ export function unwrapMentions(text: string) {
   return tmp.innerHTML;
 }
 
-type InvalidUsername = string;
+export type InvalidUsername = string;
 
 /**
  * Search for mention tags inside an HTML element, and try to match them with a
@@ -58,8 +58,10 @@ export function renderMentionTags(
       mentionUserId && mentions.find(m => m.userid === mentionUserId);
 
     if (mention) {
+      // TODO If the link is null, convert the mention link into a different tag
+
       // If the mention exists in the list of mentions, render it as a link
-      mentionLink.setAttribute('href', mention.link);
+      mentionLink.setAttribute('href', mention.link ?? '');
       mentionLink.setAttribute('target', '_blank');
 
       foundMentions.set(htmlMentionLink, mention);

--- a/src/sidebar/helpers/mentions.ts
+++ b/src/sidebar/helpers/mentions.ts
@@ -1,0 +1,32 @@
+/**
+ * Wrap all occurrences of @mentions in provided text into the corresponding
+ * special tag, as long as they are surrounded by "empty" space (space, tab, new
+ * line, or beginning/end of the whole text).
+ *
+ * For example: `@someuser` with the `hypothes.is` authority would become
+ *  `<a data-hyp-mention data-userid="acct:someuser@hypothes.is">@someuser</a>`
+ */
+export function wrapMentions(text: string, authority: string): string {
+  return text.replace(/(?:^|\s)@(\w+)(?=\s|$)/g, (match, username) => {
+    const tag = document.createElement('a');
+
+    tag.setAttribute('data-hyp-mention', '');
+    tag.setAttribute('data-userid', `acct:${username}@${authority}`);
+    tag.textContent = `@${username}`;
+
+    return ` ${tag.outerHTML}`;
+  });
+}
+
+/**
+ * Replace all mentions wrapped in the special `<a data-hyp-mention />` tag with
+ * their corresponding plain-text representation
+ */
+export function unwrapMentions(text: string) {
+  const tmp = document.createElement('div');
+  tmp.innerHTML = text;
+  for (const node of tmp.querySelectorAll('a[data-hyp-mention]')) {
+    node.replaceWith(node.textContent ?? '');
+  }
+  return tmp.innerHTML;
+}

--- a/src/sidebar/helpers/mentions.ts
+++ b/src/sidebar/helpers/mentions.ts
@@ -37,13 +37,13 @@ export function unwrapMentions(text: string) {
  * Searches for mention tags inside an HTML element, and tries to match them
  * with a provided list of mentions.
  * Those that are valid are rendered as links, and those that are not are styled
- * so that it is possible to identify them.
+ * in a way that it's possible to visually identify them.
  *
  * @return - Map of HTML elements with their corresponding mention
  */
 export function renderMentionTags(
   element: HTMLElement,
-  mentions: Mention[] = [],
+  mentions: Mention[],
 ): Map<HTMLElement, Mention> {
   const mentionLinks = element.querySelectorAll('a[data-hyp-mention]');
   const foundMentions = new Map<HTMLElement, Mention>();
@@ -55,19 +55,18 @@ export function renderMentionTags(
       mentionUserId && mentions.find(m => m.userid === mentionUserId);
 
     if (mention) {
-      // If the mention exists in the list of mentions, render it as a link to
-      // the user profile
+      // If the mention exists in the list of mentions, render it as a link
       mentionLink.setAttribute('href', mention.link);
       mentionLink.setAttribute('target', '_blank');
 
       foundMentions.set(htmlMentionLink, mention);
     } else {
       // If it doesn't, convert it to "plain text"
-      const plainTextMention = document.createElement('span');
-      plainTextMention.textContent = mentionLink.textContent;
-      plainTextMention.style.fontStyle = 'italic';
-      plainTextMention.style.borderBottom = 'dotted';
-      mentionLink.parentElement?.replaceChild(plainTextMention, mentionLink);
+      const invalidMentionElement = document.createElement('span');
+      invalidMentionElement.textContent = mentionLink.textContent;
+      invalidMentionElement.style.fontStyle = 'italic';
+      invalidMentionElement.style.borderBottom = 'dotted';
+      mentionLink.replaceWith(invalidMentionElement);
     }
   }
 

--- a/src/sidebar/render-markdown.ts
+++ b/src/sidebar/render-markdown.ts
@@ -151,7 +151,7 @@ function insertMath(html: string, mathBlocks: MathBlock[]) {
  */
 export function renderMathAndMarkdown(markdown: string): string {
   // KaTeX takes care of escaping its input, so we want to avoid passing its
-  // output through the HTML sanitizer. Therefore we first extract the math
+  // output through the HTML sanitizer. Therefore, we first extract the math
   // blocks from the input, render and sanitize the remaining markdown and then
   // render and re-insert the math blocks back into the output.
   const mathInfo = extractMath(markdown);

--- a/src/sidebar/services/annotations.ts
+++ b/src/sidebar/services/annotations.ts
@@ -6,6 +6,7 @@ import type {
   SavedAnnotation,
 } from '../../types/api';
 import type { AnnotationEventType, SidebarSettings } from '../../types/config';
+import { parseAccountID } from '../helpers/account-id';
 import * as metadata from '../helpers/annotation-metadata';
 import { wrapMentions } from '../helpers/mentions';
 import {
@@ -48,7 +49,8 @@ export class AnnotationsService {
     const changes: Partial<Annotation> = {};
     const draft = this._store.getDraft(annotation);
     const authority =
-      this._settings.services?.[0]?.authority ?? this._store.defaultAuthority();
+      parseAccountID(this._store.profile().userid)?.provider ??
+      this._store.defaultAuthority();
 
     if (draft) {
       changes.tags = draft.tags;

--- a/src/sidebar/services/annotations.ts
+++ b/src/sidebar/services/annotations.ts
@@ -18,13 +18,14 @@ import type { APIService } from './api';
 
 /**
  * Wrap all occurrences of @mentions in provided text into the corresponding
- * special tag, unless they are already wrapped.
+ * special tag, as long as they are surrounded by "empty" space (space, tab, new
+ * line, or beginning/end of the whole text).
  *
  * For example: `@someuser` with the `hypothes.is` authority would become
  *  `<a data-hyp-mention data-userid="acct:someuser@hypothes.is">@someuser</a>`
  */
 function mentionsToTags(text: string, authority: string): string {
-  return text.replace(/(^|[^<a>])@(\w+)/g, (match, prefix, username) => {
+  return text.replace(/(?:^|\s)@(\w+)(?=\s|$)/g, (match, username) => {
     const userid = `acct:${username}@${authority}`;
     return ` <a data-hyp-mention data-userid="${userid}">@${username}</a>`;
   });
@@ -119,6 +120,7 @@ export class AnnotationsService {
         hidden: false,
         links: {},
         document: { title: '' },
+        mentions: [],
       },
       annotationData,
     );

--- a/src/sidebar/services/annotations.ts
+++ b/src/sidebar/services/annotations.ts
@@ -7,6 +7,7 @@ import type {
 } from '../../types/api';
 import type { AnnotationEventType, SidebarSettings } from '../../types/config';
 import * as metadata from '../helpers/annotation-metadata';
+import { wrapMentions } from '../helpers/mentions';
 import {
   defaultPermissions,
   privatePermissions,
@@ -15,21 +16,6 @@ import {
 import type { SidebarStore } from '../store';
 import type { AnnotationActivityService } from './annotation-activity';
 import type { APIService } from './api';
-
-/**
- * Wrap all occurrences of @mentions in provided text into the corresponding
- * special tag, as long as they are surrounded by "empty" space (space, tab, new
- * line, or beginning/end of the whole text).
- *
- * For example: `@someuser` with the `hypothes.is` authority would become
- *  `<a data-hyp-mention data-userid="acct:someuser@hypothes.is">@someuser</a>`
- */
-function mentionsToTags(text: string, authority: string): string {
-  return text.replace(/(?:^|\s)@(\w+)(?=\s|$)/g, (match, username) => {
-    const userid = `acct:${username}@${authority}`;
-    return ` <a data-hyp-mention data-userid="${userid}">@${username}</a>`;
-  });
-}
 
 /**
  * A service for creating, updating and persisting annotations both in the
@@ -66,7 +52,7 @@ export class AnnotationsService {
 
     if (draft) {
       changes.tags = draft.tags;
-      changes.text = mentionsToTags(draft.text, authority);
+      changes.text = wrapMentions(draft.text, authority);
       changes.permissions = draft.isPrivate
         ? privatePermissions(annotation.user)
         : sharedPermissions(annotation.user, annotation.group);

--- a/src/sidebar/services/annotations.ts
+++ b/src/sidebar/services/annotations.ts
@@ -61,7 +61,8 @@ export class AnnotationsService {
   private _applyDraftChanges(annotation: Annotation): Annotation {
     const changes: Partial<Annotation> = {};
     const draft = this._store.getDraft(annotation);
-    const authority = this._settings.services?.[0]?.authority ?? 'hypothes.is';
+    const authority =
+      this._settings.services?.[0]?.authority ?? this._store.defaultAuthority();
 
     if (draft) {
       changes.tags = draft.tags;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -161,7 +161,14 @@ export type UserInfo = {
 export type Mention = UserInfo & {
   userid: string;
   username: string;
-  link: string;
+  link: string | null;
+
+  /**
+   * The userid at the moment the mention was created.
+   * If the user changes their username later, this can be used to still match
+   * the right mention tag in the annotation text.
+   */
+  original_userid: string;
 };
 
 /**
@@ -229,7 +236,10 @@ export type APIAnnotationData = {
    */
   metadata?: object;
 
-  mentions: Mention[];
+  /**
+   * List of unique users that were mentioned in the annotation text.
+   */
+  mentions?: Mention[];
 };
 
 /**

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -158,6 +158,12 @@ export type UserInfo = {
   display_name: string | null;
 };
 
+export type Mention = UserInfo & {
+  userid: string;
+  username: string;
+  link: string;
+};
+
 /**
  * Represents an annotation as returned by the h API.
  * API docs: https://h.readthedocs.io/en/latest/api-reference/#tag/annotations
@@ -222,6 +228,8 @@ export type APIAnnotationData = {
    * current assignment, course etc. to annotations.
    */
   metadata?: object;
+
+  mentions: Mention[];
 };
 
 /**


### PR DESCRIPTION
This PR is used to verify some assumptions, and check that we can proceed according to what's described in the engineering design document for phase 1 https://docs.google.com/document/d/16Iv-MPwQi_LIIN6Fk-aAaflZqWkSX5bQIWUEg_MUDBI/edit

The implementation here is very rough, and individual PRs will be extracted with the actual, properly tested implementation.

This PR has been tested in combination with https://github.com/hypothesis/h/pull/9279, to ensure FE and BE integrate as expected.

https://github.com/user-attachments/assets/bc6fd543-0789-494f-9f5b-62fd5497ef7d

https://github.com/user-attachments/assets/839f7ef8-a709-4731-b763-ca8ed417fdc2

### Logic

This PR covers:

1. Replacing any occurrence of `@something` in the annotation text with the special mention tag (`<a data-hyp-mention data-userid="acct:something@authority">@something</a>`) right before sending it to the BE.
    We don't try to validate those are actual usernames client-side. Instead we let the BE validate them and "discard" those that are invalid.
    This will allow us to highlight incorrect mentions to end-users, or simply render them as plain-text if desired. 
2. Convert special mention tags to their plain-text representation when going back to editing an annotation.
3. Render valid mentions as a link to the user profile, and invalid ones as a styled `span`.
4. Display a popover when hovering over valid at-mentions. The content is temporary (display name or username), but we'll have to enhance it.

This PR assumes usernames are public and user-friendly. In future, we'll need to support mentioning via display name as well, for the LMS. In that case we will have to support an additional plain-text format for mentions that could be something like `@[Display name]`, `@<Display name>`, `@Display_name` or something in those lines.

When converting that to the corresponding mention tag, we will have to get the userid somehow. Let's worry about that later.

### TODO

- [x] Parse `@username` into special tag `<a data-hyp-mention data-userid="acct:username@authority">@username</a>`
- [x] Render valid mentions from server as links to the user profile, and invalid ones as plain-text or some fallback style
- [x] Parse special tag back into `@username` when entering annotation edit mode for an annotation with mentions
- [x] Show basic popover when hovering over a mention