### PR TITLE
Attempt to fix flakey tests for HTML side-by-side mode

### DIFF
--- a/src/annotator/integrations/test/html-side-by-side-test.js
+++ b/src/annotator/integrations/test/html-side-by-side-test.js
@@ -161,10 +161,8 @@ the fighting was.`;
 
       // nb. `scrollTop` returns an integer number of pixels, whereas `delta`
       // may be fractional.
-      assert.equal(
-        Math.floor(scrollRoot.scrollTop),
-        Math.floor(initialScrollTop + delta),
-      );
+      const tolerance = 2;
+      assert.closeTo(scrollRoot.scrollTop, initialScrollTop + delta, tolerance);
     }
 
     it('selects content as a scroll anchor and preserves its position in the viewport', () => {


### PR DESCRIPTION
In CI we have sometimes seen this test fail [^1] with:

```
AssertionError: expected 290 to equal 289

+ expected - actual

-290
+289
```

I haven't determined exactly where this one pixel difference comes from, but since the actual/expected results are very close, allowing a tolerance in the comparison is fine.

[^1]: https://github.com/hypothesis/client/actions/runs/14376354889/job/40309621923?pr=6968