### PR TITLE
Implement anchoring and highlighting of shapes in PDFs

### DIFF
--- a/src/annotator/anchoring/test/fake-pdf-viewer-application.js
+++ b/src/annotator/anchoring/test/fake-pdf-viewer-application.js
@@ -73,6 +73,10 @@ class FakePDFPageProxy {
     this._config = config;
   }
 
+  get view() {
+    return [0, 0, 100, 200]; // [left, bottom, right, top]
+  }
+
   getTextContent(params = {}) {
     if (!params.normalizeWhitespace) {
       return Promise.reject(

--- a/src/annotator/integrations/pdf.tsx
+++ b/src/annotator/integrations/pdf.tsx
@@ -12,6 +12,7 @@ import type {
   FeatureFlags,
   Integration,
   Shape,
+  ShapeAnchor,
   SidebarLayout,
 } from '../../types/annotator';
 import type { Selector } from '../../types/api';
@@ -292,7 +293,10 @@ export class PDFIntegration extends TinyEmitter implements Integration {
   /**
    * Resolve serialized `selectors` from an annotation to a range.
    */
-  anchor(root: HTMLElement, selectors: Selector[]): Promise<Range> {
+  anchor(
+    root: HTMLElement,
+    selectors: Selector[],
+  ): Promise<Range | ShapeAnchor> {
     return anchor(selectors);
   }
 
@@ -401,7 +405,7 @@ export class PDFIntegration extends TinyEmitter implements Integration {
           const hl = anchor.highlights[index];
           if (!document.body.contains(hl)) {
             anchor.highlights.splice(index, 1);
-            delete anchor.range;
+            delete anchor.region;
             refreshAnnotations.push(anchor.annotation);
             break;
           }

--- a/src/annotator/integrations/test/pdf-test.js
+++ b/src/annotator/integrations/test/pdf-test.js
@@ -377,7 +377,7 @@ describe('annotator/integrations/pdf', () => {
         const anchor = {
           anchor: {},
           highlights: [document.createElement('div')],
-          range: document.createRange(),
+          region: document.createRange(),
         };
         fakeAnnotator.anchors.push(anchor);
         return anchor;
@@ -390,7 +390,7 @@ describe('annotator/integrations/pdf', () => {
         await triggerUpdate();
 
         assert.equal(anchor.highlights.length, 0);
-        assert.isUndefined(anchor.range);
+        assert.isUndefined(anchor.region);
         assert.calledWith(fakeAnnotator.anchor, anchor.annotation);
       });
 
@@ -404,7 +404,7 @@ describe('annotator/integrations/pdf', () => {
           await triggerUpdate();
 
           assert.equal(anchor.highlights.length, 1);
-          assert.ok(anchor.range);
+          assert.ok(anchor.region);
           assert.notCalled(fakeAnnotator.anchor);
         } finally {
           anchor.highlights[0].remove();

--- a/src/types/annotator.ts
+++ b/src/types/annotator.ts
@@ -106,25 +106,6 @@ export type AnchorPosition = {
 };
 
 /**
- * Anchoring implementation for a particular document type (eg. PDF or HTML).
- *
- * This is responsible for converting between serialized "selectors" that can
- * be stored in the Hypothesis backend and ranges in the document.
- */
-export type AnchoringImpl = {
-  anchor(
-    root: HTMLElement,
-    selectors: Selector[],
-    options: unknown,
-  ): Promise<Range>;
-  describe(
-    root: HTMLElement,
-    range: Range,
-    options: unknown,
-  ): Selector[] | Promise<Selector[]>;
-};
-
-/**
  * Interface for querying a collection of feature flags and subscribing to
  * flag updates.
  *

--- a/src/types/pdfjs.ts
+++ b/src/types/pdfjs.ts
@@ -93,6 +93,12 @@ export type TextContent = {
 
 export type PDFPageProxy = {
   getTextContent(o?: GetTextContentParameters): Promise<TextContent>;
+
+  /**
+   * Return the visible portion of this page in user space units as an
+   * `[x1, y1, x2, y2]` tuple.
+   */
+  get view(): [number, number, number, number];
 };
 
 export type PDFPageView = {


### PR DESCRIPTION
This PR implements anchoring and highlighting of shape selectors in PDFs. This enables annotation using the rectangle and point tools to be used end-to-end, with highlights persisting after the page is reloaded. The highlighting style is a first cut and will be refined later.

**Representing anchored shapes:**

Up until now, annotation selectors have always anchored to a DOM Range. For shape selectors there isn't always a DOM range which corresponds to the content of the shape. Hence annotations with shape selectors are resolved to an "anchored shape" (`ShapeAnchor`) instead of a DOM Range. An anchored shape is a combination of a DOM element used as an "anchor" or reference point, and a shape whose coordinates reference the anchor. For PDFs the anchor element is the DOM element which contains the page on which the annotation was made, and the shape is created by mapping the PDF user-space coordinates from the shape selector to a coordinate space where (0, 0) is the top-left corner of the anchor element and (1, 1) is the bottom right. This combination of anchor + anchor-relative coordinates should work for other document types too. For example when annotating an image in an HTML document, the anchor would be the image element and the coordinates would work the same as for a PDF page. In some cases it may be convenient to use a coordinate system with different units. If a rect annotation on an HTML document doesn't lie neatly within some image-like element, then using ordinary document units might work better.

**Preview:**

<img width="900" alt="PDF rect highlighting" src="https://github.com/user-attachments/assets/5e45fca9-3794-466f-80c4-ebbda588ca78" />

**Summary of changes:**

 - Change `anchor` method of integrations to support resolving selectors to DOM
   ranges or "anchored shapes". An anchored shape is a combination of an anchor
   element, such as the container for a PDF page, and a shape whose coordinates
   are relative to the anchor.
 - Expose `PDFPageView.view` property in PDF.js types
 - Implement anchoring of rect and point shape selectors in PDFs
 - Implement initial creation of highlight elements for shapes
 - In `Guest`, anchor newly created annotations with shape regions in
   order to draw highlights.

**Testing:**

With the `pdf_image_annotation` flag enabled:

1. Go to a PDF and use the rect tool to select an area. After making a selection, a highlight should be drawn with that area. 
2. Reload the page and the rect annotation should re-appear
3. Scroll the PDF, click on the annotation card in the sidebar and it should scroll to the highlight
4. Repeat steps 1-3 but use the point tool. Highlighting for point tools currently uses a small rect. This will be refined later.

**Known issues:**

- Some of the above comments above and in the code refer to corners of an element. These don't say which box (content, border, padding) is being referred to. That needs to be clarified.
- The sidebar does not know how to sort annotations with shape selectors by location. Hence the order may not be what you expect.

**TODO:**

- [x] Tests for anchoring and highlighting of annotations with shape selectors in the Guest tests