### PR TITLE
Avoid HTML characters to be encoded when unwrapping mention tags

### DIFF
--- a/src/sidebar/helpers/mentions.ts
+++ b/src/sidebar/helpers/mentions.ts
@@ -44,7 +44,7 @@ export function unwrapMentions(text: string) {
   for (const node of tmp.querySelectorAll('a[data-hyp-mention]')) {
     node.replaceWith(node.textContent ?? '');
   }
-  return tmp.innerHTML;
+  return tmp.innerText;
 }
 
 /**

--- a/src/sidebar/helpers/test/mentions-test.js
+++ b/src/sidebar/helpers/test/mentions-test.js
@@ -96,6 +96,14 @@ look at ${mentionTag('foo', 'example.com')} comment`,
     authority: 'example.com',
     textWithTags: `Hello ${mentionTag('jane.doe', 'example.com')}.`,
   },
+  // HTML chars should not be encoded
+  {
+    text: `> Quote
+Hello @jane.doe.`,
+    authority: 'example.com',
+    textWithTags: `> Quote
+Hello ${mentionTag('jane.doe', 'example.com')}.`,
+  },
 ].forEach(({ text, authority, textWithTags }) => {
   describe('wrapMentions', () => {
     it('wraps every mention in a mention tag', () => {


### PR DESCRIPTION
Closes #6849 

Make sure HTML special characters in the annotation text are not HTML-encoded as a side effect of unwrapping mention tags.

Among other things, this has broken the ability to quote text via `>`, as it was being converted to `&lt;`