### PR TITLE
Include group members to the list of mention suggestions

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationEditor.tsx
+++ b/src/sidebar/components/Annotation/AnnotationEditor.tsx
@@ -8,6 +8,7 @@ import {
   isReply,
   isSaved,
 } from '../../helpers/annotation-metadata';
+import { combineUsersForMentions } from '../../helpers/mention-suggestions';
 import { applyTheme } from '../../helpers/theme';
 import { withServices } from '../../service-context';
 import type { AnnotationsService } from '../../services/annotations';
@@ -178,6 +179,10 @@ function AnnotationEditor({
   const mentionsEnabled = store.isFeatureEnabled('at_mentions');
   const usersWhoAnnotated = store.usersWhoAnnotated();
   const focusedGroupMembers = store.getFocusedGroupMembers();
+  const usersForMentions = useMemo(
+    () => combineUsersForMentions(usersWhoAnnotated, focusedGroupMembers),
+    [focusedGroupMembers, usersWhoAnnotated],
+  );
 
   useEffect(() => {
     // Load members for focused group only if not yet loaded
@@ -199,7 +204,7 @@ function AnnotationEditor({
         text={text}
         onEditText={onEditText}
         mentionsEnabled={mentionsEnabled}
-        usersForMentions={usersWhoAnnotated}
+        usersForMentions={usersForMentions}
         showHelpLink={showHelpLink}
         mentions={annotation.mentions}
       />

--- a/src/sidebar/components/MentionSuggestionsPopover.tsx
+++ b/src/sidebar/components/MentionSuggestionsPopover.tsx
@@ -11,6 +11,8 @@ export type MentionSuggestionsPopoverProps = Pick<
   PopoverProps,
   'open' | 'onClose' | 'anchorElementRef'
 > & {
+  /** Whether the list of users is currently being loaded */
+  loadingUsers: boolean;
   /** List of users to suggest */
   users: UserItem[];
   /** Index for currently highlighted suggestion */
@@ -25,6 +27,7 @@ export type MentionSuggestionsPopoverProps = Pick<
  * A Popover component that displays a list of user suggestions for @mentions.
  */
 export default function MentionSuggestionsPopover({
+  loadingUsers,
   users,
   onSelectUser,
   highlightedSuggestion,
@@ -39,36 +42,47 @@ export default function MentionSuggestionsPopover({
         aria-orientation="vertical"
         id={usersListboxId}
       >
-        {users.map((u, index) => (
-          // These options are indirectly handled via keyboard event
-          // handlers in the textarea, hence, we don't want to add keyboard
-          // event handlers here, but we want to handle click events.
-          // eslint-disable-next-line jsx-a11y/click-events-have-key-events
+        {loadingUsers ? (
           <li
-            key={u.username}
-            id={`${usersListboxId}-${u.username}`}
-            className={classnames(
-              'flex justify-between items-center gap-x-2',
-              'rounded p-2 hover:bg-grey-2',
-              {
-                'bg-grey-2': highlightedSuggestion === index,
-              },
-            )}
-            onClick={e => {
-              e.stopPropagation();
-              onSelectUser(u);
-            }}
-            role="option"
-            aria-selected={highlightedSuggestion === index}
+            className="italic p-2"
+            data-testid="suggestions-loading-indicator"
           >
-            <span className="truncate">{u.username}</span>
-            <span className="text-color-text-light">{u.displayName}</span>
+            Loading suggestions…
           </li>
-        ))}
-        {users.length === 0 && (
-          <li className="italic p-2" data-testid="suggestions-fallback">
-            No matches. You can still write the username
-          </li>
+        ) : (
+          <>
+            {users.map((u, index) => (
+              // These options are indirectly handled via keyboard event
+              // handlers in the textarea, hence, we don't want to add keyboard
+              // event handlers here, but we want to handle click events.
+              // eslint-disable-next-line jsx-a11y/click-events-have-key-events
+              <li
+                key={u.username}
+                id={`${usersListboxId}-${u.username}`}
+                className={classnames(
+                  'flex justify-between items-center gap-x-2',
+                  'rounded p-2 hover:bg-grey-2',
+                  {
+                    'bg-grey-2': highlightedSuggestion === index,
+                  },
+                )}
+                onClick={e => {
+                  e.stopPropagation();
+                  onSelectUser(u);
+                }}
+                role="option"
+                aria-selected={highlightedSuggestion === index}
+              >
+                <span className="truncate">{u.username}</span>
+                <span className="text-color-text-light">{u.displayName}</span>
+              </li>
+            ))}
+            {users.length === 0 && (
+              <li className="italic p-2" data-testid="suggestions-fallback">
+                No matches. You can still write the username
+              </li>
+            )}
+          </>
         )}
       </ul>
     </Popover>

--- a/src/sidebar/components/test/MarkdownEditor-test.js
+++ b/src/sidebar/components/test/MarkdownEditor-test.js
@@ -51,13 +51,14 @@ describe('MarkdownEditor', () => {
   });
 
   function createComponent(props = {}, mountProps = {}) {
+    const { usersForMentions = {}, ...rest } = props;
     return mount(
       <MarkdownEditor
         label="Test editor"
         text="test"
         mentionsEnabled={false}
-        usersForMentions={[]}
-        {...props}
+        usersForMentions={{ status: 'loaded', users: [], ...usersForMentions }}
+        {...rest}
       />,
       mountProps,
     );
@@ -534,11 +535,14 @@ describe('MarkdownEditor', () => {
     it('allows changing highlighted suggestion via vertical arrow keys', () => {
       const wrapper = createComponent({
         mentionsEnabled: true,
-        usersForMentions: [
-          { username: 'one', displayName: 'johndoe' },
-          { username: 'two', displayName: 'johndoe' },
-          { username: 'three', displayName: 'johndoe' },
-        ],
+        usersForMentions: {
+          status: 'loaded',
+          users: [
+            { username: 'one', displayName: 'johndoe' },
+            { username: 'two', displayName: 'johndoe' },
+            { username: 'three', displayName: 'johndoe' },
+          ],
+        },
       });
 
       typeInTextarea(wrapper, '@johndoe');
@@ -572,11 +576,14 @@ describe('MarkdownEditor', () => {
       const wrapper = createComponent({
         onEditText,
         mentionsEnabled: true,
-        usersForMentions: [
-          { username: 'one', displayName: 'johndoe' },
-          { username: 'two', displayName: 'johndoe' },
-          { username: 'three', displayName: 'johndoe' },
-        ],
+        usersForMentions: {
+          status: 'loaded',
+          users: [
+            { username: 'one', displayName: 'johndoe' },
+            { username: 'two', displayName: 'johndoe' },
+            { username: 'three', displayName: 'johndoe' },
+          ],
+        },
       });
 
       typeInTextarea(wrapper, '@johndoe');
@@ -592,16 +599,23 @@ describe('MarkdownEditor', () => {
 
     [
       // With no users, there won't be any suggestions regardless of the text
-      { usersForMentions: [], text: '@', expectedSuggestions: 0 },
+      {
+        usersForMentions: { status: 'loaded', users: [] },
+        text: '@',
+        expectedSuggestions: 0,
+      },
 
       // With users, there won't be suggestions when none of them matches the
       // mention
       {
-        usersForMentions: [
-          { username: 'one', displayName: 'johndoe' },
-          { username: 'two', displayName: 'johndoe' },
-          { username: 'three', displayName: 'johndoe' },
-        ],
+        usersForMentions: {
+          status: 'loaded',
+          users: [
+            { username: 'one', displayName: 'johndoe' },
+            { username: 'two', displayName: 'johndoe' },
+            { username: 'three', displayName: 'johndoe' },
+          ],
+        },
         text: '@nothing_will_match',
         expectedSuggestions: 0,
       },
@@ -609,20 +623,26 @@ describe('MarkdownEditor', () => {
       // With users, there will be suggestions when any of them matches the
       // mention
       {
-        usersForMentions: [
-          { username: 'one', displayName: 'johndoe' },
-          { username: 'two', displayName: 'johndoe' },
-          { username: 'three', displayName: 'johndoe' },
-        ],
+        usersForMentions: {
+          status: 'loaded',
+          users: [
+            { username: 'one', displayName: 'johndoe' },
+            { username: 'two', displayName: 'johndoe' },
+            { username: 'three', displayName: 'johndoe' },
+          ],
+        },
         text: '@two',
         expectedSuggestions: 1,
       },
       {
-        usersForMentions: [
-          { username: 'one', displayName: 'johndoe' },
-          { username: 'two', displayName: 'johndoe' },
-          { username: 'three', displayName: 'johndoe' },
-        ],
+        usersForMentions: {
+          status: 'loaded',
+          users: [
+            { username: 'one', displayName: 'johndoe' },
+            { username: 'two', displayName: 'johndoe' },
+            { username: 'three', displayName: 'johndoe' },
+          ],
+        },
         text: '@johndoe',
         expectedSuggestions: 3,
       },
@@ -640,6 +660,17 @@ describe('MarkdownEditor', () => {
           expectedSuggestions,
         );
       });
+    });
+
+    it('sets users to "loading" if users for mentions are being loaded', () => {
+      const wrapper = createComponent({
+        mentionsEnabled: true,
+        usersForMentions: { status: 'loading' },
+      });
+      const popover = wrapper.find('MentionSuggestionsPopover');
+
+      assert.isEmpty(popover.prop('users'));
+      assert.isTrue(popover.prop('loadingUsers'));
     });
   });
 
@@ -674,11 +705,14 @@ describe('MarkdownEditor', () => {
           const wrapper = createComponent(
             {
               mentionsEnabled: true,
-              usersForMentions: [
-                { username: 'one', displayName: 'johndoe' },
-                { username: 'two', displayName: 'johndoe' },
-                { username: 'three', displayName: 'johndoe' },
-              ],
+              usersForMentions: {
+                status: 'loaded',
+                users: [
+                  { username: 'one', displayName: 'johndoe' },
+                  { username: 'two', displayName: 'johndoe' },
+                  { username: 'three', displayName: 'johndoe' },
+                ],
+              },
             },
             { connected: true },
           );

--- a/src/sidebar/components/test/MentionSuggestionsPopover-test.js
+++ b/src/sidebar/components/test/MentionSuggestionsPopover-test.js
@@ -24,6 +24,7 @@ describe('MentionSuggestionsPopover', () => {
   function createComponent(props) {
     return mount(
       <TestComponent
+        loadingUsers={false}
         users={defaultUsers}
         highlightedSuggestion={0}
         onSelectUser={sinon.stub()}
@@ -38,6 +39,13 @@ describe('MentionSuggestionsPopover', () => {
     return wrapper.find('[role="option"]').at(index);
   }
 
+  it('shows loading message when users are being loaded', () => {
+    const wrapper = createComponent({ loadingUsers: true });
+    assert.isTrue(
+      wrapper.exists('[data-testid="suggestions-loading-indicator"]'),
+    );
+  });
+
   [
     { users: [], shouldRenderFallback: true },
     { users: defaultUsers, shouldRenderFallback: false },
@@ -47,6 +55,9 @@ describe('MentionSuggestionsPopover', () => {
       assert.equal(
         wrapper.exists('[data-testid="suggestions-fallback"]'),
         shouldRenderFallback,
+      );
+      assert.isFalse(
+        wrapper.exists('[data-testid="suggestions-loading-indicator"]'),
       );
     });
   });

--- a/src/sidebar/helpers/mention-suggestions.ts
+++ b/src/sidebar/helpers/mention-suggestions.ts
@@ -1,0 +1,44 @@
+import type { FocusedGroupMembers } from '../store/modules/groups';
+
+export type UserItem = {
+  username: string;
+  displayName: string | null;
+};
+
+export type UsersForMentions =
+  | { status: 'loading' }
+  | { status: 'loaded'; users: UserItem[] };
+
+/**
+ * Merge, deduplicate and sort a list of users to be used for mention suggestions.
+ * The list includes both users who already annotated the document, and members
+ * of the currently focused group.
+ *
+ * We won't return any users if the group members are being loaded, preventing a
+ * mix of some already-fetched users and a loading indicator from being shown at
+ * the same time.
+ */
+export function combineUsersForMentions(
+  usersWhoAnnotated: UserItem[],
+  focusedGroupMembers: FocusedGroupMembers,
+): UsersForMentions {
+  if (!Array.isArray(focusedGroupMembers)) {
+    return { status: 'loading' };
+  }
+
+  // Once group members are loaded, we can merge them with the users who
+  // already annotated the document, then deduplicate and sort the result.
+  const focusedGroupUsers: UserItem[] = focusedGroupMembers.map(
+    ({ username, display_name: displayName }) => ({ username, displayName }),
+  );
+  const addedUsernames = new Set<string>();
+  const users = [...usersWhoAnnotated, ...focusedGroupUsers]
+    .filter(({ username }) => {
+      const usernameAlreadyAdded = addedUsernames.has(username);
+      addedUsernames.add(username);
+      return !usernameAlreadyAdded;
+    })
+    .sort((a, b) => a.username.localeCompare(b.username));
+
+  return { status: 'loaded', users };
+}

--- a/src/sidebar/helpers/test/mention-suggestions-test.js
+++ b/src/sidebar/helpers/test/mention-suggestions-test.js
@@ -1,0 +1,57 @@
+import { combineUsersForMentions } from '../mention-suggestions';
+
+describe('combineUsersForMentions', () => {
+  [{ focusedGroupMembers: null }, { focusedGroupMembers: 'loading' }].forEach(
+    ({ focusedGroupMembers }) => {
+      it('returns "loading" status if focused group members are not loaded yet', () => {
+        assert.deepEqual(combineUsersForMentions([], focusedGroupMembers), {
+          status: 'loading',
+        });
+      });
+    },
+  );
+
+  it('merges, dedups and sorts users who already annotated with group members', () => {
+    const usersWhoAnnotated = [
+      {
+        username: 'janedoe',
+        displayName: 'Jane Doe',
+      },
+      {
+        username: 'cecilia92',
+        displayName: 'Cecelia Davenport',
+      },
+    ];
+    const focusedGroupMembers = [
+      {
+        username: 'janedoe',
+        display_name: 'Jane Doe',
+      },
+      {
+        username: 'albert',
+        display_name: 'Albert Banana',
+      },
+    ];
+
+    assert.deepEqual(
+      combineUsersForMentions(usersWhoAnnotated, focusedGroupMembers),
+      {
+        status: 'loaded',
+        users: [
+          {
+            username: 'albert',
+            displayName: 'Albert Banana',
+          },
+          {
+            username: 'cecilia92',
+            displayName: 'Cecelia Davenport',
+          },
+          {
+            username: 'janedoe',
+            displayName: 'Jane Doe',
+          },
+        ],
+      },
+    );
+  });
+});

--- a/src/sidebar/store/modules/groups.ts
+++ b/src/sidebar/store/modules/groups.ts
@@ -12,7 +12,7 @@ type GroupID = Group['id'];
  * 'loading': Members being currently loaded
  * GroupMember[]: Members already loaded
  */
-type FocusedGroupMembers = null | 'loading' | GroupMember[];
+export type FocusedGroupMembers = null | 'loading' | GroupMember[];
 
 export type State = {
   /**


### PR DESCRIPTION
Closes https://github.com/hypothesis/client/issues/6860

Enhance the list of suggested users for mentions, so that it includes not only users who already annotated the document, but also those who are explicit members of the highlighted group.

Since group members are loaded asynchronously, the first time we enter edit mode to an annotation, this PR makes sure we display a loading indicator while members are being loaded, and only then, they get merged and deduplicated with the other users that already annotated the document.

https://github.com/user-attachments/assets/3be8674e-91f3-49e9-989c-dd4767b4c20f

> [!TIP]
> This PR is easier to review [hiding whitespaces](https://github.com/hypothesis/client/pull/6862/files?w=1)

### Test steps

1. Select a group with a few members, where not all of them have created an annotation yet.
2. Create a new annotation, and type `@` to open the list of mention suggestions.
3. The list should include all group members.
4. If you open the suggestions fast enough, you may see a loading indicator the first time. You can try throttling network requests to increase the chances to see this.