### PR TITLE
Improve contrast ratio in annotation textarea

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.16.7",
     "@hypothesis/frontend-build": "^3.0.0",
-    "@hypothesis/frontend-shared": "^9.2.0",
+    "@hypothesis/frontend-shared": "^9.2.1",
     "@hypothesis/frontend-testing": "^1.3.1",
     "@npmcli/arborist": "^9.0.0",
     "@octokit/rest": "^21.0.0",

--- a/src/sidebar/components/MarkdownEditor.tsx
+++ b/src/sidebar/components/MarkdownEditor.tsx
@@ -326,7 +326,7 @@ function TextArea({
       <textarea
         className={classnames(
           'border rounded p-2',
-          'text-color-text-light bg-grey-0',
+          'placeholder:text-grey-6 bg-grey-0',
           'focus:bg-white focus:outline-none focus:shadow-focus-inner',
           classes,
         )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2504,15 +2504,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/frontend-shared@npm:^9.2.0":
-  version: 9.2.0
-  resolution: "@hypothesis/frontend-shared@npm:9.2.0"
+"@hypothesis/frontend-shared@npm:^9.2.1":
+  version: 9.2.1
+  resolution: "@hypothesis/frontend-shared@npm:9.2.1"
   dependencies:
     highlight.js: ^11.6.0
     wouter-preact: ^3.0.0
   peerDependencies:
     preact: ^10.25.1
-  checksum: 1775cf2ce3fe463076973e41c271707a786169ab6a271e91be642dc6beb5a8dec3d1513a313c19a647b1341c7529fc2aef1a71b836232eea0dc208ebdbb08939
+  checksum: fe7c87658069722ae16053591daec238d4725e77656fd609e4f9a9c842f4f760882b922cdbbb7f7807d20a43b05787ebbc659c658179f0bf49a98b47c906e18b
   languageName: node
   linkType: hard
 
@@ -9020,7 +9020,7 @@ __metadata:
     "@babel/preset-react": ^7.0.0
     "@babel/preset-typescript": ^7.16.7
     "@hypothesis/frontend-build": ^3.0.0
-    "@hypothesis/frontend-shared": ^9.2.0
+    "@hypothesis/frontend-shared": ^9.2.1
     "@hypothesis/frontend-testing": ^1.3.1
     "@npmcli/arborist": ^9.0.0
     "@octokit/rest": ^21.0.0


### PR DESCRIPTION
As part of https://github.com/hypothesis/client/issues/6866, and following https://github.com/hypothesis/client/issues/6866#issuecomment-2786357124, this PR updates the text color and placeholder color in the annotation textarea to darker shades of grey:

- grey-6 (`#737373`) for placeholder. 
    > I originally recommended `#767676`, but the difference is hard to notice, so using grey-6 we avoid having to define a new color.
- grey-9 (`#202020`) for the text, via inheriting the page color, as the rest of the inputs do.

This PR does not cover changing this anywhere other than the annotation textarea. I'll prepare follow-up PRs to update the defaults in the shared library and other projects. 

Before:
![Captura desde 2025-04-08 15-17-01](https://github.com/user-attachments/assets/fad03160-3887-4d05-833d-a9116d9b254e)
![Captura desde 2025-04-08 15-17-07](https://github.com/user-attachments/assets/c9067d66-30c8-4b12-84c2-844595e35a32)

After:
![Captura desde 2025-04-08 15-16-10](https://github.com/user-attachments/assets/20b72385-55fc-45c9-bba1-0ebea52262dc)
![Captura desde 2025-04-08 15-16-19](https://github.com/user-attachments/assets/d65cd452-f633-4cd3-a84b-e348f62b7376)
