### PR TITLE
Use most recent username or display name when unwrapping mention tags

### DIFF
--- a/src/sidebar/components/MarkdownEditor.tsx
+++ b/src/sidebar/components/MarkdownEditor.tsx
@@ -585,8 +585,8 @@ export default function MarkdownEditor({
   const input = useRef<HTMLTextAreaElement>(null);
 
   const textWithoutMentionTags = useMemo(
-    () => unwrapMentions(text, mentionMode),
-    [mentionMode, text],
+    () => unwrapMentions({ text, mentionMode, mentions }),
+    [mentionMode, mentions, text],
   );
 
   useEffect(() => {

--- a/src/sidebar/helpers/test/mentions-test.js
+++ b/src/sidebar/helpers/test/mentions-test.js
@@ -134,7 +134,10 @@ Hello ${mentionTag('jane.doe', 'example.com')}.`,
 
   describe('unwrapMentions - `username` mode', () => {
     it('removes wrapping mention tags', () => {
-      assert.equal(unwrapMentions(textWithTags, 'username'), text);
+      assert.equal(
+        unwrapMentions({ text: textWithTags, mentionMode: 'username' }),
+        text,
+      );
     });
   });
 });
@@ -211,7 +214,88 @@ Hello ${mentionTag('jane.doe', 'example.com')}.`,
 
   describe('unwrapMentions - `display-name` mode', () => {
     it('removes wrapping mention tags', () => {
-      assert.equal(unwrapMentions(textWithTags, 'display-name'), text);
+      assert.equal(
+        unwrapMentions({ text: textWithTags, mentionMode: 'display-name' }),
+        text,
+      );
+    });
+  });
+});
+
+describe('unwrapMentions', () => {
+  [
+    // Mention not found. Tag content kept
+    {
+      mentionMode: 'username',
+      mentions: [],
+      text: `Hello ${mentionTag('jane_doe')}`,
+      expectedResult: 'Hello @jane_doe',
+    },
+    {
+      mentionMode: 'display-name',
+      mentions: [],
+      text: `Hello ${displayNameMentionTag('Jane Doe', 'jane_doe')}`,
+      expectedResult: 'Hello @[Jane Doe]',
+    },
+
+    // Mention found with a new username
+    {
+      mentionMode: 'username',
+      mentions: [
+        {
+          original_userid: 'acct:jane_doe@hypothes.is',
+          username: 'jane_edited',
+        },
+      ],
+      text: `Hello ${mentionTag('jane_doe')}`,
+      expectedResult: 'Hello @jane_edited',
+    },
+
+    // Mention found with a new display name
+    {
+      mentionMode: 'display-name',
+      mentions: [
+        {
+          original_userid: 'acct:jane_doe@hypothes.is',
+          display_name: 'My new name',
+        },
+      ],
+      text: `Hello ${displayNameMentionTag('Jane Doe', 'jane_doe')}`,
+      expectedResult: 'Hello @[My new name]',
+    },
+
+    // Mention found with a now empty display name
+    {
+      mentionMode: 'display-name',
+      mentions: [
+        {
+          original_userid: 'acct:jane_doe@hypothes.is',
+          display_name: '',
+        },
+      ],
+      text: `Hello ${displayNameMentionTag('Jane Doe', 'jane_doe')}`,
+      expectedResult: 'Hello @[Jane Doe]',
+    },
+
+    // data-userid not present
+    {
+      mentionMode: 'username',
+      mentions: [],
+      text: 'Hello <a data-hyp-mention="">@user_id_missing</a>',
+      expectedResult: 'Hello @user_id_missing',
+    },
+    {
+      mentionMode: 'display-name',
+      mentions: [],
+      text: 'Hello <a data-hyp-mention="">@User ID Missing</a>',
+      expectedResult: 'Hello @[User ID Missing]',
+    },
+  ].forEach(({ text, mentionMode, mentions, expectedResult }) => {
+    it('replaces mention tag with current username or display name', () => {
+      assert.equal(
+        unwrapMentions({ text, mentionMode, mentions }),
+        expectedResult,
+      );
     });
   });
 });


### PR DESCRIPTION
Closes #6906 

So far, when unwrapping an `a[data-hyp-mention]` tag into its plain-text representation, we were always relying on the hardcoded content of the tag.

This PR ensures the tag is matched against a list of `Mention` objects, so that we unwrap to the most recent username or display name instead, ensuring the mention will continue working after wrapping it back, and it will also display the value users expect.

This PR does not cover doing the same when rendering a mention tag. There's a separate issue for that https://github.com/hypothesis/client/issues/6909

### Todo

- [x] Add tests that cover the logic when username or display name have a different value in the `mentions` list.