### PR TITLE
Increase line height a bit in mention suggestions

### DIFF
--- a/src/sidebar/components/MentionSuggestionsPopover.tsx
+++ b/src/sidebar/components/MentionSuggestionsPopover.tsx
@@ -61,7 +61,7 @@ export default function MentionSuggestionsPopover({
                 id={`${usersListboxId}-${u.username}`}
                 className={classnames(
                   'flex justify-between items-center gap-x-2',
-                  'rounded p-2 hover:bg-grey-2',
+                  'rounded p-2 leading-4 hover:bg-grey-2',
                   {
                     'bg-grey-2': highlightedSuggestion === index,
                   },


### PR DESCRIPTION
Increase line height to fix some characters being cropped in mention suggestion usernames due to hidden overflow.

Before:

![image](https://github.com/user-attachments/assets/240f1ec2-65bd-43d3-a11c-0211649cb8fb)

After:
 
![Captura desde 2025-03-07 13-54-36](https://github.com/user-attachments/assets/8d533814-f71f-4f16-a9d0-a5803f6318d0)

The cropping is more obvious in letters like `y` and characters like the underscore.