### PR TITLE
Fix gap between username and display name in mention suggestions

### DIFF
--- a/src/sidebar/components/MentionPopover.tsx
+++ b/src/sidebar/components/MentionPopover.tsx
@@ -48,7 +48,7 @@ export default function MentionPopover({
             key={u.username}
             id={`${usersListboxId}-${u.username}`}
             className={classnames(
-              'flex justify-between items-center',
+              'flex justify-between items-center gap-x-2',
               'rounded p-2 hover:bg-grey-2',
               {
                 'bg-grey-2': highlightedSuggestion === index,


### PR DESCRIPTION
We overlooked adding some gap between the username and the display name in the mentions suggestions.

Before:

![Captura desde 2025-02-10 16-23-54](https://github.com/user-attachments/assets/ad4bea60-d2b2-439d-a588-00cbdb457edc)

After:

![Captura desde 2025-02-10 16-24-05](https://github.com/user-attachments/assets/412deef7-9ef4-4ce7-a937-fa7b8dffa7e2)