### PR TITLE
Refactor function to process mention tags

### DIFF
--- a/src/sidebar/components/MarkdownView.tsx
+++ b/src/sidebar/components/MarkdownView.tsx
@@ -10,7 +10,7 @@ import {
 
 import type { Mention } from '../../types/api';
 import type { InvalidUsername } from '../helpers/mentions';
-import { renderMentionTags } from '../helpers/mentions';
+import { processAndReplaceMentionElements } from '../helpers/mentions';
 import { replaceLinksWithEmbeds } from '../media-embedder';
 import { renderMathAndMarkdown } from '../render-markdown';
 import StyledText from './StyledText';
@@ -107,7 +107,10 @@ export default function MarkdownView(props: MarkdownViewProps) {
   }, [markdown]);
 
   useEffect(() => {
-    elementToMentionMap.current = renderMentionTags(content.current!, mentions);
+    elementToMentionMap.current = processAndReplaceMentionElements(
+      content.current!,
+      mentions,
+    );
   }, [mentions]);
 
   // NB: The following could be implemented by setting attribute props directly

--- a/src/sidebar/components/test/MarkdownView-test.js
+++ b/src/sidebar/components/test/MarkdownView-test.js
@@ -11,7 +11,7 @@ import MarkdownView, { $imports } from '../MarkdownView';
 describe('MarkdownView', () => {
   let fakeRenderMathAndMarkdown;
   let fakeReplaceLinksWithEmbeds;
-  let fakeRenderMentionTags;
+  let fakeProcessAndReplaceMentionElements;
   let fakeClearTimeout;
 
   function createComponent(props = {}) {
@@ -33,7 +33,7 @@ describe('MarkdownView', () => {
   beforeEach(() => {
     fakeRenderMathAndMarkdown = markdown => `rendered:${markdown}`;
     fakeReplaceLinksWithEmbeds = sinon.stub();
-    fakeRenderMentionTags = sinon.stub();
+    fakeProcessAndReplaceMentionElements = sinon.stub();
     fakeClearTimeout = sinon.stub();
 
     $imports.$mock(mockImportedComponents());
@@ -45,7 +45,7 @@ describe('MarkdownView', () => {
         replaceLinksWithEmbeds: fakeReplaceLinksWithEmbeds,
       },
       '../helpers/mentions': {
-        renderMentionTags: fakeRenderMentionTags,
+        processAndReplaceMentionElements: fakeProcessAndReplaceMentionElements,
       },
     });
   });
@@ -101,7 +101,11 @@ describe('MarkdownView', () => {
   [undefined, [{}]].forEach(mentions => {
     it('renders mention tags based on provided mentions', () => {
       createComponent({ mentions });
-      assert.calledWith(fakeRenderMentionTags, sinon.match.any, mentions ?? []);
+      assert.calledWith(
+        fakeProcessAndReplaceMentionElements,
+        sinon.match.any,
+        mentions ?? [],
+      );
     });
   });
 
@@ -128,7 +132,7 @@ describe('MarkdownView', () => {
       secondMentionElement = document.createElement('span');
       secondMention = 'invalid';
       notMentionElement = document.createElement('span');
-      fakeRenderMentionTags.returns(
+      fakeProcessAndReplaceMentionElements.returns(
         new Map([
           [firstMentionElement, firstMention],
           [secondMentionElement, secondMention],

--- a/src/sidebar/helpers/test/mentions-test.js
+++ b/src/sidebar/helpers/test/mentions-test.js
@@ -1,5 +1,5 @@
 import {
-  renderMentionTags,
+  processAndReplaceMentionElements,
   unwrapMentions,
   wrapMentions,
   getContainingMentionOffsets,
@@ -89,7 +89,7 @@ look at ${mentionTag('foo', 'example.com')} comment`,
   });
 });
 
-describe('renderMentionTags', () => {
+describe('processAndReplaceMentionElements', () => {
   it('processes every mention tag based on provided list of mentions', () => {
     const mentions = [
       {
@@ -110,7 +110,7 @@ describe('renderMentionTags', () => {
       <p>Mention without ID: <a data-hyp-mention="">@user_id_missing</a></p>
     `;
 
-    const result = renderMentionTags(container, mentions);
+    const result = processAndReplaceMentionElements(container, mentions);
     assert.equal(result.size, 4);
 
     const [


### PR DESCRIPTION
Closes https://github.com/orgs/hypothesis/projects/153/views/1?pane=issue&itemId=97415193

Refactor the `renderMentionTags` function, which has been renamed to `processAndReplaceMentionElements`, so that it is more obvious that it has side effects and mutates provided DOM element.