### PR TITLE
Handle mention suggestions for third party users

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationEditor.tsx
+++ b/src/sidebar/components/Annotation/AnnotationEditor.tsx
@@ -3,12 +3,14 @@ import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
 import type { Annotation } from '../../../types/api';
 import type { SidebarSettings } from '../../../types/config';
 import { serviceConfig } from '../../config/service-config';
+import { isThirdPartyUser } from '../../helpers/account-id';
 import {
   annotationRole,
   isReply,
   isSaved,
 } from '../../helpers/annotation-metadata';
 import { combineUsersForMentions } from '../../helpers/mention-suggestions';
+import type { MentionMode } from '../../helpers/mentions';
 import { applyTheme } from '../../helpers/theme';
 import { withServices } from '../../service-context';
 import type { AnnotationsService } from '../../services/annotations';
@@ -176,6 +178,15 @@ function AnnotationEditor({
 
   const textStyle = applyTheme(['annotationFontFamily'], settings);
 
+  const defaultAuthority = store.defaultAuthority();
+  const mentionMode = useMemo(
+    (): MentionMode =>
+      isThirdPartyUser(annotation.user, defaultAuthority)
+        ? 'display-name'
+        : 'username',
+    [annotation.user, defaultAuthority],
+  );
+
   const mentionsEnabled = store.isFeatureEnabled('at_mentions');
   const usersWhoAnnotated = store.usersWhoAnnotated();
   const focusedGroupMembers = store.getFocusedGroupMembers();
@@ -207,6 +218,7 @@ function AnnotationEditor({
         usersForMentions={usersForMentions}
         showHelpLink={showHelpLink}
         mentions={annotation.mentions}
+        mentionMode={mentionMode}
       />
       <TagEditor
         onAddTag={onAddTag}

--- a/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
@@ -70,6 +70,7 @@ describe('AnnotationEditor', () => {
       isFeatureEnabled: sinon.stub().returns(false),
       usersWhoAnnotated: sinon.stub().returns([]),
       getFocusedGroupMembers: sinon.stub().returns({ status: 'not-loaded' }),
+      defaultAuthority: sinon.stub().returns(''),
     };
 
     $imports.$mock(mockImportedComponents());
@@ -446,6 +447,33 @@ describe('AnnotationEditor', () => {
           shouldLoadMembers,
         );
       });
+    });
+  });
+
+  [
+    {
+      defaultAuthority: 'example.com',
+      expectedMentionMode: 'username',
+    },
+    {
+      defaultAuthority: 'foo.com',
+      expectedMentionMode: 'display-name',
+    },
+  ].forEach(({ defaultAuthority, expectedMentionMode }) => {
+    it('sets expected mention mode based on annotation author', () => {
+      fakeStore.defaultAuthority.returns(defaultAuthority);
+
+      const wrapper = createComponent({
+        annotation: {
+          ...fixtures.defaultAnnotation(),
+          user: 'acct:username@example.com',
+        },
+      });
+
+      assert.equal(
+        wrapper.find('MarkdownEditor').prop('mentionMode'),
+        expectedMentionMode,
+      );
     });
   });
 

--- a/src/sidebar/components/MarkdownEditor.tsx
+++ b/src/sidebar/components/MarkdownEditor.tsx
@@ -35,9 +35,11 @@ import type {
   UsersForMentions,
 } from '../helpers/mention-suggestions';
 import { usersMatchingMention } from '../helpers/mention-suggestions';
+import type { MentionMode } from '../helpers/mentions';
 import {
   getContainingMentionOffsets,
   termBeforePosition,
+  toPlainTextMention,
   unwrapMentions,
 } from '../helpers/mentions';
 import {
@@ -204,6 +206,7 @@ type TextAreaProps = {
   mentionsEnabled: boolean;
   usersForMentions: UsersForMentions;
   onEditText: (text: string) => void;
+  mentionMode: MentionMode;
 };
 
 function TextArea({
@@ -213,6 +216,7 @@ function TextArea({
   usersForMentions,
   onEditText,
   onKeyDown,
+  mentionMode,
   ...restProps
 }: TextAreaProps & JSX.TextareaHTMLAttributes) {
   const [popoverOpen, setPopoverOpen] = useState(false);
@@ -261,7 +265,7 @@ function TextArea({
         textarea.selectionStart,
       );
       const beforeMention = value.slice(0, start);
-      const beforeCaret = `${beforeMention}@${suggestion.username} `;
+      const beforeCaret = `${beforeMention}${toPlainTextMention(suggestion, mentionMode)} `;
       const afterMention = value.slice(end);
 
       // Set textarea value directly, set new caret position and keep it focused.
@@ -277,7 +281,7 @@ function TextArea({
       setPopoverOpen(false);
       setHighlightedSuggestion(0);
     },
-    [onEditText, textareaRef],
+    [mentionMode, onEditText, textareaRef],
   );
 
   const usersListboxId = useId();
@@ -376,6 +380,7 @@ function TextArea({
           highlightedSuggestion={highlightedSuggestion}
           onSelectUser={insertMention}
           usersListboxId={usersListboxId}
+          mentionMode={mentionMode}
         />
       )}
     </div>
@@ -547,6 +552,7 @@ export type MarkdownEditorProps = {
 
   /** List of mentions extracted from the annotation text. */
   mentions?: Mention[];
+  mentionMode: MentionMode;
 };
 
 /**
@@ -561,6 +567,7 @@ export default function MarkdownEditor({
   showHelpLink = true,
   usersForMentions,
   mentions,
+  mentionMode,
 }: MarkdownEditorProps) {
   // Whether the preview mode is currently active.
   const [preview, setPreview] = useState(false);
@@ -634,6 +641,7 @@ export default function MarkdownEditor({
           style={textStyle}
           mentionsEnabled={mentionsEnabled}
           usersForMentions={usersForMentions}
+          mentionMode={mentionMode}
         />
       )}
     </div>

--- a/src/sidebar/components/test/MentionSuggestionsPopover-test.js
+++ b/src/sidebar/components/test/MentionSuggestionsPopover-test.js
@@ -1,4 +1,4 @@
-import { mount } from '@hypothesis/frontend-testing';
+import { checkAccessibility, mount } from '@hypothesis/frontend-testing';
 import { useRef } from 'preact/hooks';
 import sinon from 'sinon';
 
@@ -28,6 +28,7 @@ describe('MentionSuggestionsPopover', () => {
         users={defaultUsers}
         highlightedSuggestion={0}
         onSelectUser={sinon.stub()}
+        mentionMode="username"
         {...props}
         open
       />,
@@ -90,4 +91,39 @@ describe('MentionSuggestionsPopover', () => {
       assert.calledWith(onSelectUser, defaultUsers[index]);
     });
   });
+
+  [
+    {
+      mentionMode: 'username',
+      shouldShowUsernames: true,
+    },
+    {
+      mentionMode: 'display-name',
+      shouldShowUsernames: false,
+    },
+  ].forEach(({ mentionMode, shouldShowUsernames }) => {
+    it('renders expected suggestions according to mention mode', () => {
+      const wrapper = createComponent({ mentionMode });
+
+      assert.equal(
+        wrapper.exists('[data-testid="username-one"]'),
+        shouldShowUsernames,
+      );
+      assert.equal(
+        wrapper.exists('[data-testid="username-two"]'),
+        shouldShowUsernames,
+      );
+      assert.equal(
+        wrapper.exists('[data-testid="username-three"]'),
+        shouldShowUsernames,
+      );
+    });
+  });
+
+  it(
+    'should pass a11y checks',
+    checkAccessibility({
+      content: () => createComponent(),
+    }),
+  );
 });

--- a/src/sidebar/helpers/mention-suggestions.ts
+++ b/src/sidebar/helpers/mention-suggestions.ts
@@ -1,6 +1,8 @@
 import type { FocusedGroupMembers } from '../store/modules/groups';
 
 export type UserItem = {
+  /** User ID in the form of acct:[username]@[authority] */
+  userid: string;
   username: string;
   displayName: string | null;
 };
@@ -29,13 +31,17 @@ export function combineUsersForMentions(
   // Once group members are loaded, we can merge them with the users who
   // already annotated the document, then deduplicate and sort the result.
   const focusedGroupUsers: UserItem[] = focusedGroupMembers.members.map(
-    ({ username, display_name: displayName }) => ({ username, displayName }),
+    ({ userid, username, display_name: displayName }) => ({
+      userid,
+      username,
+      displayName,
+    }),
   );
-  const addedUsernames = new Set<string>();
+  const addedUserIds = new Set<string>();
   const users = [...usersWhoAnnotated, ...focusedGroupUsers]
-    .filter(({ username }) => {
-      const usernameAlreadyAdded = addedUsernames.has(username);
-      addedUsernames.add(username);
+    .filter(({ userid }) => {
+      const usernameAlreadyAdded = addedUserIds.has(userid);
+      addedUserIds.add(userid);
       return !usernameAlreadyAdded;
     })
     .sort((a, b) => a.username.localeCompare(b.username));

--- a/src/sidebar/helpers/mentions.ts
+++ b/src/sidebar/helpers/mentions.ts
@@ -1,5 +1,6 @@
 import type { Mention } from '../../types/api';
 import { buildAccountID } from './account-id';
+import type { UserItem } from './mention-suggestions';
 
 // Pattern that matches characters treated as the boundary of a mention.
 const BOUNDARY_CHARS = String.raw`[\s,.;:|?!'"\-()[\]{}]`;
@@ -179,4 +180,28 @@ export function getContainingMentionOffsets(
         ? text.length
         : referencePosition + subsequentCharPos,
   };
+}
+
+/**
+ * Whether mentions should be done via username (`@username`) or display name
+ * (`@[Display Name]`).
+ *
+ * This also affects the information displayed in suggestions, which will not
+ * include the username in the second case.
+ */
+export type MentionMode = 'username' | 'display-name';
+
+/**
+ * Converts provided user into a plain-text mention (not wrapped in a mention
+ * tag).
+ *
+ * Depending on the mention mode it will return `@username` or `@[Display Name]`.
+ */
+export function toPlainTextMention(
+  user: UserItem,
+  mentionMode: MentionMode,
+): string {
+  return mentionMode === 'display-name'
+    ? `@[${user.displayName ?? ''}]`
+    : `@${user.username}`;
 }

--- a/src/sidebar/helpers/test/mention-suggestions-test.js
+++ b/src/sidebar/helpers/test/mention-suggestions-test.js
@@ -17,10 +17,12 @@ describe('combineUsersForMentions', () => {
   it('merges, dedups and sorts users who already annotated with group members', () => {
     const usersWhoAnnotated = [
       {
+        userid: 'acct:janedoe@example.com',
         username: 'janedoe',
         displayName: 'Jane Doe',
       },
       {
+        userid: 'acct:cecilia92@example.com',
         username: 'cecilia92',
         displayName: 'Cecelia Davenport',
       },
@@ -29,10 +31,12 @@ describe('combineUsersForMentions', () => {
       status: 'loaded',
       members: [
         {
+          userid: 'acct:janedoe@example.com',
           username: 'janedoe',
           display_name: 'Jane Doe',
         },
         {
+          userid: 'acct:albert@example.com',
           username: 'albert',
           display_name: 'Albert Banana',
         },
@@ -45,14 +49,17 @@ describe('combineUsersForMentions', () => {
         status: 'loaded',
         users: [
           {
+            userid: 'acct:albert@example.com',
             username: 'albert',
             displayName: 'Albert Banana',
           },
           {
+            userid: 'acct:cecilia92@example.com',
             username: 'cecilia92',
             displayName: 'Cecelia Davenport',
           },
           {
+            userid: 'acct:janedoe@example.com',
             username: 'janedoe',
             displayName: 'Jane Doe',
           },
@@ -82,9 +89,21 @@ describe('usersMatchingMention', () => {
       usersForMentions: {
         status: 'loaded',
         users: [
-          { username: 'one', displayName: 'johndoe' },
-          { username: 'two', displayName: 'johndoe' },
-          { username: 'three', displayName: 'johndoe' },
+          {
+            userid: 'acct:one@example.com',
+            username: 'one',
+            displayName: 'johndoe',
+          },
+          {
+            userid: 'acct:two@example.com',
+            username: 'two',
+            displayName: 'johndoe',
+          },
+          {
+            userid: 'acct:three@example.com',
+            username: 'three',
+            displayName: 'johndoe',
+          },
         ],
       },
       mention: 'nothing_will_match',
@@ -96,9 +115,21 @@ describe('usersMatchingMention', () => {
       usersForMentions: {
         status: 'loaded',
         users: [
-          { username: 'one', displayName: 'johndoe' },
-          { username: 'two', displayName: 'johndoe' },
-          { username: 'three', displayName: 'johndoe' },
+          {
+            userid: 'acct:one@example.com',
+            username: 'one',
+            displayName: 'johndoe',
+          },
+          {
+            userid: 'acct:two@example.com',
+            username: 'two',
+            displayName: 'johndoe',
+          },
+          {
+            userid: 'acct:three@example.com',
+            username: 'three',
+            displayName: 'johndoe',
+          },
         ],
       },
       mention: undefined,
@@ -111,28 +142,70 @@ describe('usersMatchingMention', () => {
       usersForMentions: {
         status: 'loaded',
         users: [
-          { username: 'one', displayName: 'johndoe' },
-          { username: 'two', displayName: 'johndoe' },
-          { username: 'three', displayName: 'johndoe' },
+          {
+            userid: 'acct:one@example.com',
+            username: 'one',
+            displayName: 'johndoe',
+          },
+          {
+            userid: 'acct:two@example.com',
+            username: 'two',
+            displayName: 'johndoe',
+          },
+          {
+            userid: 'acct:three@example.com',
+            username: 'three',
+            displayName: 'johndoe',
+          },
         ],
       },
       mention: 'two',
-      expectedSuggestions: [{ username: 'two', displayName: 'johndoe' }],
+      expectedSuggestions: [
+        {
+          userid: 'acct:two@example.com',
+          username: 'two',
+          displayName: 'johndoe',
+        },
+      ],
     },
     {
       usersForMentions: {
         status: 'loaded',
         users: [
-          { username: 'one', displayName: 'johndoe' },
-          { username: 'two', displayName: 'johndoe' },
-          { username: 'three', displayName: 'johndoe' },
+          {
+            userid: 'acct:one@example.com',
+            username: 'one',
+            displayName: 'johndoe',
+          },
+          {
+            userid: 'acct:two@example.com',
+            username: 'two',
+            displayName: 'johndoe',
+          },
+          {
+            userid: 'acct:three@example.com',
+            username: 'three',
+            displayName: 'johndoe',
+          },
         ],
       },
       mention: 'johndoe',
       expectedSuggestions: [
-        { username: 'one', displayName: 'johndoe' },
-        { username: 'two', displayName: 'johndoe' },
-        { username: 'three', displayName: 'johndoe' },
+        {
+          userid: 'acct:one@example.com',
+          username: 'one',
+          displayName: 'johndoe',
+        },
+        {
+          userid: 'acct:two@example.com',
+          username: 'two',
+          displayName: 'johndoe',
+        },
+        {
+          userid: 'acct:three@example.com',
+          username: 'three',
+          displayName: 'johndoe',
+        },
       ],
     },
 
@@ -141,16 +214,40 @@ describe('usersMatchingMention', () => {
       usersForMentions: {
         status: 'loaded',
         users: [
-          { username: 'one', displayName: 'johndoe' },
-          { username: 'two', displayName: 'johndoe' },
-          { username: 'three', displayName: 'johndoe' },
+          {
+            userid: 'acct:one@example.com',
+            username: 'one',
+            displayName: 'johndoe',
+          },
+          {
+            userid: 'acct:two@example.com',
+            username: 'two',
+            displayName: 'johndoe',
+          },
+          {
+            userid: 'acct:three@example.com',
+            username: 'three',
+            displayName: 'johndoe',
+          },
         ],
       },
       mention: '',
       expectedSuggestions: [
-        { username: 'one', displayName: 'johndoe' },
-        { username: 'two', displayName: 'johndoe' },
-        { username: 'three', displayName: 'johndoe' },
+        {
+          userid: 'acct:one@example.com',
+          username: 'one',
+          displayName: 'johndoe',
+        },
+        {
+          userid: 'acct:two@example.com',
+          username: 'two',
+          displayName: 'johndoe',
+        },
+        {
+          userid: 'acct:three@example.com',
+          username: 'three',
+          displayName: 'johndoe',
+        },
       ],
     },
 
@@ -159,16 +256,36 @@ describe('usersMatchingMention', () => {
       usersForMentions: {
         status: 'loaded',
         users: [
-          { username: 'one', displayName: 'johndoe' },
-          { username: 'two', displayName: 'johndoe' },
-          { username: 'three', displayName: 'johndoe' },
+          {
+            userid: 'acct:one@example.com',
+            username: 'one',
+            displayName: 'johndoe',
+          },
+          {
+            userid: 'acct:two@example.com',
+            username: 'two',
+            displayName: 'johndoe',
+          },
+          {
+            userid: 'acct:three@example.com',
+            username: 'three',
+            displayName: 'johndoe',
+          },
         ],
       },
       mention: 'johndoe',
       options: { maxUsers: 2 },
       expectedSuggestions: [
-        { username: 'one', displayName: 'johndoe' },
-        { username: 'two', displayName: 'johndoe' },
+        {
+          userid: 'acct:one@example.com',
+          username: 'one',
+          displayName: 'johndoe',
+        },
+        {
+          userid: 'acct:two@example.com',
+          username: 'two',
+          displayName: 'johndoe',
+        },
       ],
     },
   ].forEach(({ usersForMentions, mention, expectedSuggestions, options }) => {

--- a/src/sidebar/helpers/test/mentions-test.js
+++ b/src/sidebar/helpers/test/mentions-test.js
@@ -4,6 +4,7 @@ import {
   wrapMentions,
   getContainingMentionOffsets,
   termBeforePosition,
+  toPlainTextMention,
 } from '../mentions';
 
 /**
@@ -354,6 +355,29 @@ describe('processAndReplaceMentionElements', () => {
         getContainingMentionOffsets(textWithoutDollarSign, position),
         expectedOffsets,
       );
+    });
+  });
+});
+
+describe('toPlainTextMention', () => {
+  [
+    {
+      mentionMode: 'username',
+      expectedMention: '@jane_doe',
+    },
+    {
+      mentionMode: 'display-name',
+      expectedMention: '@[Jane Doe]',
+    },
+  ].forEach(({ expectedMention, mentionMode }) => {
+    it('returns expected format', () => {
+      const user = {
+        userid: 'acct:jane_doe@foo.com',
+        username: 'jane_doe',
+        displayName: 'Jane Doe',
+      };
+
+      assert.equal(toPlainTextMention(user, mentionMode), expectedMention);
     });
   });
 });

--- a/src/sidebar/store/modules/annotations.ts
+++ b/src/sidebar/store/modules/annotations.ts
@@ -35,11 +35,6 @@ type AnnotationStub = {
   $tag?: string;
 };
 
-export type UserItem = {
-  user: string;
-  displayName: string | null;
-};
-
 const initialState = {
   annotations: [],
   highlighted: {},
@@ -581,19 +576,19 @@ const usersWhoAnnotated = createSelector(
   annotations => {
     const usersMap = new Map<
       string,
-      { user: string; username: string; displayName: string | null }
+      { userid: string; username: string; displayName: string | null }
     >();
     annotations.forEach(anno => {
-      const { user } = anno;
+      const { user: userid } = anno;
 
       // Keep a unique list of users
-      if (usersMap.has(user)) {
+      if (usersMap.has(userid)) {
         return;
       }
 
-      const username = getUsername(user);
+      const username = getUsername(userid);
       const displayName = anno.user_info?.display_name ?? null;
-      usersMap.set(user, { user, username, displayName });
+      usersMap.set(userid, { userid, username, displayName });
     });
 
     // Sort users by username

--- a/src/sidebar/store/modules/test/annotations-test.js
+++ b/src/sidebar/store/modules/test/annotations-test.js
@@ -579,12 +579,12 @@ describe('sidebar/store/modules/annotations', () => {
       assert.deepEqual(
         [
           {
-            user: 'acct:janedoe@hypothes.is',
+            userid: 'acct:janedoe@hypothes.is',
             username: 'janedoe',
             displayName: 'Jane Doe',
           },
           {
-            user: 'acct:jondoe@hypothes.is',
+            userid: 'acct:jondoe@hypothes.is',
             username: 'jondoe',
             displayName: null,
           },


### PR DESCRIPTION
Part of #6886

This PR does two things:

* When building mention suggestions, include only their display name if they are third party users.
* When applying a mention suggestion, use the format `@[Display Name]` instead of `@username` if they are a third party user.

> [!NOTE]
> This PR does not cover rendering those mentions. This will come on a follow-up PR.

For third party users:

https://github.com/user-attachments/assets/62f94278-176d-46e9-9feb-cb581748cec1

For first party users everything should continue working the same:

https://github.com/user-attachments/assets/af9d76a3-e9fb-46ef-b5bc-0cc8993908bc