### PR TITLE
Enable user to draw selection when rect or point tools are selected

### DIFF
--- a/src/annotator/draw-tool.tsx
+++ b/src/annotator/draw-tool.tsx
@@ -1,0 +1,228 @@
+import { render } from 'preact';
+
+import { promiseWithResolvers } from '../shared/promise-with-resolvers';
+import type { Destroyable, Rect, Shape } from '../types/annotator';
+
+function isPositioned(el: HTMLElement) {
+  return getComputedStyle(el).position !== 'static';
+}
+
+/** Normalize a rect so that `left <= right` and `top <= bottom`. */
+function normalizeRect(r: Rect): Rect {
+  const minX = Math.min(r.left, r.right);
+  const maxX = Math.max(r.left, r.right);
+  const minY = Math.min(r.top, r.bottom);
+  const maxY = Math.max(r.top, r.bottom);
+  return {
+    type: 'rect',
+    left: minX,
+    top: minY,
+    right: maxX,
+    bottom: maxY,
+  };
+}
+
+/**
+ * Errors while drawing a shape using {@link DrawTool}.
+ */
+export class DrawError extends Error {
+  constructor(message = 'Drawing failed') {
+    super(message);
+  }
+}
+
+/** Specifies the type of shape to draw. */
+export type Tool = 'rect' | 'point';
+
+/**
+ * Tool for drawing shapes for use as the target region of an annotation.
+ *
+ * When drawing is active, DrawTool creates an overlay into which the incomplete
+ * shape is drawn. The shape is updated in response to user gestures.
+ *
+ * Drawing is initiated using {@link DrawTool.draw}. Only one shape can be
+ * drawn at a time.
+ */
+export class DrawTool implements Destroyable {
+  private _container: HTMLElement;
+
+  /** Surface for current drawing. */
+  private _surface?: SVGSVGElement;
+
+  private _tool: Tool;
+
+  /** Current drawing shape. */
+  private _shape?: Rect;
+
+  /** Callback for when draw operation ends successfully. */
+  private _drawEnd?: (s: Shape) => void;
+
+  /** Callback for when draw operation ends with an error. */
+  private _drawError?: (e: DrawError) => void;
+
+  /** Controller for ending the drawing operation. */
+  private _abortDraw?: AbortController;
+
+  /**
+   * @param root - Container in which the user can draw a shape
+   */
+  constructor(root: HTMLElement) {
+    this._container = root;
+    this._tool = 'rect';
+    if (!isPositioned(root)) {
+      root.style.position = 'relative';
+    }
+  }
+
+  destroy() {
+    this.cancel();
+  }
+
+  /**
+   * Begin drawing a shape.
+   *
+   * @param tool - Type of shape to draw
+   * @return - Promise for the shape drawn by the user
+   */
+  async draw(tool: Tool): Promise<Shape> {
+    this._tool = tool;
+
+    // Only one drawing operation can be in progress at a time.
+    this.cancel();
+
+    // Create a transparent SVG canvas overlaid on top of the container, with
+    // a crosshair cursor to indicate the user can click to draw.
+    const surface = document.createElementNS(
+      'http://www.w3.org/2000/svg',
+      'svg',
+    );
+    surface.setAttribute('data-testid', 'surface');
+    surface.setAttribute('width', '100%');
+    surface.setAttribute('height', '100%');
+    surface.style.cursor = 'crosshair';
+    surface.style.position = 'absolute';
+    surface.style.left = '0px';
+    surface.style.top = '0px';
+    surface.style.zIndex = '10';
+    this._container.append(surface);
+    this._surface = surface;
+
+    const { promise: shape, resolve, reject } = promiseWithResolvers<Shape>();
+    this._drawEnd = resolve;
+    this._drawError = reject;
+
+    this._surface.addEventListener('mousedown', e => {
+      switch (this._tool) {
+        case 'rect':
+          this._shape = {
+            type: 'rect',
+            left: e.clientX,
+            top: e.clientY,
+            right: e.clientX,
+            bottom: e.clientY,
+          };
+          this._renderSurface();
+          break;
+        case 'point':
+          resolve({
+            type: 'point',
+            x: e.clientX,
+            y: e.clientY,
+          });
+          this._abortDraw?.abort();
+          break;
+      }
+    });
+
+    this._surface.addEventListener('mousemove', e => {
+      if (!this._shape) {
+        return;
+      }
+
+      this._shape.right = e.clientX;
+      this._shape.bottom = e.clientY;
+      this._renderSurface();
+    });
+
+    this._surface.addEventListener('mouseup', e => {
+      if (!this._shape) {
+        return;
+      }
+      this._shape.right = e.clientX;
+      this._shape.bottom = e.clientY;
+      resolve(normalizeRect(this._shape));
+      this._abortDraw?.abort();
+    });
+
+    // Cancel drawing if user presses "Escape"
+    this._abortDraw = new AbortController();
+    document.body.addEventListener(
+      'keydown',
+      (e: KeyboardEvent) => {
+        if (e.key !== 'Escape') {
+          return;
+        }
+        if (this._drawError) {
+          this._drawError(new DrawError('Drawing canceled'));
+        }
+        this._abortDraw?.abort();
+      },
+      {
+        signal: this._abortDraw.signal,
+      },
+    );
+
+    // Cleanup when drawing is aborted
+    this._abortDraw.signal.onabort = () => {
+      this._surface?.remove();
+      this._shape = undefined;
+      this._surface = undefined;
+      this._drawError = undefined;
+      this._drawEnd = undefined;
+      this._abortDraw = undefined;
+    };
+
+    // Draw the initial empty surface
+    this._renderSurface();
+
+    return shape;
+  }
+
+  /**
+   * Cancel any drawing which is in progress.
+   *
+   * Pending promises returned by {@link DrawTool.draw} will reject.
+   */
+  cancel() {
+    if (this._drawError) {
+      this._drawError(new DrawError('Drawing canceled'));
+    }
+    this._abortDraw?.abort();
+  }
+
+  private _renderSurface() {
+    /* istanbul ignore next */
+    if (!this._surface) {
+      return;
+    }
+    if (this._shape?.type === 'rect') {
+      // Normalize rect because SVG rects must have positive width and height.
+      const rect = normalizeRect(this._shape);
+      render(
+        <rect
+          stroke="black"
+          stroke-dasharray="3"
+          stroke-width="3px"
+          fill="none"
+          x={rect.left}
+          y={rect.top}
+          width={rect.right - rect.left}
+          height={rect.bottom - rect.top}
+        />,
+        this._surface,
+      );
+    } else {
+      render(null, this._surface);
+    }
+  }
+}

--- a/src/annotator/test/draw-tool-test.js
+++ b/src/annotator/test/draw-tool-test.js
@@ -1,0 +1,167 @@
+import { delay } from '@hypothesis/frontend-testing';
+
+import { DrawError, DrawTool } from '../draw-tool';
+
+describe('DrawTool', () => {
+  let container;
+  let tool;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.append(container);
+    tool = new DrawTool(container);
+  });
+
+  afterEach(() => {
+    tool.cancel();
+    container.remove();
+  });
+
+  // Return the SVG surface created to display the incomplete shape while
+  // drawing.
+  const getSurface = () => container.querySelector('svg[data-testid=surface]');
+
+  const sendMouseEvent = (event, x = 0, y = 0) => {
+    getSurface().dispatchEvent(
+      new MouseEvent(event, { clientX: x, clientY: y }),
+    );
+  };
+
+  it('creates SVG when drawing starts', async () => {
+    tool.draw('rect').catch(() => {
+      /* ignored */
+    });
+    assert.ok(getSurface());
+  });
+
+  it('removes SVG when drawing ends', async () => {
+    const shape = tool.draw('point');
+    sendMouseEvent('mousedown');
+    await shape;
+    assert.notOk(getSurface());
+  });
+
+  it('cancels drawing if `cancel` is called', async () => {
+    const shape = tool.draw('point');
+
+    tool.cancel();
+
+    let err;
+    try {
+      await shape;
+    } catch (e) {
+      err = e;
+    }
+
+    assert.instanceOf(err, DrawError);
+    assert.notOk(getSurface());
+  });
+
+  it('cancels drawing if DrawTool is destroyed', async () => {
+    const shape = tool.draw('point');
+    tool.destroy();
+
+    let err;
+    try {
+      await shape;
+    } catch (e) {
+      err = e;
+    }
+
+    assert.instanceOf(err, DrawError);
+    assert.notOk(getSurface());
+  });
+
+  it('cancels drawing if `Escape` is pressed', async () => {
+    let done = false;
+    const shape = tool.draw('point').then(() => (done = true));
+
+    // Keys other than Escape should be ignored.
+    document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+    await delay(0);
+    assert.isFalse(done);
+
+    // Escape key should cancel drawing
+    document.body.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape' }),
+    );
+
+    let err;
+    try {
+      await shape;
+    } catch (e) {
+      err = e;
+    }
+
+    assert.instanceOf(err, DrawError);
+    assert.notOk(getSurface());
+  });
+
+  describe('drawing a point', () => {
+    it('finishes drawing when mouse is pressed', async () => {
+      const shapePromise = tool.draw('point');
+      sendMouseEvent('mousedown');
+
+      const shape = await shapePromise;
+
+      assert.deepEqual(shape, {
+        type: 'point',
+        x: 0,
+        y: 0,
+      });
+    });
+
+    it('ignores mousemove and mouseup events while drawing a point', async () => {
+      const shapePromise = tool.draw('point');
+
+      sendMouseEvent('mouseup');
+      sendMouseEvent('mousemove');
+      sendMouseEvent('mousedown', 20, 30);
+
+      const shape = await shapePromise;
+      assert.deepEqual(shape, {
+        type: 'point',
+        x: 20,
+        y: 30,
+      });
+    });
+  });
+
+  describe('drawing a rect', () => {
+    it('finishes drawing when mouse is released', async () => {
+      const shapePromise = tool.draw('rect');
+      sendMouseEvent('mousedown');
+      sendMouseEvent('mousemove', 5, 5);
+      sendMouseEvent('mouseup', 10, 20);
+
+      const shape = await shapePromise;
+
+      assert.deepEqual(shape, {
+        type: 'rect',
+        left: 0,
+        top: 0,
+        right: 10,
+        bottom: 20,
+      });
+    });
+
+    it('ignores "mousemove" and "mouseup" events before an initial "mousedown"', async () => {
+      const shapePromise = tool.draw('rect');
+      sendMouseEvent('mousemove', 5, 5);
+      sendMouseEvent('mouseup', 10, 20);
+
+      sendMouseEvent('mousedown');
+      sendMouseEvent('mousemove', 3, 3);
+      sendMouseEvent('mouseup', 6, 7);
+      const shape = await shapePromise;
+
+      assert.deepEqual(shape, {
+        type: 'rect',
+        left: 0,
+        top: 0,
+        right: 6,
+        bottom: 7,
+      });
+    });
+  });
+});

--- a/src/types/annotator.ts
+++ b/src/types/annotator.ts
@@ -161,6 +161,26 @@ export type SidebarLayout = {
   toolbarWidth: number;
 };
 
+export type Rect = {
+  type: 'rect';
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+};
+
+export type Point = {
+  type: 'point';
+  x: number;
+  y: number;
+};
+
+/**
+ * Shapes used to define 2D regions of a document that an annotation can be
+ * associated with.
+ */
+export type Shape = Rect | Point;
+
 /**
  * Interface for document type/viewer integrations that handle all the details
  * of supporting a specific document type (web page, PDF, ebook, etc.).


### PR DESCRIPTION
Implement selection of a rect or point when the user clicks the rect or pin annotation tools in the sidebar. When the user finishes drawing the selection, a new annotation is created. The new annotation is currently just a page node as serialization of shapes is not yet implemented.

The rectangle selection shape styling is just a first cut, I expect to improve it later.

**Testing:**

With the `pdf_image_annotation` feature enabled, go to a PDF (eg. http://localhost:3000/pdf/nils-olav) and then:

1. Click on the Pin icon in the toolbar and hover the mouse over the document. The cursor should change to a cross-hair. Click anywhere in the document and a new annotation should be created.
2. Click on the rect icon in the toolbar and hover the mouse over the document. The cursor should change to a cross-hair. Drag in the document to draw a rectangular selection. A dashed rect should be shown while drawing to show the shape. Release the mouse to create a new annotation.
3. Press Escape while a drawing is pending (ie. while the cross-hair icon is shown). This should cancel the drawing and the cursor should revert back to the standard cursor. When using the rectangle tool, this should work both before and while the mouse is pressed.