### PR TITLE
Use a relative line height in mention suggestions

### DIFF
--- a/src/sidebar/components/MentionSuggestionsPopover.tsx
+++ b/src/sidebar/components/MentionSuggestionsPopover.tsx
@@ -61,7 +61,10 @@ export default function MentionSuggestionsPopover({
                 id={`${usersListboxId}-${u.username}`}
                 className={classnames(
                   'flex justify-between items-center gap-x-2',
-                  'rounded p-2 leading-4 hover:bg-grey-2',
+                  'rounded p-2 hover:bg-grey-2',
+                  // Adjust line height relative to the font size. This avoids
+                  // vertically cropped usernames due to the use of `truncate`.
+                  'leading-tight',
                   {
                     'bg-grey-2': highlightedSuggestion === index,
                   },


### PR DESCRIPTION
In https://github.com/hypothesis/client/pull/6868, we increased the mention suggestions line height to work around a bug that was cropping some content due to the use of `truncate`.

However, that fix introduced a static line height that could cause the issue to reappear if the font size is changed in future.

This PR improves that by setting a [relative line-height](https://v3.tailwindcss.com/docs/line-height#relative-line-heights) that will increase with the font size.