### PR TITLE
Add pin/point tool to toolbar when PDF image annotation is enabled

### DIFF
--- a/src/annotator/components/Toolbar.tsx
+++ b/src/annotator/components/Toolbar.tsx
@@ -7,6 +7,7 @@ import {
   HideIcon,
   ImageIcon,
   NoteIcon,
+  PinIcon,
   ShowIcon,
 } from '@hypothesis/frontend-shared';
 import type { ButtonProps } from '@hypothesis/frontend-shared/lib/components/input/Button';
@@ -220,6 +221,14 @@ export default function Toolbar({
                 title="Rectangle annotation"
                 icon={ImageIcon}
                 onClick={() => createAnnotation('rect')}
+              />
+            )}
+            {supportedTools.includes('point') && (
+              <ToolbarButton
+                data-testid="point-annotation"
+                title="Point annotation"
+                icon={PinIcon}
+                onClick={() => createAnnotation('point')}
               />
             )}
           </div>

--- a/src/annotator/components/test/Toolbar-test.js
+++ b/src/annotator/components/test/Toolbar-test.js
@@ -140,6 +140,24 @@ describe('Toolbar', () => {
     assert.calledWith(createAnnotation, 'rect');
   });
 
+  it('hides point annotation button if `supportedTools` does not include "point"', () => {
+    const wrapper = createToolbar();
+    assert.isFalse(wrapper.exists('button[data-testid="point-annotation"]'));
+  });
+
+  it('shows point annotation button if `supportedTools` includes "point"', () => {
+    const createAnnotation = sinon.stub();
+    const wrapper = createToolbar({
+      createAnnotation,
+      supportedTools: ['selection', 'rect', 'point'],
+    });
+
+    const button = wrapper.find('button[data-testid="point-annotation"]');
+    button.simulate('click');
+
+    assert.calledWith(createAnnotation, 'point');
+  });
+
   it(
     'should pass a11y checks',
     checkAccessibility([

--- a/src/annotator/integrations/pdf.tsx
+++ b/src/annotator/integrations/pdf.tsx
@@ -468,7 +468,7 @@ export class PDFIntegration extends TinyEmitter implements Integration {
   supportedTools(): AnnotationTool[] {
     const imageAnnotation = this._features?.flagEnabled('pdf_image_annotation');
     if (imageAnnotation) {
-      return ['selection', 'rect'];
+      return ['selection', 'rect', 'point'];
     } else {
       return ['selection'];
     }

--- a/src/annotator/integrations/test/pdf-test.js
+++ b/src/annotator/integrations/test/pdf-test.js
@@ -637,6 +637,7 @@ describe('annotator/integrations/pdf', () => {
         assert.deepEqual(pdfIntegration.supportedTools(), [
           'selection',
           'rect',
+          'point',
         ]);
       });
 
@@ -648,7 +649,11 @@ describe('annotator/integrations/pdf', () => {
 
         features.update({ pdf_image_annotation: true });
 
-        assert.calledWith(supportedToolsChanged, ['selection', 'rect']);
+        assert.calledWith(supportedToolsChanged, [
+          'selection',
+          'rect',
+          'point',
+        ]);
       });
     });
   });

--- a/src/types/annotator.ts
+++ b/src/types/annotator.ts
@@ -376,4 +376,4 @@ export type SideBySideMode = SideBySideOptions['mode'];
  * - "selection" - Use the current text or DOM selection
  * - "rect" - Draw a rectangle to select a region of the document
  */
-export type AnnotationTool = 'selection' | 'rect';
+export type AnnotationTool = 'selection' | 'rect' | 'point';


### PR DESCRIPTION
Add a new pin tool to the toolbar which uses a specific point rather than a rect as the target of an image annotation. Like the rect tool, this only appears in PDFs if the `pdf_image_annotation` flag is enabled.

It is currently TBD which tools we will actually offer to users in the first version, but this will let us trial both.

<img width="164" alt="point-annotation-tool" src="https://github.com/user-attachments/assets/fd6a1d60-556a-4c24-b6ad-512b333b797d" />

Adding an extra icon here exacerbates the existing issue where buckets can be hidden underneath the toolbar. I will address that in a separate PR.