### PR TITLE
Generate shape selectors for rect and point annotations in PDFs

### DIFF
--- a/src/annotator/anchoring/test/fake-pdf-viewer-application.js
+++ b/src/annotator/anchoring/test/fake-pdf-viewer-application.js
@@ -141,6 +141,16 @@ class FakePDFPageView {
   dispose() {
     this.div.remove();
   }
+
+  getPagePoint(x, y) {
+    const userSpaceX = x * 2;
+
+    // PDF user space coordinates have the origin at the bottom left corner,
+    // with Y increasing going up the page.
+    const userSpaceY = 100 - y;
+
+    return [userSpaceX, userSpaceY];
+  }
 }
 
 /**

--- a/src/annotator/guest.ts
+++ b/src/annotator/guest.ts
@@ -797,14 +797,14 @@ export class Guest extends TinyEmitter implements Annotator, Destroyable {
       return this.createAnnotationFromSelection();
     } else if (['rect', 'point'].includes(tool)) {
       // Draw the shape for the new annotation's region.
-      await this._drawTool.draw(tool);
+      const shape = await this._drawTool.draw(tool);
 
       // Create annotation data and send to sidebar.
       const info = await this.getDocumentInfo();
       const target: Target[] = [
         {
           source: info.uri,
-          // TODO: Serialize shape into selectors
+          selector: await this._integration.describe(this.element, shape),
         },
       ];
 

--- a/src/annotator/integrations/html.ts
+++ b/src/annotator/integrations/html.ts
@@ -5,6 +5,7 @@ import type {
   AnnotationTool,
   FeatureFlags,
   Integration,
+  Shape,
   SidebarLayout,
   SideBySideOptions,
 } from '../../types/annotator';
@@ -110,8 +111,12 @@ export class HTMLIntegration extends TinyEmitter implements Integration {
     return anchor(root, selectors);
   }
 
-  describe(root: Element, range: Range): Selector[] {
-    return describe(root, range);
+  describe(root: Element, region: Range | Shape): Selector[] {
+    if (region instanceof Range) {
+      return describe(root, region);
+    } else {
+      throw new Error('Unsupported region type');
+    }
   }
 
   _checkForURIChange() {

--- a/src/annotator/integrations/pdf.tsx
+++ b/src/annotator/integrations/pdf.tsx
@@ -11,6 +11,7 @@ import type {
   Destroyable,
   FeatureFlags,
   Integration,
+  Shape,
   SidebarLayout,
 } from '../../types/annotator';
 import type { Selector } from '../../types/api';
@@ -20,6 +21,7 @@ import {
   anchor,
   canDescribe,
   describe,
+  describeShape,
   documentHasText,
   isTextLayerRenderingDone,
 } from '../anchoring/pdf';
@@ -321,12 +323,16 @@ export class PDFIntegration extends TinyEmitter implements Integration {
   }
 
   /**
-   * Generate selectors for the text in `range`.
+   * Generate selectors for the text in `region`.
    */
-  describe(root: HTMLElement, range: Range): Promise<Selector[]> {
-    // nb. The `root` argument is not really used by `anchor`. It existed for
-    // consistency between HTML and PDF anchoring and could be removed.
-    return describe(root, range);
+  describe(root: HTMLElement, region: Range | Shape): Promise<Selector[]> {
+    if (region instanceof Range) {
+      // nb. The `root` argument is not really used by `anchor`. It existed for
+      // consistency between HTML and PDF anchoring and could be removed.
+      return describe(root, region);
+    } else {
+      return describeShape(region);
+    }
   }
 
   /**

--- a/src/annotator/integrations/test/html-test.js
+++ b/src/annotator/integrations/test/html-test.js
@@ -102,16 +102,35 @@ describe('HTMLIntegration', () => {
     );
   }
 
-  it('implements `anchor` and `destroy` using HTML anchoring', async () => {
+  it('implements `anchor` using HTML anchoring', async () => {
     const integration = createIntegration();
     const root = {};
     const selectors = [];
 
-    const range = await integration.anchor(root, selectors);
+    await integration.anchor(root, selectors);
     assert.calledWith(fakeHTMLAnchoring.anchor, root, selectors);
+  });
 
-    integration.describe(root, range);
-    assert.calledWith(fakeHTMLAnchoring.describe, root, range);
+  describe('#describe', () => {
+    it('describes DOM ranges', () => {
+      const integration = createIntegration();
+      const root = {};
+
+      const range = document.createRange();
+      integration.describe(root, range);
+      assert.calledWith(fakeHTMLAnchoring.describe, root, range);
+    });
+
+    it('throws if passed a shape', () => {
+      const integration = createIntegration();
+      const root = {};
+
+      const shape = { type: 'point', x: 0, y: 0 };
+      assert.throws(() => {
+        integration.describe(root, shape);
+      }, 'Unsupported region type');
+      assert.notCalled(fakeHTMLAnchoring.describe);
+    });
   });
 
   describe('#getAnnotatableRange', () => {

--- a/src/annotator/integrations/test/pdf-test.js
+++ b/src/annotator/integrations/test/pdf-test.js
@@ -85,6 +85,7 @@ describe('annotator/integrations/pdf', () => {
         anchor: sinon.stub(),
         canDescribe: sinon.stub().returns(true),
         describe: sinon.stub(),
+        describeShape: sinon.stub(),
         documentHasText: sinon.stub().resolves(true),
       };
 
@@ -225,15 +226,25 @@ describe('annotator/integrations/pdf', () => {
     });
 
     describe('#describe', () => {
-      it('generates selectors for passed range', async () => {
+      it('generates selectors for DOM range', async () => {
         pdfIntegration = createPDFIntegration();
-        const range = {};
+        const range = document.createRange();
         fakePDFAnchoring.describe.returns([]);
 
         const selectors = await pdfIntegration.describe({}, range);
 
         assert.calledWith(fakePDFAnchoring.describe, sinon.match.any, range);
         assert.equal(selectors, fakePDFAnchoring.describe());
+      });
+
+      it('generates selectors for shape', async () => {
+        pdfIntegration = createPDFIntegration();
+        const shape = { type: 'point', x: 0, y: 0 };
+
+        const selectors = await pdfIntegration.describe({}, shape);
+
+        assert.calledWith(fakePDFAnchoring.describeShape, shape);
+        assert.equal(selectors, fakePDFAnchoring.describeShape());
       });
     });
 

--- a/src/annotator/integrations/test/vitalsource-test.js
+++ b/src/annotator/integrations/test/vitalsource-test.js
@@ -396,9 +396,10 @@ describe('annotator/integrations/vitalsource', () => {
       integration.contentContainer();
       assert.calledWith(fakeHTMLIntegration.contentContainer);
 
+      const root = {};
       const range = new Range();
-      await integration.describe(range);
-      assert.calledWith(fakeHTMLIntegration.describe, range);
+      await integration.describe(root, range);
+      assert.calledWith(fakeHTMLIntegration.describe, root, range);
 
       const selectors = [{ type: 'TextQuoteSelector', exact: 'foobar' }];
       await integration.anchor(selectors);
@@ -414,8 +415,9 @@ describe('annotator/integrations/vitalsource', () => {
       integration.contentContainer();
       assert.calledWith(fakeHTMLIntegration.contentContainer);
 
+      const root = {};
       const range = new Range();
-      const selectors = await integration.describe(range);
+      const selectors = await integration.describe(root, range);
 
       const cfiSelector = selectors.find(s => s.type === 'EPUBContentSelector');
 
@@ -442,8 +444,9 @@ describe('annotator/integrations/vitalsource', () => {
       integration.contentContainer();
       assert.calledWith(fakeHTMLIntegration.contentContainer);
 
+      const root = {};
       const range = new Range();
-      const selectors = await integration.describe(range);
+      const selectors = await integration.describe(root, range);
       const cfiSelector = selectors.find(s => s.type === 'EPUBContentSelector');
 
       assert.ok(cfiSelector);
@@ -475,10 +478,11 @@ describe('annotator/integrations/vitalsource', () => {
         integration.contentContainer();
         assert.calledWith(fakeHTMLIntegration.contentContainer);
 
+        const root = {};
         const range = new Range();
         let error;
         try {
-          await integration.describe(range);
+          await integration.describe(root, range);
         } catch (err) {
           error = err;
         }

--- a/src/annotator/integrations/vitalsource.ts
+++ b/src/annotator/integrations/vitalsource.ts
@@ -8,6 +8,7 @@ import type {
   AnnotationTool,
   Integration,
   SegmentInfo,
+  Shape,
   SidebarLayout,
 } from '../../types/annotator';
 import type {
@@ -347,8 +348,8 @@ export class VitalSourceContentIntegration
     return this._htmlIntegration.anchor(root, selectors);
   }
 
-  async describe(root: HTMLElement, range: Range) {
-    const selectors: Selector[] = this._htmlIntegration.describe(root, range);
+  async describe(root: HTMLElement, region: Range | Shape) {
+    const selectors: Selector[] = this._htmlIntegration.describe(root, region);
 
     const {
       cfi,

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -568,27 +568,71 @@ describe('Guest', () => {
         assert.calledWith(sidebarRPC().call, 'createAnnotation');
       });
 
-      it('starts drawing if `tool` is "rect"', async () => {
-        createGuest();
+      it('creates annotation if `tool` is "rect"', async () => {
+        const guest = createGuest();
+        const rectShape = {
+          type: 'rect',
+          left: 0,
+          top: 0,
+          right: 0,
+          bottom: 0,
+        };
+        const rectSelectors = [
+          {
+            type: 'ShapeSelector',
+            shape: rectShape,
+          },
+        ];
+        fakeDrawTool.draw.resolves(rectShape);
+        fakeIntegration.describe.resolves(rectSelectors);
 
         emitHostEvent('createAnnotation', { tool: 'rect' });
         await delay(0);
         assert.calledWith(fakeDrawTool.draw, 'rect');
+        assert.calledWith(fakeIntegration.describe, guest.element, rectShape);
 
-        // After drawing completes, an annotation should be created.
-        assert.calledWith(sidebarRPC().call, 'createAnnotation');
+        assert.calledWith(
+          sidebarRPC().call,
+          'createAnnotation',
+          sinon.match({
+            target: [
+              sinon.match({
+                selector: rectSelectors,
+              }),
+            ],
+          }),
+        );
       });
 
-      it('starts drawing if `tool` is "point"', async () => {
-        createGuest();
+      it('creates annotation if `tool` is "point"', async () => {
+        const guest = createGuest();
+        const pointShape = { type: 'point', x: 0, y: 0 };
+        const pointSelectors = [
+          {
+            type: 'ShapeSelector',
+            shape: pointShape,
+          },
+        ];
+        fakeDrawTool.draw.resolves(pointShape);
+        fakeIntegration.describe.resolves(pointSelectors);
 
         emitHostEvent('createAnnotation', { tool: 'point' });
         await delay(0);
 
         assert.calledWith(fakeDrawTool.draw, 'point');
+        assert.calledWith(fakeIntegration.describe, guest.element, pointShape);
 
-        // After drawing completes, an annotation should be created.
-        assert.calledWith(sidebarRPC().call, 'createAnnotation');
+        assert.calledWith(
+          sidebarRPC().call,
+          'createAnnotation',
+          sinon.match({
+            target: [
+              sinon.match({
+                selector: pointSelectors,
+              }),
+            ],
+          }),
+        );
       });
 
       it('reports error if annotation tool is unsupported', async () => {

--- a/src/types/annotator.ts
+++ b/src/types/annotator.ts
@@ -195,13 +195,20 @@ export type IntegrationBase = {
    */
   anchor(root: HTMLElement, selectors: Selector[]): Promise<Range>;
 
-  /** Generate a list of serializable selectors which represent the content in `range`. */
-  describe(root: HTMLElement, range: Range): Selector[] | Promise<Selector[]>;
+  /**
+   * Generate a list of serializable selectors which represent the content in `region`.
+   */
+  describe(
+    root: HTMLElement,
+    region: Range | Shape,
+  ): Selector[] | Promise<Selector[]>;
+
   /**
    * Return the main element that contains the document content. This is used
    * by controls such as the bucket bar to know when the content might have scrolled.
    */
   contentContainer(): HTMLElement;
+
   /**
    * Attempt to resize the content so that it is visible alongside the sidebar.
    *

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -134,6 +134,34 @@ export type PageSelector = {
   label?: string;
 };
 
+export type RectShape = {
+  type: 'rect';
+  left: number;
+  top: number;
+  bottom: number;
+  right: number;
+};
+
+export type PointShape = {
+  type: 'point';
+  x: number;
+  y: number;
+};
+
+export type Shape = RectShape | PointShape;
+
+/**
+ * Selector which identifies a region of the document defined by a shape.
+ *
+ * TODO:
+ *  - Specify the origin used by the shape coordinates (eg. page, document body)
+ *  - Specify the coordinate system
+ */
+export type ShapeSelector = {
+  type: 'ShapeSelector';
+  shape: Shape;
+};
+
 /**
  * Serialized representation of a region of a document which an annotation
  * pertains to.
@@ -144,7 +172,8 @@ export type Selector =
   | RangeSelector
   | EPUBContentSelector
   | MediaTimeSelector
-  | PageSelector;
+  | PageSelector
+  | ShapeSelector;
 
 /**
  * An entry in the `target` field of an annotation which identifies the document

--- a/src/types/pdfjs.ts
+++ b/src/types/pdfjs.ts
@@ -110,6 +110,12 @@ export type PDFPageView = {
   textLayer: TextLayer | null;
   /** See `RenderingStates` enum in src/annotator/anchoring/pdf.js */
   renderingState: number;
+
+  /**
+   * Return the `[x, y]` coordinates in PDF user space that correspond to a
+   * given position in the viewport for this page.
+   */
+  getPagePoint(x: number, y: number): [number, number];
 };
 
 /**


### PR DESCRIPTION
After drawing a rectangle or selecting a point using the new rect/point annotation tools, map the coordinates of the shape to PDF user space coordinates, in the page containing the top-left corner of the shape, and save them as a new "ShapeSelector" selector in the annotation payload.

Anchoring of this selector is not yet implemented, so the annotation will become an orphan after the page is reloaded.

 - Extend the `describe` operation of integrations to take a _region_ rather than _range_ argument. A _region_ is either a DOM range or a shape.
 - Add a new `ShapeSelector` selector type which represents a 2D region of a document. For paged media the coordinates are relative to the selected page.
 - Support describing (ie. serializing) shapes in the PDF integration
 - Throw exceptions in the HTML and VitalSource integrations if passed a shape, since that is not yet supported.

**Testing:**

With `pdf_image_annotation` enabled and the browser dev tools open at the Network tab:

1. Go to a PDF (eg. http://localhost:3000/pdf/nils-olav)
2. Click on the rect tool in the toolbar and draw a rectangular selection on the page
3. When the new annotation card appears, enter some text and save the annotation
4. Click on the point tool in the toolbar and click a point in the page
5. Enter text in the new annotation card and save

After steps (3) and (5), new annotations should be posted to the server. Inspect the request payload and there should be a new `ShapeSelector` selector in the `target.selector` field of the request. The `shape` property will be either `rect` or `point` depending on the tool used. There should also be a `PageSelector` containing the index of the selected page. The coordinates of the shape are in PDF user space coordinates, where the origin is at the bottom left corner of the page and the Y coordinate goes up rather than down (as in screen coordinates). These coordinates are used so as to be independent of the zoom level or rotation of the PDF.

If you try any of the following, a new annotation will not be created and a console error will be logged:
- Create a point annotation where the point is outside any PDF page
- Create a rect annotation where any corner of the rect is outside any PDF page, or where any corners of the rect are on different pages