### PR TITLE
Position popover below caret, instead of below whole text area

### DIFF
--- a/src/sidebar/util/test/textarea-caret-position-test.js
+++ b/src/sidebar/util/test/textarea-caret-position-test.js
@@ -1,0 +1,112 @@
+import { getCaretCoordinates } from '../textarea-caret-position';
+
+describe('getCaretCoordinates', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.append(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  function getCharWidth(fontName, size) {
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d');
+    ctx.font = `${size} ${fontName}`;
+    return ctx.measureText('x').width;
+  }
+
+  [
+    // Text area content and expected caret position. The caret position
+    // is expressed a multiple of the char width (X) and line height (Y).
+    //
+    // The reported caret position is at the bottom of the line, hence a caret
+    // at the start of the textarea has position `[0, 1]`.
+
+    // Caret at start of textarea
+    {
+      content: '@',
+      expectedCoords: [0, 1],
+    },
+
+    // Caret at end of first line
+    {
+      content: 'ab@',
+      expectedCoords: [2, 1],
+    },
+
+    // Caret in middle of first line
+    {
+      content: 'a@b',
+      expectedCoords: [1, 1],
+    },
+
+    // Caret at start of subsequent line
+    {
+      content: '\n\n@',
+      expectedCoords: [0, 3],
+    },
+
+    // Caret at start of line below scrollable area
+    {
+      content: 'one\ntwo\nthree\n@',
+      expectedCoords: [0, 4],
+    },
+
+    // Textarea scrolled one line down, so caret Y position is reduced
+    // accordingly.
+    {
+      content: 'one\ntwo\nthree\n@',
+      scrollTop: 1,
+      expectedCoords: [0, 3],
+    },
+
+    // Text area offset from top
+    {
+      content: '@',
+      expectedCoords: [0, 1],
+      style: { top: '150px' },
+    },
+
+    // Text area offset from left
+    {
+      content: '@',
+      expectedCoords: [0, 1],
+      style: { left: '150px' },
+    },
+  ].forEach(({ content, expectedCoords, style = {}, scrollTop = 0 }) => {
+    it('returns expected caret position', () => {
+      const fontFamily = 'monospace';
+      const fontSize = '15px';
+      const lineHeight = 20;
+
+      const textarea = document.createElement('textarea');
+      textarea.style.border = 'none';
+      textarea.style.fontSize = fontSize;
+      textarea.style.fontFamily = fontFamily;
+      textarea.style.lineHeight = `${lineHeight}px`;
+      textarea.style.height = `${lineHeight * 3}px`;
+      Object.assign(textarea.style, style);
+
+      container.append(textarea);
+
+      textarea.value = content.replace('@', '');
+      textarea.selectionStart = content.indexOf('@');
+      textarea.scrollTop = scrollTop * lineHeight;
+
+      const caretPos = getCaretCoordinates(textarea);
+      let [expectedX, expectedY] = expectedCoords;
+      expectedX *= getCharWidth(fontFamily, fontSize);
+      expectedX = Math.round(expectedX);
+      expectedY *= lineHeight;
+
+      assert.deepEqual(
+        [Math.round(caretPos.x), caretPos.y],
+        [expectedX, expectedY],
+      );
+    });
+  });
+});

--- a/src/sidebar/util/textarea-caret-position.ts
+++ b/src/sidebar/util/textarea-caret-position.ts
@@ -1,0 +1,91 @@
+// Hidden div used by `getCaretCoordinates` to mirror content of text area.
+let mirrorDiv: HTMLElement | undefined;
+
+// Enable debug mode. This makes the hidden div used to measure the caret
+// position visible and keeps it in the DOM after the position is calculated.
+const mirrorDebug = false;
+
+/**
+ * Calculate the coordinates of the caret position within a textarea.
+ *
+ * @return Coordinates of the caret relative to the textarea's top-left corner
+ */
+export function getCaretCoordinates(textarea: HTMLTextAreaElement): {
+  x: number;
+  y: number;
+} {
+  if (!mirrorDiv) {
+    mirrorDiv = document.createElement('div');
+    document.body.append(mirrorDiv);
+  }
+
+  try {
+    const textareaRect = textarea.getBoundingClientRect();
+
+    // Style text in the mirror to match the textarea
+    const styles = window.getComputedStyle(textarea);
+    mirrorDiv.style.font = styles.font;
+    mirrorDiv.style.padding = styles.padding;
+    mirrorDiv.style.whiteSpace = 'pre-wrap';
+    mirrorDiv.style.wordWrap = 'break-word';
+    mirrorDiv.style.position = 'fixed';
+
+    /* istanbul ignore next */
+    if (!mirrorDebug) {
+      mirrorDiv.style.visibility = 'hidden';
+    } else {
+      mirrorDiv.style.pointerEvents = 'none';
+      mirrorDiv.style.background = 'rgba(255, 0, 0, 0.5)';
+    }
+
+    // Position mirror above the textarea
+    mirrorDiv.style.width = `${textareaRect.width}px`;
+    mirrorDiv.style.height = `${textareaRect.height}px`;
+    mirrorDiv.style.top = `${textareaRect.top}px`;
+    mirrorDiv.style.left = `${textareaRect.left}px`;
+
+    // Update mirror content to match textarea and insert an element at the
+    // caret position.
+    //
+    // We need to include the text before and after the caret so that the scroll
+    // height is the same as the text area.
+    const caretPosition = textarea.selectionStart;
+    const caretSpan = document.createElement('span');
+
+    // Align top of caret indicator with bottom of line. This makes the precise
+    // position a little easier to reason about. Otherwise it will be aligned
+    // with the baseline.
+    caretSpan.style.display = 'inline-block';
+    caretSpan.style.verticalAlign = 'bottom';
+
+    const textBeforeCaret = textarea.value.substring(0, caretPosition);
+    const textAfterCaret = textarea.value.slice(caretPosition);
+
+    // Add a non-empty line at the end. This avoids a problem where the mirror's
+    // scrollable height can be less than the textarea if the text content ends
+    // with a new line.
+    const suffix = '\nx';
+
+    mirrorDiv.innerHTML = '';
+    mirrorDiv.append(textBeforeCaret, caretSpan, textAfterCaret, suffix);
+
+    // Adjust scroll position to match the textarea. For this to work, the
+    // scrollable height of the mirror must be at least equal to the scrollable
+    // height of the text area.
+    mirrorDiv.style.overflow = 'scroll';
+    mirrorDiv.scrollTop = textarea.scrollTop;
+
+    // Capture caret position relative to top-left corner of textarea.
+    const rect = caretSpan.getBoundingClientRect();
+
+    return {
+      x: rect.left - textareaRect.left,
+      y: rect.top - textareaRect.top,
+    };
+  } finally {
+    if (!mirrorDebug) {
+      mirrorDiv.remove();
+      mirrorDiv = undefined;
+    }
+  }
+}


### PR DESCRIPTION
Change anchor element for mentions popover in markdown editor to be a hidden
element which is positioned at the location of the caret within the text area,
instead of using the textarea itself.

Fixes https://github.com/hypothesis/client/issues/6799.

**Testing:**

1. Create a new annotation.
2. Type "@" to show mentions popover. The popover should be positioned below the caret instead of below the whole textarea.
3. Try typing "@" at the start of the text, in the middle, at the end, when the textarea is scrolled, when the whole sidebar is scrolled etc.