### PR TITLE
Use most recent username or display name when rendering mentions

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationBody.tsx
+++ b/src/sidebar/components/Annotation/AnnotationBody.tsx
@@ -6,6 +6,7 @@ import type { Annotation } from '../../../types/api';
 import type { SidebarSettings } from '../../../types/config';
 import { isThirdPartyUser } from '../../helpers/account-id';
 import { isHidden } from '../../helpers/annotation-metadata';
+import type { MentionMode } from '../../helpers/mentions';
 import { applyTheme } from '../../helpers/theme';
 import { withServices } from '../../service-context';
 import { useSidebarStore } from '../../store';
@@ -80,10 +81,13 @@ function AnnotationBody({ annotation, settings }: AnnotationBodyProps) {
 
   const textStyle = applyTheme(['annotationFontFamily'], settings);
 
-  const shouldLinkTags = useMemo(
-    () => annotation && !isThirdPartyUser(annotation?.user, defaultAuthority),
+  const authorIsThirdParty = useMemo(
+    () => isThirdPartyUser(annotation.user, defaultAuthority),
     [annotation, defaultAuthority],
   );
+  const mentionMode: MentionMode = authorIsThirdParty
+    ? 'display-name'
+    : 'username';
 
   const createTagSearchURL = (tag: string) => {
     return store.getLink('search.tag', { tag });
@@ -108,6 +112,7 @@ function AnnotationBody({ annotation, settings }: AnnotationBodyProps) {
             style={textStyle}
             mentions={annotation.mentions}
             mentionsEnabled={mentionsEnabled}
+            mentionMode={mentionMode}
           />
         </Excerpt>
       )}
@@ -122,7 +127,9 @@ function AnnotationBody({ annotation, settings }: AnnotationBodyProps) {
                       key={tag}
                       tag={tag}
                       href={
-                        shouldLinkTags ? createTagSearchURL(tag) : undefined
+                        !authorIsThirdParty
+                          ? createTagSearchURL(tag)
+                          : undefined
                       }
                     />
                   );

--- a/src/sidebar/components/MarkdownEditor.tsx
+++ b/src/sidebar/components/MarkdownEditor.tsx
@@ -633,6 +633,7 @@ export default function MarkdownEditor({
           style={textStyle}
           mentions={mentions}
           mentionsEnabled={mentionsEnabled}
+          mentionMode={mentionMode}
         />
       ) : (
         <TextArea

--- a/src/sidebar/components/MarkdownView.tsx
+++ b/src/sidebar/components/MarkdownView.tsx
@@ -10,7 +10,7 @@ import {
 } from 'preact/hooks';
 
 import type { Mention } from '../../types/api';
-import type { InvalidUsername } from '../helpers/mentions';
+import type { InvalidMentionContent, MentionMode } from '../helpers/mentions';
 import { processAndReplaceMentionElements } from '../helpers/mentions';
 import { replaceLinksWithEmbeds } from '../media-embedder';
 import { renderMathAndMarkdown } from '../render-markdown';
@@ -55,6 +55,7 @@ export type MarkdownViewProps = {
   classes?: string;
   style?: Record<string, string>;
   mentions?: Mention[];
+  mentionMode: MentionMode;
 
   /**
    * Whether the at-mentions feature ir enabled or not.
@@ -67,7 +68,7 @@ export type MarkdownViewProps = {
   clearTimeout_?: typeof clearTimeout;
 };
 
-type PopoverContent = Mention | InvalidUsername | null;
+type PopoverContent = Mention | InvalidMentionContent | null;
 
 /**
  * A component which renders markdown as HTML, replaces recognized links with
@@ -81,6 +82,7 @@ export default function MarkdownView(props: MarkdownViewProps) {
     style,
     mentions = [],
     mentionsEnabled = false,
+    mentionMode,
     setTimeout_ = setTimeout,
     clearTimeout_ = clearTimeout,
   } = props;
@@ -94,7 +96,7 @@ export default function MarkdownView(props: MarkdownViewProps) {
   const mentionsPopoverRef = useRef<HTMLElement>(null);
 
   const elementToMentionMap = useRef(
-    new Map<HTMLElement, Mention | InvalidUsername>(),
+    new Map<HTMLElement, Mention | InvalidMentionContent>(),
   );
   const [popoverContent, setPopoverContent] = useState<PopoverContent>(null);
   const popoverContentTimeout = useRef<ReturnType<typeof setTimeout> | null>();
@@ -145,8 +147,9 @@ export default function MarkdownView(props: MarkdownViewProps) {
     elementToMentionMap.current = processAndReplaceMentionElements(
       content.current!,
       mentions,
+      mentionMode,
     );
-  }, [mentions]);
+  }, [mentionMode, mentions]);
 
   // Monitor mouse position when mentions popover is visible and hide when it
   // goes outside the anchor or popover.

--- a/src/sidebar/components/mentions/MentionPopoverContent.tsx
+++ b/src/sidebar/components/mentions/MentionPopoverContent.tsx
@@ -1,10 +1,10 @@
 import { formatDateTime } from '@hypothesis/frontend-shared';
 
 import type { Mention } from '../../../types/api';
-import type { InvalidUsername } from '../../helpers/mentions';
+import type { InvalidMentionContent } from '../../helpers/mentions';
 
 export type MentionPopoverContent = {
-  content: Mention | InvalidUsername;
+  content: Mention | InvalidMentionContent;
 };
 
 /**

--- a/src/sidebar/components/test/MarkdownView-test.js
+++ b/src/sidebar/components/test/MarkdownView-test.js
@@ -18,6 +18,7 @@ describe('MarkdownView', () => {
     return mount(
       <MarkdownView
         markdown=""
+        mentionMode="username"
         {...props}
         setTimeout_={callback => setTimeout(callback, 0)}
         clearTimeout_={fakeClearTimeout}
@@ -98,13 +99,17 @@ describe('MarkdownView', () => {
     });
   });
 
-  [undefined, [{}]].forEach(mentions => {
+  [
+    { mentions: undefined, mentionMode: 'username' },
+    { mentions: [{}], mentionMode: 'display-name' },
+  ].forEach(({ mentions, mentionMode }) => {
     it('renders mention tags based on provided mentions', () => {
-      createComponent({ mentions });
+      createComponent({ mentions, mentionMode });
       assert.calledWith(
         fakeProcessAndReplaceMentionElements,
         sinon.match.any,
         mentions ?? [],
+        mentionMode,
       );
     });
   });

--- a/src/sidebar/helpers/test/mentions-test.js
+++ b/src/sidebar/helpers/test/mentions-test.js
@@ -321,7 +321,11 @@ describe('processAndReplaceMentionElements', () => {
       <p>Mention without ID: <a data-hyp-mention="">@user_id_missing</a></p>
     `;
 
-    const result = processAndReplaceMentionElements(container, mentions);
+    const result = processAndReplaceMentionElements(
+      container,
+      mentions,
+      'username',
+    );
     assert.equal(result.size, 4);
 
     const [
@@ -391,7 +395,11 @@ describe('processAndReplaceMentionElements', () => {
       invalidProcessedMention,
     );
 
-    const result = processAndReplaceMentionElements(container, mentions);
+    const result = processAndReplaceMentionElements(
+      container,
+      mentions,
+      'username',
+    );
     assert.equal(result.size, 3);
 
     const [
@@ -408,6 +416,50 @@ describe('processAndReplaceMentionElements', () => {
 
     assert.equal(thirdElement, invalidProcessedMention);
     assert.equal(thirdMention, '@invalid');
+  });
+
+  [
+    {
+      mentionMode: 'username',
+      oldContent: '@janedoe',
+      mention: { username: 'janedoe_updated' },
+      expectedContent: '@janedoe_updated',
+    },
+    {
+      mentionMode: 'display-name',
+      oldContent: '@Jane Doe',
+      mention: { display_name: 'Jane Doe Updated' },
+      expectedContent: '@Jane Doe Updated',
+    },
+    {
+      mentionMode: 'display-name',
+      oldContent: '@Jane Doe',
+      mention: { display_name: '' },
+      expectedContent: '@Jane Doe',
+    },
+  ].forEach(({ mentionMode, oldContent, mention, expectedContent }) => {
+    it('returns most recent usernames or display names', () => {
+      const mentions = [
+        {
+          userid: 'acct:janedoe@hypothes.is',
+          ...mention,
+        },
+      ];
+      const container = document.createElement('div');
+      container.innerHTML = mentionElement({
+        username: 'janedoe',
+        content: oldContent,
+      }).outerHTML;
+
+      const result = processAndReplaceMentionElements(
+        container,
+        mentions,
+        mentionMode,
+      );
+      const [[mentionEl]] = [...result.entries()];
+
+      assert.equal(mentionEl.textContent, expectedContent);
+    });
   });
 });
 


### PR DESCRIPTION
Closes #6909

When rendering an annotation tag, check if the corresponding mention object contains a more recent display name or username (depending on the mention mode) and use it instead of the one hardcoded in the tag.

For invalid mentions we still rely in the hardcoded tag content.