### PR TITLE
Include already mentioned users in mention suggestions

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationEditor.tsx
+++ b/src/sidebar/components/Annotation/AnnotationEditor.tsx
@@ -232,15 +232,22 @@ function AnnotationEditor({
 
   const mentionsEnabled = store.isFeatureEnabled('at_mentions');
   const usersWhoAnnotated = store.usersWhoAnnotated();
+  const usersWhoWereMentioned = store.usersWhoWereMentioned();
   const focusedGroupMembers = store.getFocusedGroupMembers();
   const usersForMentions = useMemo(
     () =>
-      combineUsersForMentions(
+      combineUsersForMentions({
         usersWhoAnnotated,
+        usersWhoWereMentioned,
         focusedGroupMembers,
         mentionMode,
-      ),
-    [focusedGroupMembers, mentionMode, usersWhoAnnotated],
+      }),
+    [
+      focusedGroupMembers,
+      mentionMode,
+      usersWhoAnnotated,
+      usersWhoWereMentioned,
+    ],
   );
 
   useEffect(() => {

--- a/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
@@ -69,6 +69,7 @@ describe('AnnotationEditor', () => {
       removeAnnotations: sinon.stub(),
       isFeatureEnabled: sinon.stub().returns(false),
       usersWhoAnnotated: sinon.stub().returns([]),
+      usersWhoWereMentioned: sinon.stub().returns([]),
       getFocusedGroupMembers: sinon.stub().returns({ status: 'not-loaded' }),
       defaultAuthority: sinon.stub().returns(''),
     };

--- a/src/sidebar/helpers/mention-suggestions.ts
+++ b/src/sidebar/helpers/mention-suggestions.ts
@@ -12,6 +12,13 @@ export type UsersForMentions =
   | { status: 'loading' }
   | { status: 'loaded'; users: UserItem[] };
 
+export type CombineUsersOptions = {
+  usersWhoAnnotated: UserItem[];
+  usersWhoWereMentioned: UserItem[];
+  focusedGroupMembers: FocusedGroupMembers;
+  mentionMode: MentionMode;
+};
+
 /**
  * Merge, deduplicate and sort a list of users to be used for mention suggestions.
  * The list includes both users who already annotated the document, and members
@@ -26,11 +33,12 @@ export type UsersForMentions =
  * mix of some already-fetched users and a loading indicator from being shown at
  * the same time.
  */
-export function combineUsersForMentions(
-  usersWhoAnnotated: UserItem[],
-  focusedGroupMembers: FocusedGroupMembers,
-  mentionMode: MentionMode,
-): UsersForMentions {
+export function combineUsersForMentions({
+  usersWhoAnnotated,
+  usersWhoWereMentioned,
+  focusedGroupMembers,
+  mentionMode,
+}: CombineUsersOptions): UsersForMentions {
   if (focusedGroupMembers.status !== 'loaded') {
     return { status: 'loading' };
   }
@@ -45,7 +53,11 @@ export function combineUsersForMentions(
     }),
   );
   const addedUserIds = new Set<string>();
-  const users = [...usersWhoAnnotated, ...focusedGroupUsers]
+  const users = [
+    ...usersWhoAnnotated,
+    ...usersWhoWereMentioned,
+    ...focusedGroupUsers,
+  ]
     .filter(({ userid }) => {
       const usernameAlreadyAdded = addedUserIds.has(userid);
       addedUserIds.add(userid);

--- a/src/sidebar/helpers/test/mention-suggestions-test.js
+++ b/src/sidebar/helpers/test/mention-suggestions-test.js
@@ -7,14 +7,21 @@ describe('combineUsersForMentions', () => {
   [{ status: 'not-loaded' }, { status: 'loading' }].forEach(
     focusedGroupMembers => {
       it('returns "loading" status if focused group members are not loaded yet', () => {
-        assert.deepEqual(combineUsersForMentions([], focusedGroupMembers), {
-          status: 'loading',
-        });
+        assert.deepEqual(
+          combineUsersForMentions({
+            usersWhoAnnotated: [],
+            usersWhoWereMentioned: [],
+            focusedGroupMembers,
+          }),
+          {
+            status: 'loading',
+          },
+        );
       });
     },
   );
 
-  it('merges and dedups users who already annotated with group members', () => {
+  it('merges and dedups users who already annotated, mentioned users and group members', () => {
     const usersWhoAnnotated = [
       {
         userid: 'acct:janedoe@example.com',
@@ -22,8 +29,20 @@ describe('combineUsersForMentions', () => {
         displayName: 'Jane Doe',
       },
       {
-        userid: 'acct:cecilia92@example.com',
-        username: 'cecilia92',
+        userid: 'acct:cecelia92@example.com',
+        username: 'cecelia92',
+        displayName: 'Cecelia Davenport',
+      },
+    ];
+    const usersWhoWereMentioned = [
+      {
+        userid: 'acct:johndoe@example.com',
+        username: 'johndoe',
+        displayName: 'John Doe',
+      },
+      {
+        userid: 'acct:cecelia92@example.com',
+        username: 'cecelia92',
         displayName: 'Cecelia Davenport',
       },
     ];
@@ -44,11 +63,12 @@ describe('combineUsersForMentions', () => {
     };
 
     assert.deepEqual(
-      combineUsersForMentions(
+      combineUsersForMentions({
         usersWhoAnnotated,
+        usersWhoWereMentioned,
         focusedGroupMembers,
-        'username',
-      ),
+        mentionMode: 'username',
+      }),
       {
         status: 'loaded',
         users: [
@@ -58,14 +78,19 @@ describe('combineUsersForMentions', () => {
             displayName: 'Albert Banana',
           },
           {
-            userid: 'acct:cecilia92@example.com',
-            username: 'cecilia92',
+            userid: 'acct:cecelia92@example.com',
+            username: 'cecelia92',
             displayName: 'Cecelia Davenport',
           },
           {
             userid: 'acct:janedoe@example.com',
             username: 'janedoe',
             displayName: 'Jane Doe',
+          },
+          {
+            userid: 'acct:johndoe@example.com',
+            username: 'johndoe',
+            displayName: 'John Doe',
           },
         ],
       },
@@ -82,13 +107,13 @@ describe('combineUsersForMentions', () => {
           displayName: 'á',
         },
         {
-          userid: 'acct:cecilia1@example.com',
-          username: 'cecilia1',
+          userid: 'acct:cecelia1@example.com',
+          username: 'cecelia1',
           displayName: 'Cecelia Davenport',
         },
         {
-          userid: 'acct:cecilia92@example.com',
-          username: 'cecilia92',
+          userid: 'acct:cecelia92@example.com',
+          username: 'cecelia92',
           displayName: 'Cecelia Davenport',
         },
         {
@@ -112,13 +137,13 @@ describe('combineUsersForMentions', () => {
           displayName: 'a',
         },
         {
-          userid: 'acct:cecilia1@example.com',
-          username: 'cecilia1',
+          userid: 'acct:cecelia1@example.com',
+          username: 'cecelia1',
           displayName: 'Cecelia Davenport',
         },
         {
-          userid: 'acct:cecilia92@example.com',
-          username: 'cecilia92',
+          userid: 'acct:cecelia92@example.com',
+          username: 'cecelia92',
           displayName: 'Cecelia Davenport',
         },
       ],
@@ -137,22 +162,23 @@ describe('combineUsersForMentions', () => {
           displayName: 'a',
         },
         {
-          userid: 'acct:cecilia92@example.com',
-          username: 'cecilia92',
+          userid: 'acct:cecelia92@example.com',
+          username: 'cecelia92',
           displayName: 'Cecelia Davenport',
         },
         {
-          userid: 'acct:cecilia1@example.com',
-          username: 'cecilia1',
+          userid: 'acct:cecelia1@example.com',
+          username: 'cecelia1',
           displayName: 'Cecelia Davenport',
         },
       ];
       assert.deepEqual(
-        combineUsersForMentions(
+        combineUsersForMentions({
           usersWhoAnnotated,
-          { status: 'loaded', members: [] },
+          usersWhoWereMentioned: [],
+          focusedGroupMembers: { status: 'loaded', members: [] },
           mentionMode,
-        ),
+        }),
         {
           status: 'loaded',
           users: expectedUsers,

--- a/src/sidebar/store/modules/annotations.ts
+++ b/src/sidebar/store/modules/annotations.ts
@@ -603,6 +603,29 @@ const usersWhoAnnotated = createSelector(
   },
 );
 
+/**
+ * Return the list of unique users who have been mentioned in currently loaded
+ * annotations.
+ */
+const usersWhoWereMentioned = createSelector(
+  (state: State) => state.annotations,
+  annotations => {
+    const mentions = annotations.flatMap(anno => anno.mentions ?? []);
+    const addedUserIds = new Set<string>();
+
+    return mentions
+      .filter(({ userid }) => {
+        const userAlreadyAdded = addedUserIds.has(userid);
+        addedUserIds.add(userid);
+        return !userAlreadyAdded;
+      })
+      .map(({ display_name: displayName, ...rest }) => ({
+        displayName,
+        ...rest,
+      }));
+  },
+);
+
 export const annotationsModule = createStoreModule(initialState, {
   namespace: 'annotations',
   reducers,
@@ -634,5 +657,6 @@ export const annotationsModule = createStoreModule(initialState, {
     orphanCount,
     savedAnnotations,
     usersWhoAnnotated,
+    usersWhoWereMentioned,
   },
 });

--- a/src/sidebar/store/modules/test/annotations-test.js
+++ b/src/sidebar/store/modules/test/annotations-test.js
@@ -593,4 +593,66 @@ describe('sidebar/store/modules/annotations', () => {
       );
     });
   });
+
+  describe('usersWhoWereMentioned', () => {
+    it('returns expected list of unique users', () => {
+      const store = createTestStore();
+
+      // Add a few annotations with mentions
+      store.addAnnotations([
+        Object.assign(fixtures.defaultAnnotation(), {
+          id: 'a1',
+          mentions: [
+            {
+              userid: 'acct:jondoe@hypothes.is',
+              username: 'jondoe',
+              display_name: null,
+            },
+          ],
+        }),
+        Object.assign(fixtures.defaultAnnotation(), {
+          id: 'a2',
+          mentions: [
+            {
+              userid: 'acct:janedoe@hypothes.is',
+              username: 'janedoe',
+              display_name: 'Jane Doe',
+            },
+          ],
+        }),
+        Object.assign(fixtures.defaultAnnotation(), {
+          id: 'a3',
+          mentions: [
+            {
+              userid: 'acct:janedoe@hypothes.is',
+              username: 'janedoe',
+              display_name: 'Jane Doe',
+            },
+            {
+              userid: 'acct:jondoe@hypothes.is',
+              username: 'jondoe',
+              display_name: null,
+            },
+          ],
+        }),
+      ]);
+
+      // Only one instance of every mentioned user should be returned
+      assert.deepEqual(
+        [
+          {
+            userid: 'acct:jondoe@hypothes.is',
+            username: 'jondoe',
+            displayName: null,
+          },
+          {
+            userid: 'acct:janedoe@hypothes.is',
+            username: 'janedoe',
+            displayName: 'Jane Doe',
+          },
+        ],
+        store.usersWhoWereMentioned(),
+      );
+    });
+  });
 });


### PR DESCRIPTION
While testing something else, I realized that, if a user is manually mentioned in a public group, when trying to mention that user again, their name will not appear in the list of suggestions.

This felt a bit confusing, as my expectation was that the sidebar should already know about this person that has already been mentioned.

This PR improves the list of suggestions so that it is generated combining users who already annotated the document + users who have been mentioned in at least one annotation + members of the active group.

https://github.com/user-attachments/assets/f3f12410-4d05-42f9-a07a-3175d1878633

### Test steps

1. Open a public group where some existing users have not created an annotation yet.
2. Using another user, create an annotation mentioning one of those users. They will not show-up in suggestions, so type their username manually.
3. Try creating another annotation with a mention. Observe that the user mentioned in previous step is now part of the list of suggestions.