### PR TITLE
Use a darker shade of grey in annotation textarea text

### DIFF
--- a/src/sidebar/components/MarkdownEditor.tsx
+++ b/src/sidebar/components/MarkdownEditor.tsx
@@ -326,7 +326,7 @@ function TextArea({
       <textarea
         className={classnames(
           'border rounded p-2',
-          'text-color-text-light bg-grey-0',
+          'bg-grey-0 text-grey-8 placeholder:text-grey-6',
           'focus:bg-white focus:outline-none focus:shadow-focus-inner',
           classes,
         )}


### PR DESCRIPTION
Part of #6866

Increase color contrast in annotation textarea placeholder so that it has a minimum required contrast ratio to be accessible.

Before:
![image](https://github.com/user-attachments/assets/3e2dfd11-7afa-4b45-b23e-18cb768c9e38)
![image](https://github.com/user-attachments/assets/1dc68f58-99f7-469c-b06e-87b706038299)

After:
![image](https://github.com/user-attachments/assets/1a5b04c1-87a8-4f81-a048-9a38da641bd9)
![image](https://github.com/user-attachments/assets/007e6c7d-da89-4805-a09c-ffee4ed89664)
