### PR TITLE
Add ellipsis to placeholders missing it

### DIFF
--- a/src/sidebar/components/MarkdownEditor.tsx
+++ b/src/sidebar/components/MarkdownEditor.tsx
@@ -659,7 +659,7 @@ export default function MarkdownEditor({
       ) : (
         <TextArea
           aria-label={label}
-          placeholder={label}
+          placeholder={`${label}…`}
           dir="auto"
           classes={classnames(
             'w-full min-h-[8em] resize-y',

--- a/src/sidebar/components/TagEditor.tsx
+++ b/src/sidebar/components/TagEditor.tsx
@@ -268,7 +268,7 @@ function TagEditor({
           onKeyDown={handleKeyDown}
           onFocus={handleFocus}
           elementRef={inputEl}
-          placeholder="Add new tags"
+          placeholder="Add new tags…"
           type="text"
           autoComplete="off"
           aria-autocomplete="list"

--- a/src/sidebar/components/test/MarkdownEditor-test.js
+++ b/src/sidebar/components/test/MarkdownEditor-test.js
@@ -361,7 +361,7 @@ describe('MarkdownEditor', () => {
     const wrapper = createComponent({ label: 'Enter comment' });
     const inputField = wrapper.find('textarea');
     assert.equal(inputField.prop('aria-label'), 'Enter comment');
-    assert.equal(inputField.prop('placeholder'), 'Enter comment');
+    assert.equal(inputField.prop('placeholder'), 'Enter comment…');
   });
 
   it('unwraps mention tags', () => {


### PR DESCRIPTION
This PR adds an ellipsis to the inputs where the placeholder does not have it yet. That makes it more obvious that it is in fact a placeholder and not the actual input value, now that we are using a darker shade of grey for placeholders: https://github.com/hypothesis/client/pull/6966

Before:
![image](https://github.com/user-attachments/assets/73e2996e-0e8a-430a-94d3-dc82a1c8a774)
![image](https://github.com/user-attachments/assets/b6badcc6-9c2a-4af8-a896-dc467e06c646)

After:
![image](https://github.com/user-attachments/assets/28b8f3e3-2702-4e80-ba25-86224353d787)
![image](https://github.com/user-attachments/assets/202b8362-c517-4304-8cf4-55dc07f8c542)

