### PR TITLE
Use different shades of gray for highlighted and hovered suggestions

### DIFF
--- a/src/sidebar/components/MentionSuggestionsPopover.tsx
+++ b/src/sidebar/components/MentionSuggestionsPopover.tsx
@@ -31,13 +31,13 @@ function SuggestionItem({
       key={user.username}
       id={`${usersListboxId}-${user.username}`}
       className={classnames(
-        'flex justify-between items-center gap-x-2',
-        'rounded p-2 hover:bg-grey-2',
+        'flex justify-between items-center gap-x-2 rounded p-2',
         // Adjust line height relative to the font size. This avoids
         // vertically cropped usernames due to the use of `truncate`.
         'leading-tight',
         {
-          'bg-grey-2': highlighted,
+          'hover:bg-grey-1': !highlighted,
+          'bg-grey-3': highlighted,
         },
       )}
       onClick={e => {


### PR DESCRIPTION
Closes #6911 

Make sure it never looks like there's two highlighted mention suggestions at once, because one is the highlighted one and another one is being hovered.

This is achieved by using different shades of grey for highlighted and hovered suggestions.

https://github.com/user-attachments/assets/2326926e-50ef-46cb-9172-516df94c7fb6

> Inspired by hog GitHub handles this.