### PR TITLE
Use eslint's defineConfig and globalIgnores utils

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,25 +1,24 @@
 import hypothesisBase from 'eslint-config-hypothesis/base';
 import hypothesisJSX from 'eslint-config-hypothesis/jsx';
 import hypothesisTS from 'eslint-config-hypothesis/ts';
+import { defineConfig, globalIgnores } from 'eslint/config';
 import globals from 'globals';
 
-export default [
-  {
-    ignores: [
-      '.tox/**/*',
-      '.yalc/**/*',
-      '.yarn/**/*',
-      'build/**/*',
-      '**/vendor/**/*.js',
-      '**/coverage/**/*',
-      'docs/_build/*',
-      'dev-server/static/**/*.js',
-    ],
-  },
+export default defineConfig([
+  globalIgnores([
+    '.tox/**/*',
+    '.yalc/**/*',
+    '.yarn/**/*',
+    'build/**/*',
+    '**/vendor/**/*.js',
+    '**/coverage/**/*',
+    'docs/_build/*',
+    'dev-server/static/**/*.js',
+  ]),
 
-  ...hypothesisBase,
-  ...hypothesisJSX,
-  ...hypothesisTS,
+  hypothesisBase,
+  hypothesisJSX,
+  hypothesisTS,
 
   // Annotator module
   {
@@ -54,4 +53,4 @@ export default [
       },
     },
   },
-];
+]);

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "enzyme-adapter-preact-pure": "^4.0.1",
     "escape-html": "^1.0.3",
     "escape-string-regexp": "^4.0.0",
-    "eslint": "^9.12.0",
+    "eslint": "^9.22.0",
     "eslint-config-hypothesis": "^3.2.0",
     "eslint-plugin-jsx-a11y": "^6.10.0",
     "eslint-plugin-mocha": "^10.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7423,7 +7423,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^9.12.0":
+"eslint@npm:^9.22.0":
   version: 9.22.0
   resolution: "eslint@npm:9.22.0"
   dependencies:
@@ -8973,7 +8973,7 @@ __metadata:
     enzyme-adapter-preact-pure: ^4.0.1
     escape-html: ^1.0.3
     escape-string-regexp: ^4.0.0
-    eslint: ^9.12.0
+    eslint: ^9.22.0
     eslint-config-hypothesis: ^3.2.0
     eslint-plugin-jsx-a11y: ^6.10.0
     eslint-plugin-mocha: ^10.5.0


### PR DESCRIPTION
ESLint 9.22 has introduced two small utilities that make it easier to define the flat config:

- [`defineConfig`](https://eslint.org/blog/2025/03/flat-config-extends-define-config-global-ignores/#introducing-defineconfig()-for-eslint): Generates and merges configurations in a type-safe way, and allows IDEs to autocomplete options.
- [`globalIgnores`](https://eslint.org/blog/2025/03/flat-config-extends-define-config-global-ignores/#introducing-the-globalignores()-helper): Allows to define global patterns to ignore ensuring they do not become local ignores by mistake.

This PR updates our configuration to use them.