### PR TITLE
Explicitly handle errors when loading focused group members

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationEditor.tsx
+++ b/src/sidebar/components/Annotation/AnnotationEditor.tsx
@@ -185,8 +185,12 @@ function AnnotationEditor({
   );
 
   useEffect(() => {
-    // Load members for focused group only if not yet loaded
-    if (mentionsEnabled && focusedGroupMembers.status === 'not-loaded') {
+    // Load members for focused group only if not yet loaded, or loading failed
+    // on previous attempt
+    if (
+      mentionsEnabled &&
+      ['not-loaded', 'error'].includes(focusedGroupMembers.status)
+    ) {
       groupsService.loadFocusedGroupMembers();
     }
   }, [focusedGroupMembers, groupsService, mentionsEnabled]);

--- a/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
@@ -420,6 +420,11 @@ describe('AnnotationEditor', () => {
         shouldLoadMembers: true,
       },
       {
+        mentionsEnabled: true,
+        focusedGroupMembers: { status: 'error' },
+        shouldLoadMembers: true,
+      },
+      {
         mentionsEnabled: false,
         focusedGroupMembers: { status: 'not-loaded' },
         shouldLoadMembers: false,

--- a/src/sidebar/services/groups.ts
+++ b/src/sidebar/services/groups.ts
@@ -507,8 +507,12 @@ export class GroupsService {
     const { signal } = this._focusedMembersController;
 
     this._store.startLoadingFocusedGroupMembers();
-    const members = await this._fetchAllMembers(groupId, signal);
-    this._store.loadFocusedGroupMembers(signal?.aborted ? null : members);
+    try {
+      const members = await this._fetchAllMembers(groupId, signal);
+      this._store.loadFocusedGroupMembers(signal?.aborted ? null : members);
+    } catch (e) {
+      this._store.focusedGroupMembersError(e);
+    }
   }
 
   private async _fetchAllMembers(

--- a/src/sidebar/services/test/groups-test.js
+++ b/src/sidebar/services/test/groups-test.js
@@ -94,6 +94,7 @@ describe('GroupsService', () => {
         getFocusedGroupMembers: sinon.stub().returns(null),
         startLoadingFocusedGroupMembers: sinon.stub(),
         loadFocusedGroupMembers: sinon.stub(),
+        focusedGroupMembersError: sinon.stub(),
       },
     );
     fakeApi = {
@@ -313,6 +314,19 @@ describe('GroupsService', () => {
 
       assert.callCount(fakeApi.group.members.read, expectedApiCalls);
       assert.calledWith(fakeStore.loadFocusedGroupMembers, null);
+    });
+
+    it('sets error status if loading group members fails', async () => {
+      fakeStore.focusedGroupId.returns('group');
+
+      const error = new Error('Failed!');
+      fakeApi.group.members.read.rejects(error);
+
+      const svc = createService();
+      await svc.loadFocusedGroupMembers();
+
+      assert.calledWith(fakeStore.focusedGroupMembersError, error);
+      assert.notCalled(fakeStore.loadFocusedGroupMembers);
     });
   });
 

--- a/src/sidebar/store/modules/groups.ts
+++ b/src/sidebar/store/modules/groups.ts
@@ -10,7 +10,8 @@ type GroupID = Group['id'];
 export type FocusedGroupMembers =
   | { status: 'not-loaded' }
   | { status: 'loading' }
-  | { status: 'loaded'; members: GroupMember[] };
+  | { status: 'loaded'; members: GroupMember[] }
+  | { status: 'error'; error: unknown };
 
 export type State = {
   /**
@@ -179,6 +180,15 @@ function loadFocusedGroupMembers(members: GroupMember[] | null) {
   });
 }
 
+function focusedGroupMembersError(error: unknown) {
+  return makeAction(reducers, 'LOAD_FOCUSED_GROUP_MEMBERS', {
+    focusedGroupMembers: {
+      status: 'error',
+      error,
+    },
+  });
+}
+
 /**
  * Return list of members for focused group.
  * Null is returned if members are being loaded or a group is not focused.
@@ -297,6 +307,7 @@ export const groupsModule = createStoreModule(initialState, {
     loadGroups,
     startLoadingFocusedGroupMembers,
     loadFocusedGroupMembers,
+    focusedGroupMembersError,
     clearGroups,
   },
   selectors: {

--- a/src/sidebar/store/modules/test/groups-test.js
+++ b/src/sidebar/store/modules/test/groups-test.js
@@ -255,6 +255,33 @@ describe('sidebar/store/modules/groups', () => {
     });
   });
 
+  describe('focusedGroupMembersError', () => {
+    it('throws if trying to set error before focusing a group', () => {
+      assert.throws(
+        () => store.focusedGroupMembersError(new Error('Error')),
+        'A group needs to be focused before loading its members',
+      );
+    });
+
+    it('sets group members status to error', () => {
+      store.loadGroups([privateGroup]);
+      store.focusGroup(privateGroup.id);
+
+      assert.equal(
+        store.getState().groups.focusedGroupMembers.status,
+        'not-loaded',
+      );
+
+      const error = new Error('Error');
+      store.focusedGroupMembersError(error);
+
+      assert.deepEqual(store.getState().groups.focusedGroupMembers, {
+        status: 'error',
+        error,
+      });
+    });
+  });
+
   describe('clearGroups', () => {
     it('clears the list of groups', () => {
       store.loadGroups([publicGroup]);


### PR DESCRIPTION
When loading focused group members we were handling thre possible statuses: `not-loaded`, `loading` and `loaded`, but we were missing an `error` status, as the possible error was not being handled properly.

This PR adds the missing `error` status, and explicitly handles errors when loading group members.

Additionally, we make sure group members are loaded both when not yet loaded, or when the last attempt failed.