### PR TITLE
Unwrap mention tags when entering annotation edit mode

### DIFF
--- a/src/sidebar/components/MarkdownEditor.tsx
+++ b/src/sidebar/components/MarkdownEditor.tsx
@@ -32,6 +32,7 @@ import { isMacOS } from '../../shared/user-agent';
 import {
   getContainingMentionOffsets,
   termBeforePosition,
+  unwrapMentions,
 } from '../helpers/mentions';
 import {
   LinkType,
@@ -566,6 +567,8 @@ export default function MarkdownEditor({
   // The input element where the user inputs their comment.
   const input = useRef<HTMLTextAreaElement>(null);
 
+  const textWithoutMentionTags = useMemo(() => unwrapMentions(text), [text]);
+
   useEffect(() => {
     if (!preview) {
       input.current?.focus();
@@ -624,7 +627,7 @@ export default function MarkdownEditor({
           containerRef={input}
           onKeyDown={handleKeyDown}
           onEditText={onEditText}
-          value={text}
+          value={textWithoutMentionTags}
           style={textStyle}
           mentionsEnabled={mentionsEnabled}
           usersForMentions={usersForMentions}

--- a/src/sidebar/components/test/MarkdownEditor-test.js
+++ b/src/sidebar/components/test/MarkdownEditor-test.js
@@ -5,7 +5,9 @@ import {
 import { mount } from '@hypothesis/frontend-testing';
 import { render } from 'preact';
 import { act } from 'preact/test-utils';
+import sinon from 'sinon';
 
+import { wrapMentions } from '../../helpers/mentions';
 import { LinkType } from '../../markdown-commands';
 import MarkdownEditor, { $imports } from '../MarkdownEditor';
 
@@ -311,6 +313,14 @@ describe('MarkdownEditor', () => {
     const inputField = wrapper.find('textarea');
     assert.equal(inputField.prop('aria-label'), 'Enter comment');
     assert.equal(inputField.prop('placeholder'), 'Enter comment');
+  });
+
+  it('unwraps mention tags', () => {
+    const wrapper = createComponent({
+      text: wrapMentions('Hello @bob', 'hypothes.is'),
+    });
+
+    assert.equal(wrapper.find('TextArea').prop('value'), 'Hello @bob');
   });
 
   describe('keyboard navigation', () => {


### PR DESCRIPTION
This is a follow up of https://github.com/hypothesis/client/pull/6815, which ensures mention tags are unwrapped into their plain-text version when entering annotation edit mode.

### Test steps

1. Checkout this branch
2. Create an annotation with a mention
3. Edit the annotation you just created. The mention should be loaded in the textarea in plain-text format.

In `main`, when editing an annotation that has mentions, it will load the mention tags.