### PR TITLE
Make click and hover handling work for shape highlights

### DIFF
--- a/src/annotator/highlighter.ts
+++ b/src/annotator/highlighter.ts
@@ -439,24 +439,17 @@ export function setHighlightsVisible(root: HTMLElement, visible: boolean) {
 }
 
 /**
- * Get the highlight elements that contain the given node.
+ * Get the highlight elements at the given client coordinates.
  */
-export function getHighlightsContainingNode(node: Node): HighlightElement[] {
-  let el =
-    node.nodeType === Node.ELEMENT_NODE
-      ? (node as Element)
-      : node.parentElement;
-
-  const highlights = [];
-
-  while (el) {
-    if (el.classList.contains('hypothesis-highlight')) {
-      highlights.push(el);
-    }
-    el = el.parentElement;
-  }
-
-  return highlights as HighlightElement[];
+export function getHighlightsFromPoint(
+  x: number,
+  y: number,
+): HighlightElement[] {
+  return document
+    .elementsFromPoint(x, y)
+    .filter(
+      el => el.localName === 'hypothesis-highlight',
+    ) as HighlightElement[];
 }
 
 // Subset of `DOMRect` interface

--- a/src/annotator/test/highlighter-test.js
+++ b/src/annotator/test/highlighter-test.js
@@ -2,7 +2,7 @@ import { render } from 'preact';
 
 import {
   getBoundingClientRect,
-  getHighlightsContainingNode,
+  getHighlightsFromPoint,
   highlightRange,
   highlightShape,
   removeHighlights,
@@ -780,38 +780,34 @@ describe('annotator/highlighter', () => {
     });
   });
 
-  describe('getHighlightsContainingNode', () => {
-    const makeRange = (start, end = start) => {
-      const range = new Range();
-      range.setStartBefore(start);
-      range.setEndAfter(end);
-      return range;
-    };
+  describe('getHighlightsFromPoint', () => {
+    it('returns all the highlights at the given point', () => {
+      const container = document.createElement('div');
+      const elements = [
+        document.createElement('hypothesis-highlight'),
+        document.createElement('hypothesis-highlight'),
+        document.createElement('not-a-highlight'),
+      ];
+      document.body.append(container);
 
-    it('returns all the highlights containing the node', () => {
-      const root = document.createElement('div');
-      const text0 = document.createTextNode('One');
-      const text1 = document.createTextNode('Two');
-      root.appendChild(text0);
-      root.appendChild(text1);
+      for (const hl of elements) {
+        hl.style.position = 'absolute';
+        hl.style.left = '100px';
+        hl.style.top = '200px';
+        hl.style.width = '10px';
+        hl.style.height = '10px';
+        container.append(hl);
+      }
 
-      const [highlight0] = highlightRange(makeRange(text0, text1));
-      const [highlight1] = highlightRange(makeRange(text0));
-
-      const highlights = getHighlightsContainingNode(text0);
-
-      assert.deepEqual(highlights, [highlight1, highlight0]);
-    });
-
-    it('returns an empty array if the node is not contained in a highlight', () => {
-      const root = document.createElement('div');
-      root.textContent = 'Test text';
-      assert.deepEqual(getHighlightsContainingNode(root.childNodes[0]), []);
-    });
-
-    it('returns an empty array if node has no parent element', () => {
-      const text = document.createTextNode('foobar');
-      assert.deepEqual(getHighlightsContainingNode(text), []);
+      try {
+        assert.sameMembers(
+          getHighlightsFromPoint(105, 205),
+          elements.slice(0, 2),
+        );
+        assert.deepEqual(getHighlightsFromPoint(0, 0), []);
+      } finally {
+        container.remove();
+      }
     });
   });
 


### PR DESCRIPTION
Make clicking and hovering highlights of shape annotations work the same as for text annotations. This is done by changing the lookup of highlight elements to be done using `document.elementsFromPoint` instead of traversing the DOM hierarchy from the node where the mouse event was received. The previous method only worked when the highlighted contents were text nodes inside a `<hypothesis-highlight>`.

There is a known issue that drawing a rect highlight prevents any interaction with elements under it. That will be addressed separately.

**Testing:**

1. Go into a PDF and make a mix of text, rect and point annotations
2. Hover the highlights, and the annotation cards should appear hovered in the sidebar (more pronounced shadow)
3. Click the highlights and they should be focused in the sidebar
4. Click on highlights when the sidebar is closed and it should open
5. Go to an HTML document. Text highlights should work the same as before.