### PR TITLE
Correct shape anchoring in PDF pages with offset bounding box

### DIFF
--- a/src/annotator/anchoring/pdf.ts
+++ b/src/annotator/anchoring/pdf.ts
@@ -644,6 +644,9 @@ async function anchorShape(
   const pageWidth = pageRight - pageLeft;
   const pageHeight = pageTop - pageBottom;
 
+  const mapX = (x: number) => (x - pageLeft) / pageWidth;
+  const mapY = (y: number) => (pageTop - y) / pageHeight;
+
   // Map the user-space coordinates of the shape to coordinates relative to the
   // PDF page container, where the top-left is (0, 0) and the bottom right is
   // (1, 1).
@@ -652,19 +655,19 @@ async function anchorShape(
     case 'rect':
       {
         const s = shapeSelector.shape;
-        const left = (s.left - pageLeft) / pageWidth;
-        const top = (pageHeight - s.top) / pageHeight;
-        const right = (s.right - pageLeft) / pageWidth;
-        const bottom = (pageHeight - s.bottom) / pageHeight;
-        shape = { type: 'rect', left, right, top, bottom };
+        shape = {
+          type: 'rect',
+          left: mapX(s.left),
+          right: mapX(s.right),
+          top: mapY(s.top),
+          bottom: mapY(s.bottom),
+        };
       }
       break;
     case 'point':
       {
         const s = shapeSelector.shape;
-        const x = (s.x - pageLeft) / pageWidth;
-        const y = (pageHeight - s.y) / pageHeight;
-        shape = { type: 'point', x, y };
+        shape = { type: 'point', x: mapX(s.x), y: mapY(s.y) };
       }
       break;
     default:

--- a/src/annotator/anchoring/test/fake-pdf-viewer-application.js
+++ b/src/annotator/anchoring/test/fake-pdf-viewer-application.js
@@ -71,10 +71,18 @@ class FakePDFPageProxy {
   constructor(pageText, config) {
     this.pageText = pageText;
     this._config = config;
+    this._view = [0, 0, 100, 200]; // [left, bottom, right, top]
+  }
+
+  /**
+   * Set the page bounding box. This is not part of the `PDFPageProxy` API.
+   */
+  setPageBoundingBox(box) {
+    this._view = box;
   }
 
   get view() {
-    return [0, 0, 100, 200]; // [left, bottom, right, top]
+    return this._view;
   }
 
   getTextContent(params = {}) {

--- a/src/annotator/anchoring/test/pdf-test.js
+++ b/src/annotator/anchoring/test/pdf-test.js
@@ -708,6 +708,7 @@ describe('annotator/anchoring/pdf', () => {
     [
       // Rect annotation
       {
+        pageBoundingBox: [5, 9, 105, 209],
         selectors: [
           {
             type: 'ShapeSelector',
@@ -715,10 +716,10 @@ describe('annotator/anchoring/pdf', () => {
             // Rect at bottom-left corner of page.
             shape: {
               type: 'rect',
-              left: 0,
-              top: 0,
-              right: 10,
-              bottom: 10,
+              left: 5,
+              top: 9,
+              right: 15,
+              bottom: 19,
             },
           },
           { type: 'PageSelector', index: 0 },
@@ -737,12 +738,13 @@ describe('annotator/anchoring/pdf', () => {
       },
       // Point annotation
       {
+        pageBoundingBox: [5, 9, 105, 209],
         selectors: [
           {
             type: 'ShapeSelector',
 
             // Point at bottom-left corner of page.
-            shape: { type: 'point', x: 0, y: 0 },
+            shape: { type: 'point', x: 5, y: 9 },
           },
           { type: 'PageSelector', index: 1 },
         ],
@@ -752,12 +754,34 @@ describe('annotator/anchoring/pdf', () => {
           coordinates: 'anchor',
         },
       },
-    ].forEach(({ selectors, expected }) => {
+      {
+        pageBoundingBox: [5, 9, 105, 209],
+        selectors: [
+          {
+            type: 'ShapeSelector',
+
+            // Point at top-right corner of page.
+            shape: { type: 'point', x: 105, y: 209 },
+          },
+          { type: 'PageSelector', index: 1 },
+        ],
+        expected: {
+          anchor: 1,
+          shape: { type: 'point', x: 1, y: 0 },
+          coordinates: 'anchor',
+        },
+      },
+    ].forEach(({ pageBoundingBox, selectors, expected }) => {
       it('anchors shape selectors', async () => {
+        const pageView = viewer.pdfViewer.getPageView(expected.anchor);
+
+        // Set page bounding box in PDF user space coordinates.
+        pageView.pdfPage.setPageBoundingBox(pageBoundingBox);
+
         const anchor = await pdfAnchoring.anchor(selectors);
         const expectedAnchor = {
           ...expected,
-          anchor: viewer.pdfViewer.getPageView(expected.anchor).div,
+          anchor: pageView.div,
         };
         assert.deepEqual(anchor, expectedAnchor);
       });


### PR DESCRIPTION
Conversion of Y coordinates from PDF user space to "anchor space" (relative to the DOM container element for the PDF page) was incorrect if the bottom-left corner of the page bounding box, in PDF user space, was not at (0, 0).

The transform should map a Y coordinate equal to `pageTop` to 0 and a Y coordinate equal to `pageBottom` to 1. Change the transform so this is the case.

**Testing:**

1. Open https://static1.squarespace.com/static/5a79d12eb7411c0be496e3f1/t/5d321843582c3000015c3105/1563564106926/LAZIER_EARTHRISE.pdf in your local Via
2. Scroll to the second page and draw a rect annotation around Earth in the photo

On `main`, the bounding box of the highlight will be offset vertically compared to the selection you drew. On this branch the highlight rect should appear in the same place as the selection.