### PR TITLE
Create currentUserAuthority store selector

### DIFF
--- a/src/sidebar/services/annotations.ts
+++ b/src/sidebar/services/annotations.ts
@@ -6,7 +6,6 @@ import type {
   SavedAnnotation,
 } from '../../types/api';
 import type { AnnotationEventType, SidebarSettings } from '../../types/config';
-import { parseAccountID } from '../helpers/account-id';
 import * as metadata from '../helpers/annotation-metadata';
 import { wrapMentions } from '../helpers/mentions';
 import {
@@ -48,9 +47,7 @@ export class AnnotationsService {
   private _applyDraftChanges(annotation: Annotation): Annotation {
     const changes: Partial<Annotation> = {};
     const draft = this._store.getDraft(annotation);
-    const authority =
-      parseAccountID(this._store.profile().userid)?.provider ??
-      this._store.defaultAuthority();
+    const authority = this._store.currentUserAuthority();
     const mentionsEnabled = this._store.isFeatureEnabled('at_mentions');
 
     if (draft) {

--- a/src/sidebar/services/test/annotations-test.js
+++ b/src/sidebar/services/test/annotations-test.js
@@ -69,8 +69,8 @@ describe('AnnotationsService', () => {
       selectTab: sinon.stub(),
       setExpanded: sinon.stub(),
       updateFlagStatus: sinon.stub(),
-      defaultAuthority: sinon.stub().returns('hypothes.is'),
       isFeatureEnabled: sinon.stub().returns(false),
+      currentUserAuthority: sinon.stub().returns(''),
     };
 
     setLoggedIn(true);
@@ -512,26 +512,26 @@ describe('AnnotationsService', () => {
 
     [
       {
-        profile: { userid: 'acct:foo@bar.com' },
+        currentUserAuthority: 'bar.com',
         mentionsEnabled: false,
         expectedText: 'hello @bob',
       },
       {
-        profile: { userid: 'acct:foo@bar.com' },
+        currentUserAuthority: 'bar.com',
         mentionsEnabled: true,
         expectedText:
           'hello <a data-hyp-mention="" data-userid="acct:bob@bar.com">@bob</a>',
       },
       {
-        profile: { userid: 'acct:foo' },
+        currentUserAuthority: 'hypothes.is',
         mentionsEnabled: true,
         expectedText:
           'hello <a data-hyp-mention="" data-userid="acct:bob@hypothes.is">@bob</a>',
       },
-    ].forEach(({ profile, mentionsEnabled, expectedText }) => {
+    ].forEach(({ currentUserAuthority, mentionsEnabled, expectedText }) => {
       it('wraps mentions in tags when feature is enabled', async () => {
         fakeStore.isFeatureEnabled.returns(mentionsEnabled);
-        fakeStore.profile.returns(profile);
+        fakeStore.currentUserAuthority.returns(currentUserAuthority);
         fakeStore.getDraft.returns({ text: 'hello @bob' });
 
         await svc.save(fixtures.defaultAnnotation());

--- a/src/sidebar/store/modules/session.ts
+++ b/src/sidebar/store/modules/session.ts
@@ -2,6 +2,7 @@ import { createSelector } from 'reselect';
 
 import type { Profile } from '../../../types/api';
 import type { SidebarSettings } from '../../../types/config';
+import { parseAccountID } from '../../helpers/account-id';
 import { createStoreModule, makeAction } from '../create-store';
 
 export type State = {
@@ -74,6 +75,16 @@ function defaultAuthority(state: State) {
 }
 
 /**
+ * Return current user's authority, or the default authority if a user is not
+ * logged in
+ */
+function currentUserAuthority(state: State) {
+  return (
+    parseAccountID(state.profile.userid)?.provider ?? state.defaultAuthority
+  );
+}
+
+/**
  * Return true if a user is logged in and false otherwise.
  */
 function isLoggedIn(state: State) {
@@ -140,6 +151,7 @@ export const sessionModule = createStoreModule(initialState, {
 
   selectors: {
     defaultAuthority,
+    currentUserAuthority,
     features,
     hasFetchedProfile,
     isFeatureEnabled,

--- a/src/sidebar/store/modules/test/session-test.js
+++ b/src/sidebar/store/modules/test/session-test.js
@@ -27,6 +27,33 @@ describe('sidebar/store/modules/session', () => {
     });
   });
 
+  describe('#currentUserAuthority', () => {
+    it('returns the default authority if a user is not logged in', () => {
+      fakeSettings.authDomain = 'foo.com';
+      store = createStore([sessionModule], [fakeSettings]);
+
+      assert.equal(store.currentUserAuthority(), 'foo.com');
+    });
+
+    it('returns the default authority if if current user provider could not be resolved', () => {
+      fakeSettings.authDomain = 'foo.com';
+      store = createStore([sessionModule], [fakeSettings]);
+
+      store.updateProfile({ userid: 'acct:johndoe' });
+
+      assert.equal(store.currentUserAuthority(), 'foo.com');
+    });
+
+    it('returns the logged-in user authority', () => {
+      fakeSettings.authDomain = 'foo.com';
+      store = createStore([sessionModule], [fakeSettings]);
+
+      store.updateProfile({ userid: 'acct:johndoe@example.com' });
+
+      assert.equal(store.currentUserAuthority(), 'example.com');
+    });
+  });
+
   describe('#isLoggedIn', () => {
     [
       { userid: 'john', expectedIsLoggedIn: true },


### PR DESCRIPTION
Create a new store selector in the session module that tries to get the authority from currently logged-in user's username, and falls back to the default authority otherwise.

This logis is currently used only in one place, but I'm planning to use it in other components as part of `@mentions`.