### PR TITLE
Display a popover when hovering over highlighted mentions

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationBody.tsx
+++ b/src/sidebar/components/Annotation/AnnotationBody.tsx
@@ -70,6 +70,7 @@ function AnnotationBody({ annotation, settings }: AnnotationBodyProps) {
   const store = useSidebarStore();
   const defaultAuthority = store.defaultAuthority();
   const draft = store.getDraft(annotation);
+  const mentionsEnabled = store.isFeatureEnabled('at_mentions');
 
   // If there is a draft use the tag and text from it.
   const tags = draft?.tags ?? annotation.tags;
@@ -106,6 +107,7 @@ function AnnotationBody({ annotation, settings }: AnnotationBodyProps) {
             })}
             style={textStyle}
             mentions={annotation.mentions}
+            mentionsEnabled={mentionsEnabled}
           />
         </Excerpt>
       )}

--- a/src/sidebar/components/Annotation/test/AnnotationBody-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationBody-test.js
@@ -4,6 +4,7 @@ import {
 } from '@hypothesis/frontend-testing';
 import { mount } from '@hypothesis/frontend-testing';
 import { act } from 'preact/test-utils';
+import sinon from 'sinon';
 
 import * as fixtures from '../../../test/annotation-fixtures';
 import AnnotationBody, { $imports } from '../AnnotationBody';
@@ -54,6 +55,7 @@ describe('AnnotationBody', () => {
       getLink: sinon
         .stub()
         .callsFake((linkPath, { tag }) => `http://www.example.com/${tag}`),
+      isFeatureEnabled: sinon.stub().returns(false),
     };
 
     $imports.$mock(mockImportedComponents());

--- a/src/sidebar/components/MarkdownEditor.tsx
+++ b/src/sidebar/components/MarkdownEditor.tsx
@@ -617,6 +617,7 @@ export default function MarkdownEditor({
           classes="border bg-grey-1 p-2"
           style={textStyle}
           mentions={mentions}
+          mentionsEnabled={mentionsEnabled}
         />
       ) : (
         <TextArea

--- a/src/sidebar/components/MarkdownView.tsx
+++ b/src/sidebar/components/MarkdownView.tsx
@@ -1,10 +1,20 @@
-import { useEffect, useMemo, useRef } from 'preact/hooks';
+import { Popover } from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'preact/hooks';
 
 import type { Mention } from '../../types/api';
+import type { InvalidUsername } from '../helpers/mentions';
 import { renderMentionTags } from '../helpers/mentions';
 import { replaceLinksWithEmbeds } from '../media-embedder';
 import { renderMathAndMarkdown } from '../render-markdown';
 import StyledText from './StyledText';
+import MentionPopoverContent from './mentions/MentionPopoverContent';
 
 export type MarkdownViewProps = {
   /** The string of markdown to display as HTML. */
@@ -12,23 +22,80 @@ export type MarkdownViewProps = {
   classes?: string;
   style?: Record<string, string>;
   mentions?: Mention[];
+
+  /**
+   * Whether the at-mentions feature ir enabled or not.
+   * Defaults to false.
+   */
+  mentionsEnabled?: boolean;
+
+  // Test seams
+  setTimeout_?: typeof setTimeout;
+  clearTimeout_?: typeof clearTimeout;
 };
 
+type PopoverContent = Mention | InvalidUsername | null;
+
 /**
- * A component which renders markdown as HTML and replaces recognized links
- * with embedded video/audio.
+ * A component which renders markdown as HTML, replaces recognized links with
+ * embedded video/audio and processes mention tags.
  */
-export default function MarkdownView({
-  markdown,
-  classes,
-  style,
-  mentions,
-}: MarkdownViewProps) {
+export default function MarkdownView(props: MarkdownViewProps) {
+  /* istanbul ignore next - Unpack here to ignore default values for test seams */
+  const {
+    markdown,
+    classes,
+    style,
+    mentions = [],
+    mentionsEnabled = false,
+    setTimeout_ = setTimeout,
+    clearTimeout_ = clearTimeout,
+  } = props;
   const html = useMemo(
     () => (markdown ? renderMathAndMarkdown(markdown) : ''),
     [markdown],
   );
   const content = useRef<HTMLDivElement | null>(null);
+
+  const mentionsPopoverAnchorRef = useRef<HTMLElement | null>(null);
+  const elementToMentionMap = useRef(
+    new Map<HTMLElement, Mention | InvalidUsername>(),
+  );
+  const [popoverContent, setPopoverContent] = useState<PopoverContent>(null);
+  const popoverContentTimeout = useRef<ReturnType<typeof setTimeout> | null>();
+  const setPopoverContentAfterDelay = useCallback(
+    // This allows the content to be set with a small delay, so that popovers
+    // don't flicker simply by hovering an annotation with mentions
+    (content: PopoverContent) => {
+      if (popoverContentTimeout.current) {
+        clearTimeout_(popoverContentTimeout.current);
+      }
+
+      const setContent = () => {
+        setPopoverContent(content);
+        popoverContentTimeout.current = null;
+      };
+
+      // Set the content immediately when resetting, so that there's no delay
+      // when hiding the popover, only when showing it
+      if (content === null) {
+        setContent();
+      } else {
+        popoverContentTimeout.current = setTimeout_(setContent, 400);
+      }
+    },
+    [clearTimeout_, setTimeout_],
+  );
+
+  useEffect(() => {
+    // Clear any potentially in-progress popover timeout when this component is
+    // unmounted
+    return () => {
+      if (popoverContentTimeout.current) {
+        clearTimeout_(popoverContentTimeout.current);
+      }
+    };
+  }, [clearTimeout_]);
 
   useEffect(() => {
     replaceLinksWithEmbeds(content.current!, {
@@ -40,7 +107,7 @@ export default function MarkdownView({
   }, [markdown]);
 
   useEffect(() => {
-    renderMentionTags(content.current!, mentions ?? []);
+    elementToMentionMap.current = renderMentionTags(content.current!, mentions);
   }, [mentions]);
 
   // NB: The following could be implemented by setting attribute props directly
@@ -50,14 +117,57 @@ export default function MarkdownView({
   // a review in the future.
   return (
     <div className="w-full break-anywhere cursor-text">
-      <StyledText>
+      <StyledText
+        classes={classnames({
+          // A `relative` wrapper around the `Popover` component is needed for
+          // when the native Popover API is not supported.
+          relative: mentionsEnabled,
+        })}
+      >
         <div
           className={classes}
           data-testid="markdown-text"
           ref={content}
           dangerouslySetInnerHTML={{ __html: html }}
           style={style}
+          // React types do not define `onMouseEnterCapture`, but preact does
+          // eslint-disable-next-line react/no-unknown-property
+          onMouseEnterCapture={
+            mentionsEnabled
+              ? ({ target }) => {
+                  const element = target as HTMLElement;
+                  const mention = elementToMentionMap.current.get(element);
+
+                  if (mention) {
+                    setPopoverContentAfterDelay(mention);
+                    mentionsPopoverAnchorRef.current = element;
+                  }
+                }
+              : undefined
+          }
+          // React types do not define `onMouseLeaveCapture`, but preact does
+          // eslint-disable-next-line react/no-unknown-property
+          onMouseLeaveCapture={
+            mentionsEnabled
+              ? () => {
+                  setPopoverContentAfterDelay(null);
+                  mentionsPopoverAnchorRef.current = null;
+                }
+              : undefined
+          }
         />
+        {mentionsEnabled && (
+          <Popover
+            open={!!popoverContent}
+            onClose={() => setPopoverContentAfterDelay(null)}
+            anchorElementRef={mentionsPopoverAnchorRef}
+            classes="px-3 py-2"
+          >
+            {popoverContent !== null && (
+              <MentionPopoverContent content={popoverContent} />
+            )}
+          </Popover>
+        )}
       </StyledText>
     </div>
   );

--- a/src/sidebar/components/mentions/MentionPopoverContent.tsx
+++ b/src/sidebar/components/mentions/MentionPopoverContent.tsx
@@ -1,0 +1,35 @@
+import type { Mention } from '../../../types/api';
+import type { InvalidUsername } from '../../helpers/mentions';
+
+export type MentionPopoverContent = {
+  content: Mention | InvalidUsername;
+};
+
+/**
+ * Information to display in a Popover when hovering over a processed mention.
+ */
+export default function MentionPopoverContent({
+  content,
+}: MentionPopoverContent) {
+  if (typeof content === 'string') {
+    return (
+      <>
+        No user with username <span className="font-bold">{content}</span>{' '}
+        exists
+      </>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-y-1.5">
+      <div data-testid="username" className="text-md font-bold">
+        @{content.username}
+      </div>
+      {content.display_name && (
+        <div data-testid="display-name" className="text-color-text-light">
+          {content.display_name}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/sidebar/components/mentions/test/MentionPopoverContent-test.js
+++ b/src/sidebar/components/mentions/test/MentionPopoverContent-test.js
@@ -1,0 +1,37 @@
+import { mount } from '@hypothesis/frontend-testing';
+
+import MentionPopoverContent from '../MentionPopoverContent';
+
+describe('MentionPopoverContent', () => {
+  function createComponent(content) {
+    return mount(<MentionPopoverContent content={content} />);
+  }
+
+  it('renders user-not-found message when InvalidUser is provided', () => {
+    const wrapper = createComponent('@invalid');
+
+    assert.equal('No user with username @invalid exists', wrapper.text());
+    assert.isFalse(wrapper.exists('[data-testid="username"]'));
+    assert.isFalse(wrapper.exists('[data-testid="display-name"]'));
+  });
+
+  it('renders username when valid mention without display name is provided', () => {
+    const wrapper = createComponent({ username: 'janedoe' });
+
+    assert.equal(wrapper.find('[data-testid="username"]').text(), '@janedoe');
+    assert.isFalse(wrapper.exists('[data-testid="display-name"]'));
+  });
+
+  it('renders username and display name when valid mention with display name is provided', () => {
+    const wrapper = createComponent({
+      username: 'janedoe',
+      display_name: 'Jane Doe',
+    });
+
+    assert.equal(wrapper.find('[data-testid="username"]').text(), '@janedoe');
+    assert.equal(
+      wrapper.find('[data-testid="display-name"]').text(),
+      'Jane Doe',
+    );
+  });
+});

--- a/src/sidebar/components/test/MarkdownView-test.js
+++ b/src/sidebar/components/test/MarkdownView-test.js
@@ -1,5 +1,9 @@
-import { checkAccessibility } from '@hypothesis/frontend-testing';
-import { mount } from '@hypothesis/frontend-testing';
+import {
+  checkAccessibility,
+  mockImportedComponents,
+  mount,
+  waitFor,
+} from '@hypothesis/frontend-testing';
 import sinon from 'sinon';
 
 import MarkdownView, { $imports } from '../MarkdownView';
@@ -8,14 +12,31 @@ describe('MarkdownView', () => {
   let fakeRenderMathAndMarkdown;
   let fakeReplaceLinksWithEmbeds;
   let fakeRenderMentionTags;
+  let fakeClearTimeout;
 
-  const markdownSelector = '[data-testid="markdown-text"]';
+  function createComponent(props = {}) {
+    return mount(
+      <MarkdownView
+        markdown=""
+        {...props}
+        setTimeout_={callback => setTimeout(callback, 0)}
+        clearTimeout_={fakeClearTimeout}
+      />,
+      { connected: true },
+    );
+  }
+
+  function getMarkdownContainer(wrapper) {
+    return wrapper.find('[data-testid="markdown-text"]');
+  }
 
   beforeEach(() => {
     fakeRenderMathAndMarkdown = markdown => `rendered:${markdown}`;
     fakeReplaceLinksWithEmbeds = sinon.stub();
     fakeRenderMentionTags = sinon.stub();
+    fakeClearTimeout = sinon.stub();
 
+    $imports.$mock(mockImportedComponents());
     $imports.$mock({
       '../render-markdown': {
         renderMathAndMarkdown: fakeRenderMathAndMarkdown,
@@ -34,58 +55,162 @@ describe('MarkdownView', () => {
   });
 
   it('renders nothing if no markdown is provided', () => {
-    const wrapper = mount(<MarkdownView />);
+    const wrapper = createComponent();
     assert.equal(wrapper.text(), '');
   });
 
   it('renders markdown as HTML', () => {
-    const wrapper = mount(<MarkdownView markdown="**test**" />);
-    const rendered = wrapper.find(markdownSelector).getDOMNode();
+    const wrapper = createComponent({ markdown: '**test**' });
+    const rendered = getMarkdownContainer(wrapper).getDOMNode();
     assert.equal(rendered.innerHTML, 'rendered:**test**');
   });
 
   it('re-renders markdown after an update', () => {
-    const wrapper = mount(<MarkdownView markdown="**test**" />);
+    const wrapper = createComponent({ markdown: '**test**' });
     wrapper.setProps({ markdown: '_updated_' });
-    const rendered = wrapper.find(markdownSelector).getDOMNode();
+    const rendered = getMarkdownContainer(wrapper).getDOMNode();
     assert.equal(rendered.innerHTML, 'rendered:_updated_');
   });
 
   it('replaces links with embeds in rendered output', () => {
-    const wrapper = mount(<MarkdownView markdown="**test**" />);
-    const rendered = wrapper.find(markdownSelector).getDOMNode();
+    const wrapper = createComponent({ markdown: '**test**' });
+    const rendered = getMarkdownContainer(wrapper).getDOMNode();
     assert.calledWith(fakeReplaceLinksWithEmbeds, rendered, {
       className: sinon.match.string,
     });
   });
 
   it('applies `textClass` class to container', () => {
-    const wrapper = mount(
-      <MarkdownView markdown="foo" classes={'fancy-effect'} />,
-    );
+    const wrapper = createComponent({
+      markdown: 'foo',
+      classes: 'fancy-effect',
+    });
     assert.isTrue(wrapper.find('.fancy-effect').exists());
   });
 
   it('applies `textStyle` style to container', () => {
-    const wrapper = mount(
-      <MarkdownView markdown="foo" style={{ fontFamily: 'serif' }} />,
-    );
-    assert.deepEqual(wrapper.find(markdownSelector).prop('style'), {
+    const wrapper = createComponent({
+      markdown: 'foo',
+      style: { fontFamily: 'serif' },
+    });
+    assert.deepEqual(getMarkdownContainer(wrapper).prop('style'), {
       fontFamily: 'serif',
     });
   });
 
   [undefined, [{}]].forEach(mentions => {
     it('renders mention tags based on provided mentions', () => {
-      mount(<MarkdownView mentions={mentions} />);
+      createComponent({ mentions });
       assert.calledWith(fakeRenderMentionTags, sinon.match.any, mentions ?? []);
+    });
+  });
+
+  context('when mentions are enabled', () => {
+    let firstMentionElement;
+    let firstMention;
+    let secondMentionElement;
+    let secondMention;
+    let notMentionElement;
+
+    function createComponentWithChildren() {
+      const wrapper = createComponent({ mentionsEnabled: true });
+      const markdownContainer = getMarkdownContainer(wrapper);
+      markdownContainer
+        .getDOMNode()
+        .append(firstMentionElement, secondMentionElement, notMentionElement);
+
+      return wrapper;
+    }
+
+    beforeEach(() => {
+      firstMentionElement = document.createElement('a');
+      firstMention = {};
+      secondMentionElement = document.createElement('span');
+      secondMention = 'invalid';
+      notMentionElement = document.createElement('span');
+      fakeRenderMentionTags.returns(
+        new Map([
+          [firstMentionElement, firstMention],
+          [secondMentionElement, secondMention],
+        ]),
+      );
+    });
+
+    afterEach(() => {
+      firstMentionElement.remove();
+      secondMentionElement.remove();
+      notMentionElement.remove();
+    });
+
+    [true, false].forEach(mentionsEnabled => {
+      it('renders Popover only if mentions are enabled', () => {
+        const wrapper = createComponent({ mentionsEnabled });
+        assert.equal(wrapper.exists('Popover'), mentionsEnabled);
+      });
+    });
+
+    [
+      {
+        getElement: () => firstMentionElement,
+        getExpectedMention: () => firstMention,
+      },
+      {
+        getElement: () => secondMentionElement,
+        getExpectedMention: () => secondMention,
+      },
+    ].forEach(({ getElement, getExpectedMention }) => {
+      it('opens popover with expected content when hovering over mention element', async () => {
+        const wrapper = createComponentWithChildren();
+
+        getElement().dispatchEvent(new MouseEvent('mouseenter'));
+        // The popover is "eventually" open after some delay
+        await waitFor(() => {
+          wrapper.update();
+          return wrapper.find('Popover').prop('open');
+        });
+        assert.equal(
+          wrapper.find('MentionPopoverContent').prop('content'),
+          getExpectedMention(),
+        );
+
+        getElement().dispatchEvent(new MouseEvent('mouseleave'));
+        wrapper.update();
+        // The popover is immediately closed
+        assert.isFalse(wrapper.find('Popover').prop('open'));
+        assert.isFalse(wrapper.exists('MentionPopoverContent'));
+      });
+    });
+
+    it('does not open popover when hovering over non-mention elements', () => {
+      const wrapper = createComponentWithChildren();
+      notMentionElement.dispatchEvent(new MouseEvent('mouseenter'));
+
+      assert.isFalse(wrapper.find('Popover').prop('open'));
+    });
+
+    it('clears timeout when removing mouse from mention before popover is opened', () => {
+      createComponentWithChildren();
+
+      firstMentionElement.dispatchEvent(new MouseEvent('mouseenter'));
+      firstMentionElement.dispatchEvent(new MouseEvent('mouseleave'));
+
+      assert.called(fakeClearTimeout);
+    });
+
+    it('clears timeout when the component is unmounted', () => {
+      const wrapper = createComponentWithChildren();
+
+      firstMentionElement.dispatchEvent(new MouseEvent('mouseenter'));
+      wrapper.unmount();
+
+      assert.called(fakeClearTimeout);
     });
   });
 
   it(
     'should pass a11y checks',
     checkAccessibility({
-      content: () => <MarkdownView markdown="foo" />,
+      content: () => createComponent({ markdown: 'foo' }),
     }),
   );
 });


### PR DESCRIPTION
Depends on https://github.com/hypothesis/client/pull/6818

Closes #6804 

Display a popover with basic user information when hovering over a highlighted valid mention, whether it is a link or not.

Additionally, display a popover indicating a user does not exist when hovering over an invalid mention.

Popovers appear with a 400ms delay, to avoid a lot of flickering when hovering over annotations.

https://github.com/user-attachments/assets/cced6e07-23ba-4c4b-b20c-74b28b02c283
