### PR TITLE
Rename MentionPopover to MentionSuggestionsPopover

### DIFF
--- a/src/sidebar/components/MarkdownEditor.tsx
+++ b/src/sidebar/components/MarkdownEditor.tsx
@@ -44,7 +44,7 @@ import {
 import type { EditorState } from '../markdown-commands';
 import { getCaretCoordinates } from '../util/textarea-caret-position';
 import MarkdownView from './MarkdownView';
-import MentionPopover from './MentionPopover';
+import MentionSuggestionsPopover from './MentionSuggestionsPopover';
 
 /**
  * Toolbar commands that modify the editor state. This excludes the Help link
@@ -372,7 +372,7 @@ function TextArea({
         className="absolute top-0 left-0 w-0 h-0 pointer-events-none"
       />
       {mentionsEnabled && (
-        <MentionPopover
+        <MentionSuggestionsPopover
           open={popoverOpen}
           onClose={() => setPopoverOpen(false)}
           anchorElementRef={caretElementRef}

--- a/src/sidebar/components/MentionSuggestionsPopover.tsx
+++ b/src/sidebar/components/MentionSuggestionsPopover.tsx
@@ -7,7 +7,7 @@ export type UserItem = {
   displayName: string | null;
 };
 
-export type MentionPopoverProps = Pick<
+export type MentionSuggestionsPopoverProps = Pick<
   PopoverProps,
   'open' | 'onClose' | 'anchorElementRef'
 > & {
@@ -24,13 +24,13 @@ export type MentionPopoverProps = Pick<
 /**
  * A Popover component that displays a list of user suggestions for @mentions.
  */
-export default function MentionPopover({
+export default function MentionSuggestionsPopover({
   users,
   onSelectUser,
   highlightedSuggestion,
   usersListboxId,
   ...popoverProps
-}: MentionPopoverProps) {
+}: MentionSuggestionsPopoverProps) {
   return (
     <Popover {...popoverProps} classes="p-1">
       <ul

--- a/src/sidebar/components/test/MarkdownEditor-test.js
+++ b/src/sidebar/components/test/MarkdownEditor-test.js
@@ -415,17 +415,22 @@ describe('MarkdownEditor', () => {
     }
 
     function getHighlightedSuggestion(wrapper) {
-      return wrapper.find('MentionPopover').prop('highlightedSuggestion');
+      return wrapper
+        .find('MentionSuggestionsPopover')
+        .prop('highlightedSuggestion');
     }
 
     function suggestionsPopoverIsOpen(wrapper) {
-      return wrapper.find('MentionPopover').prop('open');
+      return wrapper.find('MentionSuggestionsPopover').prop('open');
     }
 
     [true, false].forEach(mentionsEnabled => {
       it('renders Popover if @mentions are enabled', () => {
         const wrapper = createComponent({ mentionsEnabled });
-        assert.equal(wrapper.exists('MentionPopover'), mentionsEnabled);
+        assert.equal(
+          wrapper.exists('MentionSuggestionsPopover'),
+          mentionsEnabled,
+        );
 
         // Popover is opened after typing "@"
         typeInTextarea(wrapper, '@');
@@ -493,7 +498,7 @@ describe('MarkdownEditor', () => {
       typeInTextarea(wrapper, '@johndoe');
       assert.isTrue(suggestionsPopoverIsOpen(wrapper));
 
-      wrapper.find('MentionPopover').props().onClose();
+      wrapper.find('MentionSuggestionsPopover').props().onClose();
       wrapper.update();
       assert.isFalse(suggestionsPopoverIsOpen(wrapper));
     });
@@ -631,7 +636,7 @@ describe('MarkdownEditor', () => {
         typeInTextarea(wrapper, text);
 
         assert.equal(
-          wrapper.find('MentionPopover').prop('users').length,
+          wrapper.find('MentionSuggestionsPopover').prop('users').length,
           expectedSuggestions,
         );
       });
@@ -661,9 +666,9 @@ describe('MarkdownEditor', () => {
         name: 'Suggestions popover',
         content: () => {
           $imports.$restore({
-            // We need to render MentionPopover, as some aria attributes
-            // reference elements rendered by it
-            './MentionPopover': true,
+            // We need to render MentionSuggestionsPopover, as some aria
+            // attributes reference elements rendered by it
+            './MentionSuggestionsPopover': true,
           });
 
           const wrapper = createComponent(

--- a/src/sidebar/components/test/MentionSuggestionsPopover-test.js
+++ b/src/sidebar/components/test/MentionSuggestionsPopover-test.js
@@ -2,9 +2,9 @@ import { mount } from '@hypothesis/frontend-testing';
 import { useRef } from 'preact/hooks';
 import sinon from 'sinon';
 
-import MentionPopover from '../MentionPopover';
+import MentionSuggestionsPopover from '../MentionSuggestionsPopover';
 
-describe('MentionPopover', () => {
+describe('MentionSuggestionsPopover', () => {
   const defaultUsers = [
     { username: 'one', displayName: 'johndoe' },
     { username: 'two', displayName: 'johndoe' },
@@ -16,7 +16,7 @@ describe('MentionPopover', () => {
     return (
       <div>
         <div ref={anchorRef} />
-        <MentionPopover {...props} anchorElementRef={anchorRef} />
+        <MentionSuggestionsPopover {...props} anchorElementRef={anchorRef} />
       </div>
     );
   }


### PR DESCRIPTION
This PR renames the `MentionPopover` component to `MentionSuggestionsPopover`, to disambiguate from the popover used to display a preview of a mentioned user when hovering over a rendered mention, which we frequently refer to as "mentions popover" as well.

Interestingly, the test for the now-named `MentionSuggestionsPopover` was already `MentionSuggestionsPopover-test`, so I guess that was its name at some point and we forgot to rename the test.