### PR TITLE
Wrap display-name-based mentions in mention tags

### DIFF
--- a/src/sidebar/components/MarkdownEditor.tsx
+++ b/src/sidebar/components/MarkdownEditor.tsx
@@ -207,6 +207,7 @@ type TextAreaProps = {
   usersForMentions: UsersForMentions;
   onEditText: (text: string) => void;
   mentionMode: MentionMode;
+  onInsertMentionSuggestion?: (user: UserItem) => void;
 };
 
 function TextArea({
@@ -217,6 +218,7 @@ function TextArea({
   onEditText,
   onKeyDown,
   mentionMode,
+  onInsertMentionSuggestion,
   ...restProps
 }: TextAreaProps & JSX.TextareaHTMLAttributes) {
   const [popoverOpen, setPopoverOpen] = useState(false);
@@ -276,12 +278,15 @@ function TextArea({
       // Then update state to keep it in sync.
       onEditText(textarea.value);
 
+      // Additionally, notify that a mention was inserted from a suggestion
+      onInsertMentionSuggestion?.(suggestion);
+
       // Close popover and reset highlighted suggestion once the value is
       // replaced
       setPopoverOpen(false);
       setHighlightedSuggestion(0);
     },
-    [mentionMode, onEditText, textareaRef],
+    [mentionMode, onEditText, onInsertMentionSuggestion, textareaRef],
   );
 
   const usersListboxId = useId();
@@ -553,6 +558,9 @@ export type MarkdownEditorProps = {
   /** List of mentions extracted from the annotation text. */
   mentions?: Mention[];
   mentionMode: MentionMode;
+
+  /** Invoked when a mention is inserted from a suggestion */
+  onInsertMentionSuggestion?: (suggestion: UserItem) => void;
 };
 
 /**
@@ -568,6 +576,7 @@ export default function MarkdownEditor({
   usersForMentions,
   mentions,
   mentionMode,
+  onInsertMentionSuggestion,
 }: MarkdownEditorProps) {
   // Whether the preview mode is currently active.
   const [preview, setPreview] = useState(false);
@@ -575,7 +584,10 @@ export default function MarkdownEditor({
   // The input element where the user inputs their comment.
   const input = useRef<HTMLTextAreaElement>(null);
 
-  const textWithoutMentionTags = useMemo(() => unwrapMentions(text), [text]);
+  const textWithoutMentionTags = useMemo(
+    () => unwrapMentions(text, mentionMode),
+    [mentionMode, text],
+  );
 
   useEffect(() => {
     if (!preview) {
@@ -642,6 +654,7 @@ export default function MarkdownEditor({
           mentionsEnabled={mentionsEnabled}
           usersForMentions={usersForMentions}
           mentionMode={mentionMode}
+          onInsertMentionSuggestion={onInsertMentionSuggestion}
         />
       )}
     </div>

--- a/src/sidebar/components/test/MarkdownEditor-test.js
+++ b/src/sidebar/components/test/MarkdownEditor-test.js
@@ -58,6 +58,7 @@ describe('MarkdownEditor', () => {
         text="test"
         mentionsEnabled={false}
         usersForMentions={{ status: 'loaded', users: [], ...usersForMentions }}
+        mentionMode="username"
         {...rest}
       />,
       mountProps,
@@ -573,8 +574,10 @@ describe('MarkdownEditor', () => {
 
     it('applies highlighted suggestion when `Enter` is pressed', () => {
       const onEditText = sinon.stub();
+      const onInsertMentionSuggestion = sinon.stub();
       const wrapper = createComponent({
         onEditText,
+        onInsertMentionSuggestion,
         mentionsEnabled: true,
         usersForMentions: {
           status: 'loaded',
@@ -595,6 +598,11 @@ describe('MarkdownEditor', () => {
 
       // The textarea should include the username for second suggestion
       assert.calledWith(onEditText, '@two ');
+      // Selected mention should have been passed to onInsertMentionSuggestion
+      assert.calledWith(
+        onInsertMentionSuggestion,
+        sinon.match({ username: 'two', displayName: 'johndoe' }),
+      );
     });
 
     it('sets users to "loading" if users for mentions are being loaded', () => {


### PR DESCRIPTION
Part of #6886 

This PR ensures that display-name-based mentions can be converted to mention tags while saving the annotation, and from mention tags back to plain text when entering edit mode.

https://github.com/user-attachments/assets/ea88692a-b00c-4499-acda-840351a59f4d

There are a few considerations/topics to discuss:

1. Only one mention mode at a time is currently supported. Either all mentions are username-based or all are display-name-based. We can try to consolidate this in future if we think it makes sense.
2. We are not checking what kind of mention mode is "in place" when saving annotations outside of the annotation editor, like during auto save or when importing annotations.
    The later is in fact tricky to handle, as one could export annotations from a public context (where username-based mentions were used), and the import them in a display-name-mention context.
    I'll address this issue separately.
3. In order to wrap display-name mentions in mention tags, we rely on a map of tracked applied suggestions.
    If an "unknown" mention is found (for example, one that was manually typed), we need to decide what to do. This PR simply keeps that as plain text as written, but we may try to handle it as an invalid mention instead.

Not covered by this PR:

1. Display-name mentions should not show a popover on hover. That is not addressed here.