### PR TITLE
Style highlighted mention via ring instead of bg color

### DIFF
--- a/src/sidebar/components/MentionSuggestionsPopover.tsx
+++ b/src/sidebar/components/MentionSuggestionsPopover.tsx
@@ -37,7 +37,7 @@ function SuggestionItem({
         // vertically cropped usernames due to the use of `truncate`.
         'leading-tight',
         {
-          'bg-grey-2': highlighted,
+          'ring-2 z-10 relative': highlighted,
         },
       )}
       onClick={e => {


### PR DESCRIPTION
Closes #6911 

Make sure it never looks like there's two highlighted mention suggestions at once, because one is the highlighted one and another one is being hovered.

This is achieved by using a ring for highlighted suggestion, and a different background color for hovered suggestions.

The ring resembles the style we use for focused elements when interacting with them with the keyboard, so it's consistent with other UI controls.

https://github.com/user-attachments/assets/673de9db-8924-4bc1-b3b8-719010631489

