### PR TITLE
Reset highlighted suggestion on annotation input

### DIFF
--- a/src/sidebar/components/MarkdownEditor.tsx
+++ b/src/sidebar/components/MarkdownEditor.tsx
@@ -312,7 +312,12 @@ function TextArea({
           'focus:bg-white focus:outline-none focus:shadow-focus-inner',
           classes,
         )}
-        onInput={(e: Event) => onEditText((e.target as HTMLInputElement).value)}
+        onInput={(e: Event) => {
+          onEditText((e.target as HTMLInputElement).value);
+          // Reset highlighted suggestion every time text is edited, as that
+          // could affect the list of suggestions
+          setHighlightedSuggestion(0);
+        }}
         {...restProps}
         // We listen for `keyup` to make sure the text in the textarea reflects
         // the just-pressed key when we evaluate it

--- a/src/sidebar/components/test/MarkdownEditor-test.js
+++ b/src/sidebar/components/test/MarkdownEditor-test.js
@@ -607,6 +607,32 @@ describe('MarkdownEditor', () => {
       assert.isEmpty(popover.prop('users'));
       assert.isTrue(popover.prop('loadingUsers'));
     });
+
+    it('resets highlighted suggestion when editing textarea input', () => {
+      const wrapper = createComponent({
+        mentionsEnabled: true,
+        usersForMentions: {
+          status: 'loaded',
+          users: [
+            { username: 'one', displayName: 'johndoe' },
+            { username: 'two', displayName: 'johndoe' },
+            { username: 'three', displayName: 'johndoe' },
+          ],
+        },
+      });
+
+      typeInTextarea(wrapper, '@johndoe');
+
+      // Move highlighted suggestions down
+      keyDownInTextarea(wrapper, 'ArrowDown');
+      assert.equal(getHighlightedSuggestion(wrapper), 1);
+      keyDownInTextarea(wrapper, 'ArrowDown');
+      assert.equal(getHighlightedSuggestion(wrapper), 2);
+
+      // After input, first suggestion is highlighted again
+      wrapper.find('textarea').simulate('input');
+      assert.equal(getHighlightedSuggestion(wrapper), 0);
+    });
   });
 
   it(


### PR DESCRIPTION
When typing `@` in an annotation textarea while `@mentions` are enabled, we display the list of user suggestions. Using the up and down arrows you can move the highlighted suggestion, and apply it via <kbd>Enter</kbd>.

However, if after changing the highlighted suggestion you type something else, the list of suggested users might change, causing the highlighted suggestion to be out of bounds or be a completely different one.

This PR solves that, by making sure the first suggestion is highlighted when editing the textarea input, assuming that could change the list of suggested users.

### Test steps:

1. Enable `at_mentions` in http://localhost:5000/admin/features
2. Create an annotation, and type `@`. You should see a list of suggestions.
3. Press <kbd>ArrowDown</kbd> to change the highlighted suggestion.
4. Type something after the `@` symbol. The list of suggestions might change, and the first suggestion will be highlighted again. 