### PR TITLE
Keep mention popover visible while mouse hovers over it

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.16.7",
     "@hypothesis/frontend-build": "^3.0.0",
-    "@hypothesis/frontend-shared": "^9.1.1",
+    "@hypothesis/frontend-shared": "^9.2.0",
     "@hypothesis/frontend-testing": "^1.3.1",
     "@npmcli/arborist": "^9.0.0",
     "@octokit/rest": "^21.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2416,15 +2416,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^9.1.1":
-  version: 9.1.1
-  resolution: "@hypothesis/frontend-shared@npm:9.1.1"
+"@hypothesis/frontend-shared@npm:^9.2.0":
+  version: 9.2.0
+  resolution: "@hypothesis/frontend-shared@npm:9.2.0"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.25.1
-  checksum: b83a4dfdd4557077c1f9dcdc90fb451474db50194060aaedacb7fadb585b0f73c37db55da7057d88621ee0fba0269d8ecb2073ae747adaf303d341c790b85bc2
+  checksum: 1775cf2ce3fe463076973e41c271707a786169ab6a271e91be642dc6beb5a8dec3d1513a313c19a647b1341c7529fc2aef1a71b836232eea0dc208ebdbb08939
   languageName: node
   linkType: hard
 
@@ -8932,7 +8932,7 @@ __metadata:
     "@babel/preset-react": ^7.0.0
     "@babel/preset-typescript": ^7.16.7
     "@hypothesis/frontend-build": ^3.0.0
-    "@hypothesis/frontend-shared": ^9.1.1
+    "@hypothesis/frontend-shared": ^9.2.0
     "@hypothesis/frontend-testing": ^1.3.1
     "@npmcli/arborist": ^9.0.0
     "@octokit/rest": ^21.0.0


### PR DESCRIPTION
~~Depends on https://github.com/hypothesis/frontend-shared/pull/1914.~~

When the mentions popover appears, keep it visible as long as the mouse is inside the rectangular region containing the mention anchor and the popover. This will allow us to add interactive elements (eg. profile links) to the popover.

This behavior is slightly different than eg. GitHub where the popover hides if the mouse goes outside a smaller non-rectangular region containing exactly the anchor and the popover. I found it was a little easy to accidentally cause the popover to hide when moving the mouse from the anchor to the popover content.

Fixes https://github.com/hypothesis/client/issues/6821.

**Testing:**

1. Create a new annotation with a valid mention
2. Hover the mention and wait for the popover to show
3. Move the mouse over the popover, or anywhere inside the highlighted region, it should remain visible.

<img width="403" alt="mention rect" src="https://github.com/user-attachments/assets/87ce11ff-59bc-4fb9-9c58-07571f2f2d8c" />

If the mouse moves over a _different_ mention which is in the highlighted region, then the popover should update.


