### PR TITLE
Avoid suggestions popover scroll when 10 items are displayed

### DIFF
--- a/src/sidebar/components/MentionSuggestionsPopover.tsx
+++ b/src/sidebar/components/MentionSuggestionsPopover.tsx
@@ -99,7 +99,16 @@ export default function MentionSuggestionsPopover({
   ...popoverProps
 }: MentionSuggestionsPopoverProps) {
   return (
-    <Popover {...popoverProps} classes="p-1">
+    <Popover
+      {...popoverProps}
+      classes={classnames('p-1', [
+        // Popovers have a default max-h-80, which only fits a bit more than 9
+        // suggestions at their current height.
+        // Since we cap at 10 suggestions, increasing this max height prevents
+        // scrollbars to appear.
+        '!max-h-96',
+      ])}
+    >
       <ul
         className="flex-col gap-y-0.5"
         role="listbox"


### PR DESCRIPTION
The `Popover` component has an implicit `max-h-80` class, which makes it render a scrollbar when there is more than 9 suggestions to display (that height can fit like 9 and a half items).

Since we cap the max amount of suggestions to 10, it's a bit ugly that the scrollbar appears at that point, so this PR increases the max height, ensuring no scroll is displayed unless there's not enough vertical space to render the whole popover.

This is how 10 suggestions look with this change:

![image](https://github.com/user-attachments/assets/b8fdc61a-4ad6-4f0e-8d7b-15eec6cadfb5)

And this is how it looks in `main` branch:

![image](https://github.com/user-attachments/assets/6c9a4d07-53d8-49d4-889e-0035346af9fc)