### PR TITLE
Remove square brackets from display names before using in mention

### DIFF
--- a/src/sidebar/helpers/mentions.ts
+++ b/src/sidebar/helpers/mentions.ts
@@ -81,7 +81,7 @@ export function wrapDisplayNameMentions(
       // TODO Should we still build a mention tag so that it renders as an
       //      invalid mention instead of plain text?
       if (!suggestion) {
-        return `${precedingChar}@[${displayName}]`;
+        return `${precedingChar}${displayNameMention(displayName)}`;
       }
 
       const mentionTag = buildMentionTag(suggestion.userid, `@${displayName}`);
@@ -145,7 +145,7 @@ export function unwrapMentions({
       : // Using || rather than ?? for the display name, to avoid setting an
         // empty string if the user used to have a display name and has been
         // removed since the mention was created
-        `@[${mention?.display_name || tagContent}]`;
+        displayNameMention(mention?.display_name || tagContent);
   });
 }
 
@@ -296,6 +296,18 @@ export function toPlainTextMention(
   mentionMode: MentionMode,
 ): string {
   return mentionMode === 'display-name'
-    ? `@[${user.displayName ?? ''}]`
+    ? displayNameMention(user.displayName ?? '')
     : `@${user.username}`;
+}
+
+/**
+ * Convert a display name into a plain-text mention.
+ * `Display Name` -> `@[Display Name]`
+ *
+ * Square brackets are removed from it, as they are reserved to delimit the
+ * beginning and end of the display name itself.
+ * `Foo [Bar]` -> `@[Foo Bar]`
+ */
+function displayNameMention(displayName: string): string {
+  return `@[${displayName.replace(/[[\]]/g, '')}]`;
 }

--- a/src/sidebar/helpers/test/mentions-test.js
+++ b/src/sidebar/helpers/test/mentions-test.js
@@ -556,4 +556,17 @@ describe('toPlainTextMention', () => {
       assert.equal(toPlainTextMention(user, mentionMode), expectedMention);
     });
   });
+
+  it('removes square brackets in display-name mode', () => {
+    const user = {
+      userid: 'acct:jane_doe@foo.com',
+      username: 'jane_doe',
+      displayName: 'Jane [Doe] [More Brackets]',
+    };
+
+    assert.equal(
+      toPlainTextMention(user, 'display-name'),
+      '@[Jane Doe More Brackets]',
+    );
+  });
 });


### PR DESCRIPTION
Depends on https://github.com/hypothesis/client/pull/6908

Closes #6891 

Remove any appearance of `[` and `]` from display-name mentions, since those characters are reserved to delimit the display name itself.

This is something that is rare to occur, and in most cases dropping those characters should not cause any confusion.