### PR TITLE
Sort mention suggestions based on mention mode

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationEditor.tsx
+++ b/src/sidebar/components/Annotation/AnnotationEditor.tsx
@@ -234,8 +234,13 @@ function AnnotationEditor({
   const usersWhoAnnotated = store.usersWhoAnnotated();
   const focusedGroupMembers = store.getFocusedGroupMembers();
   const usersForMentions = useMemo(
-    () => combineUsersForMentions(usersWhoAnnotated, focusedGroupMembers),
-    [focusedGroupMembers, usersWhoAnnotated],
+    () =>
+      combineUsersForMentions(
+        usersWhoAnnotated,
+        focusedGroupMembers,
+        mentionMode,
+      ),
+    [focusedGroupMembers, mentionMode, usersWhoAnnotated],
   );
 
   useEffect(() => {

--- a/src/sidebar/helpers/test/mention-suggestions-test.js
+++ b/src/sidebar/helpers/test/mention-suggestions-test.js
@@ -14,7 +14,7 @@ describe('combineUsersForMentions', () => {
     },
   );
 
-  it('merges, dedups and sorts users who already annotated with group members', () => {
+  it('merges and dedups users who already annotated with group members', () => {
     const usersWhoAnnotated = [
       {
         userid: 'acct:janedoe@example.com',
@@ -44,7 +44,11 @@ describe('combineUsersForMentions', () => {
     };
 
     assert.deepEqual(
-      combineUsersForMentions(usersWhoAnnotated, focusedGroupMembers),
+      combineUsersForMentions(
+        usersWhoAnnotated,
+        focusedGroupMembers,
+        'username',
+      ),
       {
         status: 'loaded',
         users: [
@@ -66,6 +70,95 @@ describe('combineUsersForMentions', () => {
         ],
       },
     );
+  });
+
+  [
+    {
+      mentionMode: 'username',
+      expectedUsers: [
+        {
+          userid: 'acct:accent@example.com',
+          username: 'accent',
+          displayName: 'á',
+        },
+        {
+          userid: 'acct:cecilia1@example.com',
+          username: 'cecilia1',
+          displayName: 'Cecelia Davenport',
+        },
+        {
+          userid: 'acct:cecilia92@example.com',
+          username: 'cecilia92',
+          displayName: 'Cecelia Davenport',
+        },
+        {
+          userid: 'acct:no_accent@example.com',
+          username: 'no_accent',
+          displayName: 'a',
+        },
+      ],
+    },
+    {
+      mentionMode: 'display-name',
+      expectedUsers: [
+        {
+          userid: 'acct:accent@example.com',
+          username: 'accent',
+          displayName: 'á',
+        },
+        {
+          userid: 'acct:no_accent@example.com',
+          username: 'no_accent',
+          displayName: 'a',
+        },
+        {
+          userid: 'acct:cecilia1@example.com',
+          username: 'cecilia1',
+          displayName: 'Cecelia Davenport',
+        },
+        {
+          userid: 'acct:cecilia92@example.com',
+          username: 'cecilia92',
+          displayName: 'Cecelia Davenport',
+        },
+      ],
+    },
+  ].forEach(({ mentionMode, expectedUsers }) => {
+    it('sorts users differently based on mention mode', () => {
+      const usersWhoAnnotated = [
+        {
+          userid: 'acct:accent@example.com',
+          username: 'accent',
+          displayName: 'á',
+        },
+        {
+          userid: 'acct:no_accent@example.com',
+          username: 'no_accent',
+          displayName: 'a',
+        },
+        {
+          userid: 'acct:cecilia92@example.com',
+          username: 'cecilia92',
+          displayName: 'Cecelia Davenport',
+        },
+        {
+          userid: 'acct:cecilia1@example.com',
+          username: 'cecilia1',
+          displayName: 'Cecelia Davenport',
+        },
+      ];
+      assert.deepEqual(
+        combineUsersForMentions(
+          usersWhoAnnotated,
+          { status: 'loaded', members: [] },
+          mentionMode,
+        ),
+        {
+          status: 'loaded',
+          users: expectedUsers,
+        },
+      );
+    });
   });
 });
 


### PR DESCRIPTION
Closes #6904 

Ensure mention suggestions are sorted in the most sensible way depending on the mention mode.

When mention mode is `username`, we sort the list by username only, as it's a unique field that will always produce consistent results. This is the mode used for first party users:

![image](https://github.com/user-attachments/assets/9c2df2d4-1dcb-42eb-800c-754d9df8c978)

When mention mode is `display-name`, we sort the list by display name first, and then by username so that when duplicated display names appear, the list is consistently sorted:

![image](https://github.com/user-attachments/assets/6a960de3-8627-4451-a63b-d277ff4a18fa)
