### PR TITLE
Enable interaction with content inside shape highlights

### DIFF
--- a/src/annotator/test/highlighter-test.js
+++ b/src/annotator/test/highlighter-test.js
@@ -781,28 +781,41 @@ describe('annotator/highlighter', () => {
   });
 
   describe('getHighlightsFromPoint', () => {
+    const createHighlight = type => {
+      const hl = document.createElement('hypothesis-highlight');
+      hl.style.position = 'absolute';
+      hl.style.left = '100px';
+      hl.style.top = '200px';
+      hl.style.width = '10px';
+      hl.style.height = '10px';
+
+      if (type === 'shape') {
+        // Disable pointer events to match real shape highlights.
+        hl.style.pointerEvents = 'none';
+        hl.classList.add('hypothesis-shape-highlight');
+      }
+
+      return hl;
+    };
+
     it('returns all the highlights at the given point', () => {
       const container = document.createElement('div');
       const elements = [
-        document.createElement('hypothesis-highlight'),
-        document.createElement('hypothesis-highlight'),
+        createHighlight('text'),
+        createHighlight('text'),
+        createHighlight('shape'),
         document.createElement('not-a-highlight'),
       ];
       document.body.append(container);
 
       for (const hl of elements) {
-        hl.style.position = 'absolute';
-        hl.style.left = '100px';
-        hl.style.top = '200px';
-        hl.style.width = '10px';
-        hl.style.height = '10px';
         container.append(hl);
       }
 
       try {
         assert.sameMembers(
           getHighlightsFromPoint(105, 205),
-          elements.slice(0, 2),
+          elements.filter(hl => hl.localName === 'hypothesis-highlight'),
         );
         assert.deepEqual(getHighlightsFromPoint(0, 0), []);
       } finally {

--- a/src/styles/annotator/highlights.scss
+++ b/src/styles/annotator/highlights.scss
@@ -89,9 +89,10 @@
   border: 3px solid transparent;
   position: absolute;
   z-index: 10;
-
-  // Allow interaction with content under the highlight when not visible.
   visibility: hidden;
+
+  // Enable interaction with content inside the shape.
+  pointer-events: none;
 }
 
 @mixin clusterHighlightStyles($clusterKey) {


### PR DESCRIPTION
Set `pointer-events: none` on shape highlights so that the user can still interact with any text or other content that happens to be inside the highlight. The downside to this is that the element become invisible for DOM hit-testing methods such as `elementsFromPoint`, so we have to implement our own hit testing.

**Testing:**

1. In a PDF, draw a rect annotation over an area that includes some text or other interactive content
2. Test that you can still select text or interact with the content after highlighting it. This should work whether the highlight is visible or not