### PR TITLE
Scroll to most relevant highlighted annotation

### DIFF
--- a/src/sidebar/helpers/highlighted-annotations.ts
+++ b/src/sidebar/helpers/highlighted-annotations.ts
@@ -1,0 +1,53 @@
+import type { Annotation } from '../../types/api';
+
+export type AnnotationId = string;
+
+export type MostRelevantAnnotationOptions = {
+  /** The list of highlighted annotation IDs to filter by */
+  highlightedAnnotations: AnnotationId[];
+  currentUserId: string | null;
+};
+
+/**
+ * Finds the most relevant annotation in a list.
+ *
+ * The most relevant annotation is:
+ * 1. The most recent annotation which is highlighted, with mentions of current user, or
+ * 2. The most recent annotation which is highlighted, or
+ * 3. `null`
+ *
+ * @param annotations - The list of annotations to search from
+ */
+export function mostRelevantAnnotation(
+  annotations: Annotation[],
+  { highlightedAnnotations, currentUserId }: MostRelevantAnnotationOptions,
+): Annotation | null {
+  if (highlightedAnnotations.length === 0) {
+    return null;
+  }
+
+  // To determine which is the most relevant annotation, we first sort them
+  // from newest to oldest
+  const sortedHighlightedAnnos = annotations
+    .filter(anno => anno.id && highlightedAnnotations.includes(anno.id))
+    // The `updated` field contains a date in ISO format. This means their
+    // alphabetical and chronological orders match.
+    .sort((a, b) => {
+      if (b.updated === a.updated) {
+        return 0;
+      }
+      return b.updated > a.updated ? 1 : -1;
+    });
+
+  // Then we find the most recent one with mentions of current user
+  const mostRelevantHighlightedAnnotation = currentUserId
+    ? sortedHighlightedAnnos.find(
+        anno =>
+          anno.mentions &&
+          anno.mentions.some(({ userid }) => userid === currentUserId),
+      )
+    : null;
+
+  // Finally we try to fall back to the most recent one
+  return mostRelevantHighlightedAnnotation ?? sortedHighlightedAnnos[0] ?? null;
+}

--- a/src/sidebar/helpers/test/highlighted-annotations-test.js
+++ b/src/sidebar/helpers/test/highlighted-annotations-test.js
@@ -1,0 +1,113 @@
+import { mostRelevantAnnotation } from '../highlighted-annotations';
+
+describe('mostRelevantAnnotation', () => {
+  const annotations = [
+    { id: 't1', updated: '2024-01-01T10:42:00' },
+    { id: 't2', updated: '2024-01-02T10:42:00' },
+    { id: 't3', updated: '2024-01-03T10:42:00' },
+    { id: 't4', updated: '2024-01-03T10:42:00' }, // Same date as previous one
+  ];
+
+  it('returns `null` if no highlighted annotations are provided', () => {
+    assert.isNull(
+      mostRelevantAnnotation(annotations, {
+        highlightedAnnotations: [],
+        currentUserId: '',
+      }),
+    );
+  });
+
+  [
+    {
+      highlightedAnnotations: annotations.map(({ id }) => id),
+      // Last and previous to last one have the same updated date, so they'll
+      // keep the same order on the list, and the thord one will match
+      expectedResult: annotations[2],
+    },
+    {
+      highlightedAnnotations: ['t1', 't3'],
+      expectedResult: annotations[2],
+    },
+    {
+      highlightedAnnotations: ['t2', 't1'],
+      expectedResult: annotations[1],
+    },
+    {
+      highlightedAnnotations: ['t2'],
+      expectedResult: annotations[1],
+    },
+    {
+      highlightedAnnotations: ['t2', 't4'],
+      expectedResult: annotations[3],
+    },
+  ].forEach(({ highlightedAnnotations, expectedResult }) => {
+    it('returns most recent highlighted annotation if currentUserId is `null`', () => {
+      assert.deepEqual(
+        mostRelevantAnnotation(annotations, {
+          highlightedAnnotations,
+          currentUserId: null,
+        }),
+        expectedResult,
+      );
+    });
+  });
+
+  [
+    {
+      annosWithCurrentUserMention: ['t1'],
+      expectedResult: annotations[0],
+    },
+    {
+      annosWithCurrentUserMention: ['t2'],
+      expectedResult: annotations[1],
+    },
+    {
+      annosWithCurrentUserMention: ['t3'],
+      expectedResult: annotations[2],
+    },
+    {
+      annosWithCurrentUserMention: ['t4'],
+      expectedResult: annotations[3],
+    },
+    {
+      annosWithCurrentUserMention: ['t2', 't4'],
+      expectedResult: annotations[3],
+    },
+    {
+      annosWithCurrentUserMention: ['t1', 't4'],
+      expectedResult: annotations[3],
+    },
+    {
+      annosWithCurrentUserMention: ['t2', 't3'],
+      expectedResult: annotations[2],
+    },
+    {
+      annosWithCurrentUserMention: ['t1', 't2', 't3'],
+      expectedResult: annotations[2],
+    },
+    {
+      annosWithCurrentUserMention: ['t1', 't2'],
+      expectedResult: annotations[1],
+    },
+  ].forEach(({ annosWithCurrentUserMention, expectedResult }) => {
+    it('returns most recent annotation with a mention to current user', () => {
+      const currentUserId = 'current_user_id';
+      const allAnnotations = annotations.map(({ id, updated }) => {
+        const mentions = [];
+        if (annosWithCurrentUserMention.includes(id)) {
+          mentions.push({ userid: currentUserId });
+        }
+
+        return { id, updated, mentions };
+      });
+      const highlightedAnnotations = annotations.map(({ id }) => id);
+
+      const result = mostRelevantAnnotation(allAnnotations, {
+        highlightedAnnotations,
+        currentUserId,
+      });
+
+      assert.match(result, expectedResult);
+    });
+  });
+});


### PR DESCRIPTION
Closes #6931 

When pending updates are applied via the pending updates notification, we highlight all corresponding annotations in the sidebar, and then, we scroll to the most recent one from among them.

This PR extends that logic so that there can be more business rules to determine which annotation to scroll into the viewport.

With these changes we now scroll to the most recent annotation that contains mentions of the currently logged-in user, or simply to the most recent annotation if none contains mentions (this is current behavior).

In future we could extend this even further so that we scroll to replies if present, but that would require extra logic to ensure replies are uncollapsed when highlighted.

### Test steps

1. Open http://localhost:3000/ in two browsers.
2. From one browser create three new annotations. In the second annotation mention the user from the other browser.
3. In the other browser, the real-time updates widget should indicate there are 3 updates and 1 mention.
4. Click the widget. You should be scrolled to the annotation containing a mention, even if it's not the most recent one.