### PR TITLE
Style shape highlights with CSS

### DIFF
--- a/src/annotator/highlighter.ts
+++ b/src/annotator/highlighter.ts
@@ -217,14 +217,11 @@ export function highlightShape(region: ShapeAnchor): HighlightElement[] {
     anchorOuterBox.height - 2 * borderWidth,
   );
 
-  const highlightBorderWidth = 3;
   const highlightEl = document.createElement('hypothesis-highlight');
-  highlightEl.style.position = 'absolute';
-  highlightEl.style.zIndex = '10';
 
-  // This color is similar to the default highlight fill, but darker so it has
-  // more contrast when used as a border.
-  highlightEl.style.border = `${highlightBorderWidth}px solid #edd72b`;
+  // Should match the width used by the `hypothesis-shape-highlight` class.
+  const highlightBorderWidth = 3;
+  highlightEl.className = 'hypothesis-shape-highlight';
 
   if (shape.type === 'rect') {
     const left = shape.left * anchorBox.width - borderWidth;

--- a/src/styles/annotator/highlights.scss
+++ b/src/styles/annotator/highlights.scss
@@ -85,6 +85,15 @@
   }
 }
 
+.hypothesis-shape-highlight {
+  border: 3px solid transparent;
+  position: absolute;
+  z-index: 10;
+
+  // Allow interaction with content under the highlight when not visible.
+  visibility: hidden;
+}
+
 @mixin clusterHighlightStyles($clusterKey) {
   .hypothesis-highlight.#{$clusterKey},
   .hypothesis-svg-highlight.#{$clusterKey} {
@@ -189,6 +198,14 @@
     @apply sr-only;
     content: ' annotation end ';
   }
+}
+
+.hypothesis-highlights-always-on .hypothesis-shape-highlight {
+  // This color is similar to the default highlight fill, but darker so it has
+  // more contrast when used as a border.
+  border-color: #edd72b;
+  cursor: pointer;
+  visibility: visible;
 }
 
 // Apply focused-highlight styling


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/client/pull/6970.**

Move the styling of shape highlights from inline styles set in JS to CSS. This makes them consistent with text highlights and also enables shape highlight visibility to reflect the global highlights-visible status.

Shape highlights use a different class than regular highlights because they have different colors and other attributes.

Fixes https://github.com/hypothesis/client/issues/6971

---

**Testing:**

1. Create a mix of text, rect and point annotations on a PDF
2. Click the eye icon in the toolbar to toggle highlight visibility. This should affect all highlights.