### PR TITLE
Do not try to render mentioned user joined date if not set

### DIFF
--- a/src/sidebar/components/mentions/MentionPopoverContent.tsx
+++ b/src/sidebar/components/mentions/MentionPopoverContent.tsx
@@ -39,9 +39,11 @@ export default function MentionPopoverContent({
           {content.description}
         </div>
       )}
-      <div data-testid="created" className="text-color-text-light">
-        Joined <b>{formatDateTime(content.joined, { includeTime: false })}</b>
-      </div>
+      {content.joined && (
+        <div data-testid="joined" className="text-color-text-light">
+          Joined <b>{formatDateTime(content.joined, { includeTime: false })}</b>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/sidebar/components/mentions/test/MentionPopoverContent-test.js
+++ b/src/sidebar/components/mentions/test/MentionPopoverContent-test.js
@@ -71,6 +71,22 @@ describe('MentionPopoverContent', () => {
   });
 
   [
+    { joined: null, shouldRenderJoinedDate: false },
+    {
+      joined: '2008-02-29T13:00:00.000000+00:00',
+      shouldRenderJoinedDate: true,
+    },
+  ].forEach(({ joined, shouldRenderJoinedDate }) => {
+    it('shows join date only if set', () => {
+      const wrapper = createComponent({ username: 'janedoe', joined });
+      assert.equal(
+        wrapper.exists('[data-testid="joined"]'),
+        shouldRenderJoinedDate,
+      );
+    });
+  });
+
+  [
     '2025-01-23T15:36:52.100817+00:00',
     '2022-08-16T00:00:00.000000+00:00',
     '2008-02-29T13:00:00.000000+00:00',
@@ -78,7 +94,7 @@ describe('MentionPopoverContent', () => {
     it('formats created date', () => {
       const wrapper = createComponent({ username: 'janedoe', joined });
       assert.equal(
-        wrapper.find('[data-testid="created"]').text(),
+        wrapper.find('[data-testid="joined"]').text(),
         `Joined ${formatDateTime(joined, { includeTime: false })}`,
       );
     });

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -173,7 +173,7 @@ export type Mention = {
   /** The user description/bio */
   description: string | null;
   /** The date when the user joined, in ISO format */
-  joined: ISODateTime;
+  joined: ISODateTime | null;
 
   /**
    * The userid at the moment the mention was created.


### PR DESCRIPTION
Closes #6870 

For some users, the joined date may not be known, in which case the backend returns `joined: null`.

This PR updates the type definition and takes this case into consideration so that we do not try to render the date, and incorrectly end up showing the user joined on 1970-01-01.