### PR TITLE
Replace tiny-emitter with strongly-typed event emitter

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "showdown": "^2.0.0",
     "sinon": "^20.0.0",
     "tailwindcss": "^3.0.2",
-    "tiny-emitter": "^2.0.2",
     "typescript": "^5.0.2",
     "typescript-eslint": "^8.10.0",
     "wrap-text": "^1.0.7"

--- a/src/annotator/anchoring/test/fake-pdf-viewer-application.js
+++ b/src/annotator/anchoring/test/fake-pdf-viewer-application.js
@@ -9,8 +9,7 @@
  * each of the relevant classes in PDF.js. The APIs of the fakes should conform
  * to the corresponding interfaces defined in `src/types/pdfjs.js`.
  */
-import { TinyEmitter as EventEmitter } from 'tiny-emitter';
-
+import { EventEmitter } from '../../../shared/event-emitter';
 import { RenderingStates } from '../pdf';
 
 /**

--- a/src/annotator/components/NotebookModal.tsx
+++ b/src/annotator/components/NotebookModal.tsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 
 import { addConfigFragment } from '../../shared/config-fragment';
+import type { Events } from '../../types/annotator';
 import { createAppConfig } from '../config/app';
 import type { EventBus, Emitter } from '../util/emitter';
 import ModalDialog from './ModalDialog';
@@ -43,7 +44,7 @@ function NotebookIframe({ config, groupId }: NotebookIframeProps) {
 }
 
 export type NotebookModalProps = {
-  eventBus: EventBus;
+  eventBus: EventBus<Events>;
   config: NotebookConfig;
 };
 
@@ -62,7 +63,7 @@ export default function NotebookModal({
   const [isHidden, setIsHidden] = useState(true);
   const [groupId, setGroupId] = useState<string | null>(null);
   const originalDocumentOverflowStyle = useRef('');
-  const emitterRef = useRef<Emitter | null>(null);
+  const emitterRef = useRef<Emitter<Events> | null>(null);
 
   // Stores the original overflow CSS property of document.body and reset it
   // when the component is destroyed

--- a/src/annotator/components/ProfileModal.tsx
+++ b/src/annotator/components/ProfileModal.tsx
@@ -2,19 +2,20 @@ import { CancelIcon, IconButton } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useEffect, useRef, useState } from 'preact/hooks';
 
+import type { Events } from '../../types/annotator';
 import type { Emitter, EventBus } from '../util/emitter';
 import ModalDialog from './ModalDialog';
 
 export type ProfileConfig = { profileAppUrl: string } & Record<string, unknown>;
 
 type ProfileModalProps = {
-  eventBus: EventBus;
+  eventBus: EventBus<Events>;
   config: ProfileConfig;
 };
 
 export default function ProfileModal({ eventBus, config }: ProfileModalProps) {
   const [isHidden, setIsHidden] = useState(true);
-  const emitterRef = useRef<Emitter | null>(null);
+  const emitterRef = useRef<Emitter<Events> | null>(null);
 
   useEffect(() => {
     const emitter = eventBus.createEmitter();

--- a/src/annotator/components/ToastMessages.tsx
+++ b/src/annotator/components/ToastMessages.tsx
@@ -2,10 +2,11 @@ import { ToastMessages as BaseToastMessages } from '@hypothesis/frontend-shared'
 import type { ToastMessage } from '@hypothesis/frontend-shared';
 import { useCallback, useEffect, useState } from 'preact/hooks';
 
+import type { Events } from '../../types/annotator';
 import type { Emitter } from '../util/emitter';
 
 export type ToastMessagesProps = {
-  emitter: Emitter;
+  emitter: Emitter<Events>;
 };
 
 /**

--- a/src/annotator/components/test/ToastMessages-test.js
+++ b/src/annotator/components/test/ToastMessages-test.js
@@ -1,6 +1,6 @@
 import { mount } from '@hypothesis/frontend-testing';
-import EventEmitter from 'tiny-emitter';
 
+import { EventEmitter } from '../../../shared/event-emitter';
 import { Emitter } from '../../util/emitter';
 import ToastMessages from '../ToastMessages';
 

--- a/src/annotator/features.ts
+++ b/src/annotator/features.ts
@@ -1,7 +1,9 @@
-import { TinyEmitter } from 'tiny-emitter';
-
+import { EventEmitter } from '../shared/event-emitter';
 import { warnOnce } from '../shared/warn-once';
-import type { FeatureFlags as IFeatureFlags } from '../types/annotator';
+import type {
+  FeatureFlags as IFeatureFlags,
+  FeatureFlagsEvents,
+} from '../types/annotator';
 
 /**
  * List of feature flags that annotator code tests for.
@@ -11,7 +13,10 @@ const annotatorFlags = ['pdf_image_annotation', 'styled_highlight_clusters'];
 /**
  * An observable container of feature flags.
  */
-export class FeatureFlags extends TinyEmitter implements IFeatureFlags {
+export class FeatureFlags
+  extends EventEmitter<FeatureFlagsEvents>
+  implements IFeatureFlags
+{
   /** Map of flag name to enabled state. */
   private _flags: Map<string, boolean>;
   private _knownFlags: string[];

--- a/src/annotator/guest.ts
+++ b/src/annotator/guest.ts
@@ -1,6 +1,6 @@
 import { ListenerCollection } from '@hypothesis/frontend-shared';
-import { TinyEmitter } from 'tiny-emitter';
 
+import { EventEmitter } from '../shared/event-emitter';
 import { PortFinder, PortRPC } from '../shared/messaging';
 import { generateHexString } from '../shared/random';
 import { matchShortcut } from '../shared/shortcut';
@@ -171,6 +171,10 @@ export class ScrollToRangeEvent extends CustomEvent<Range> {
   }
 }
 
+export type Events = {
+  hostDisconnected(): void;
+};
+
 /**
  * `Guest` is the central class of the annotator that handles anchoring (locating)
  * annotations in the document when they are fetched by the sidebar, rendering
@@ -188,7 +192,10 @@ export class ScrollToRangeEvent extends CustomEvent<Range> {
  * each frame connects to the sidebar and host frames as part of its
  * initialization.
  */
-export class Guest extends TinyEmitter implements Annotator, Destroyable {
+export class Guest
+  extends EventEmitter<Events>
+  implements Annotator, Destroyable
+{
   public element: HTMLElement;
 
   /** Ranges of the current text selection. */
@@ -674,6 +681,8 @@ export class Guest extends TinyEmitter implements Annotator, Destroyable {
     removeAllHighlights(this.element);
 
     this._integration.destroy();
+
+    super.destroy();
   }
 
   /**

--- a/src/annotator/index.ts
+++ b/src/annotator/index.ts
@@ -7,7 +7,7 @@ import {
   PortProvider,
   installPortCloseWorkaroundForSafari,
 } from '../shared/messaging';
-import type { Destroyable } from '../types/annotator';
+import type { Destroyable, Events } from '../types/annotator';
 import type { NotebookConfig } from './components/NotebookModal';
 import type { ProfileConfig } from './components/ProfileModal';
 import { getConfig } from './config/index';
@@ -105,7 +105,7 @@ function init() {
     const hypothesisAppsOrigin = new URL(sidebarConfig.sidebarAppUrl).origin;
     const portProvider = new PortProvider(hypothesisAppsOrigin);
 
-    const eventBus = new EventBus();
+    const eventBus = new EventBus<Events>();
     const sidebar = new Sidebar(document.body, eventBus, sidebarConfig);
     const notebook = new Notebook(
       document.body,

--- a/src/annotator/integrations/html.ts
+++ b/src/annotator/integrations/html.ts
@@ -1,10 +1,10 @@
-import { TinyEmitter } from 'tiny-emitter';
-
+import { EventEmitter } from '../../shared/event-emitter';
 import type {
   Anchor,
   AnnotationTool,
   FeatureFlags,
   Integration,
+  IntegrationEvents,
   Shape,
   SidebarLayout,
   SideBySideOptions,
@@ -31,7 +31,10 @@ const MIN_HTML_WIDTH = 480;
  * This integration is used for web pages and applications that are not handled
  * by a more specific integration (eg. for PDFs).
  */
-export class HTMLIntegration extends TinyEmitter implements Integration {
+export class HTMLIntegration
+  extends EventEmitter<IntegrationEvents>
+  implements Integration
+{
   container: HTMLElement;
   featureFlags: FeatureFlags;
 
@@ -151,6 +154,7 @@ export class HTMLIntegration extends TinyEmitter implements Integration {
     this._navObserver.disconnect();
     this._metaObserver.disconnect();
     this.featureFlags.off('flagsChanged', this._flagsChanged);
+    super.destroy();
   }
 
   contentContainer() {

--- a/src/annotator/integrations/pdf.tsx
+++ b/src/annotator/integrations/pdf.tsx
@@ -1,7 +1,7 @@
 import { ListenerCollection } from '@hypothesis/frontend-shared';
 import debounce from 'lodash.debounce';
-import { TinyEmitter } from 'tiny-emitter';
 
+import { EventEmitter } from '../../shared/event-emitter';
 import type {
   Anchor,
   AnnotationData,
@@ -11,6 +11,7 @@ import type {
   Destroyable,
   FeatureFlags,
   Integration,
+  IntegrationEvents,
   Shape,
   ShapeAnchor,
   SidebarLayout,
@@ -165,7 +166,10 @@ export type Options = {
 /**
  * Integration that works with PDF.js
  */
-export class PDFIntegration extends TinyEmitter implements Integration {
+export class PDFIntegration
+  extends EventEmitter<IntegrationEvents>
+  implements Integration
+{
   private _annotator: Annotator;
 
   /** Banners shown at the top of the PDF viewer. */
@@ -266,6 +270,8 @@ export class PDFIntegration extends TinyEmitter implements Integration {
     this._observer.disconnect();
     this._banner.destroy();
     this._destroyed = true;
+
+    super.destroy();
   }
 
   /**

--- a/src/annotator/integrations/test/pdf-metadata-test.js
+++ b/src/annotator/integrations/test/pdf-metadata-test.js
@@ -1,6 +1,6 @@
 import { delay } from '@hypothesis/frontend-testing';
-import EventEmitter from 'tiny-emitter';
 
+import { EventEmitter } from '../../../shared/event-emitter';
 import { promiseWithResolvers } from '../../../shared/promise-with-resolvers';
 import { PDFMetadata } from '../pdf-metadata';
 

--- a/src/annotator/integrations/vitalsource.ts
+++ b/src/annotator/integrations/vitalsource.ts
@@ -1,12 +1,13 @@
 import { ListenerCollection } from '@hypothesis/frontend-shared';
-import { TinyEmitter } from 'tiny-emitter';
 
 import { documentCFI, stripCFIAssertions } from '../../shared/cfi';
+import { EventEmitter } from '../../shared/event-emitter';
 import type {
   Anchor,
   AnnotationData,
   AnnotationTool,
   Integration,
+  IntegrationEvents,
   SegmentInfo,
   Shape,
   SidebarLayout,
@@ -222,7 +223,7 @@ function stripOrigin(url: string) {
  *    in the PDF image. This is similar to what PDF.js does for us in PDFs.
  */
 export class VitalSourceContentIntegration
-  extends TinyEmitter
+  extends EventEmitter<IntegrationEvents>
   implements Integration
 {
   private _bookElement: MosaicBookElement;
@@ -342,6 +343,7 @@ export class VitalSourceContentIntegration
     }
     this._listeners.removeAll();
     this._htmlIntegration.destroy();
+    super.destroy();
   }
 
   anchor(root: HTMLElement, selectors: Selector[]) {

--- a/src/annotator/notebook.tsx
+++ b/src/annotator/notebook.tsx
@@ -1,4 +1,4 @@
-import type { Destroyable } from '../types/annotator';
+import type { Destroyable, Events } from '../types/annotator';
 import NotebookModal from './components/NotebookModal';
 import type { NotebookConfig } from './components/NotebookModal';
 import type { EventBus } from './util/emitter';
@@ -13,7 +13,7 @@ export class Notebook implements Destroyable {
    */
   constructor(
     element: HTMLElement,
-    eventBus: EventBus,
+    eventBus: EventBus<Events>,
     config: NotebookConfig,
   ) {
     this._container = new PreactContainer('notebook', () => (

--- a/src/annotator/profile.tsx
+++ b/src/annotator/profile.tsx
@@ -1,4 +1,4 @@
-import type { Destroyable } from '../types/annotator';
+import type { Destroyable, Events } from '../types/annotator';
 import type { ProfileConfig } from './components/ProfileModal';
 import ProfileModal from './components/ProfileModal';
 import type { EventBus } from './util/emitter';
@@ -7,7 +7,11 @@ import { PreactContainer } from './util/preact-container';
 export class Profile implements Destroyable {
   private _container: PreactContainer;
 
-  constructor(element: HTMLElement, eventBus: EventBus, config: ProfileConfig) {
+  constructor(
+    element: HTMLElement,
+    eventBus: EventBus<Events>,
+    config: ProfileConfig,
+  ) {
     this._container = new PreactContainer('profile', () => (
       <ProfileModal eventBus={eventBus} config={config} />
     ));

--- a/src/annotator/sidebar.tsx
+++ b/src/annotator/sidebar.tsx
@@ -11,6 +11,7 @@ import type {
   AnnotationTool,
   SidebarLayout,
   Destroyable,
+  Events,
 } from '../types/annotator';
 import type { Service } from '../types/config';
 import type {
@@ -104,7 +105,7 @@ type DragResizeState = {
  * as well as (3) the adjacent controls.
  */
 export class Sidebar implements Destroyable {
-  private _emitter: Emitter;
+  private _emitter: Emitter<Events>;
   private _config: SidebarContainerConfig & SidebarConfig;
   private _dragResizeHandler: DragHandler | undefined;
   private _dragResizeState: DragResizeState;
@@ -151,7 +152,7 @@ export class Sidebar implements Destroyable {
    */
   constructor(
     element: HTMLElement,
-    eventBus: EventBus,
+    eventBus: EventBus<Events>,
     config: SidebarContainerConfig & SidebarConfig,
   ) {
     this._emitter = eventBus.createEmitter();

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -1,6 +1,6 @@
 import { delay } from '@hypothesis/frontend-testing';
-import { TinyEmitter } from 'tiny-emitter';
 
+import { EventEmitter } from '../../shared/event-emitter';
 import { Guest, $imports } from '../guest';
 
 class FakeAdder {
@@ -174,7 +174,7 @@ describe('Guest', () => {
 
     fakeFrameFillsAncestor = sinon.stub().returns(true);
 
-    fakeIntegration = Object.assign(new TinyEmitter(), {
+    fakeIntegration = Object.assign(new EventEmitter(), {
       anchor: sinon.stub(),
       getAnnotatableRange: sinon.stub().returnsArg(0),
       canStyleClusteredHighlights: sinon.stub().returns(false),

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -1,6 +1,5 @@
-import { TinyEmitter } from 'tiny-emitter';
-
 import { addConfigFragment } from '../../shared/config-fragment';
+import { EventEmitter } from '../../shared/event-emitter';
 import { Sidebar, MIN_RESIZE, $imports } from '../sidebar';
 import { Emitter } from '../util/emitter';
 
@@ -183,7 +182,7 @@ describe('Sidebar', () => {
 
     fakeSendErrorsTo = sinon.stub();
 
-    fakeEmitter = new Emitter(new TinyEmitter());
+    fakeEmitter = new Emitter(new EventEmitter());
 
     const fakeCreateAppConfig = sinon.spy((appURL, config) => {
       const appConfig = { ...config };

--- a/src/shared/event-emitter.ts
+++ b/src/shared/event-emitter.ts
@@ -1,0 +1,49 @@
+export type EventMap = Record<string, (...args: any) => void>;
+
+/**
+ * A simple event emitter with an API similar to Node's `EventEmitter`.
+ *
+ * `Event` is an object type that maps event names to the function signatures of
+ * subscribers for those events. For example, this defines an emitter which
+ * emits one event, `uriChanged`, with a single string argument:
+ *
+ * ```
+ * type Events = {
+ *   uriChanged(uri: string): void;
+ * }
+ * ```
+ */
+export class EventEmitter<Event extends EventMap> {
+  // Use a private field here to avoid conflicts with subclasses.
+  #listeners: Array<{ name: keyof Event; callback: (...args: any) => void }> =
+    [];
+
+  /** Remove all event listeners. */
+  destroy() {
+    this.#listeners = [];
+  }
+
+  /** Add an event handler. */
+  on<K extends keyof Event>(name: K, callback: Event[K]) {
+    this.#listeners.push({ name, callback });
+  }
+
+  /** Remove an event handler. */
+  off<K extends keyof Event>(name: K, callback: Event[K]) {
+    this.#listeners = this.#listeners.filter(
+      ln => !(ln.name === name && ln.callback === callback),
+    );
+  }
+
+  /** Emit an event. */
+  emit<K extends keyof Event>(name: K, ...args: Parameters<Event[K]>) {
+    for (const listener of this.#listeners) {
+      if (listener.name !== name) {
+        continue;
+      }
+      // Ensure callback is invoked without `this`.
+      const callback = listener.callback;
+      callback(...args);
+    }
+  }
+}

--- a/src/shared/messaging/port-provider.ts
+++ b/src/shared/messaging/port-provider.ts
@@ -1,6 +1,6 @@
 import { ListenerCollection } from '@hypothesis/frontend-shared';
-import { TinyEmitter } from 'tiny-emitter';
 
+import { EventEmitter } from '../../shared/event-emitter';
 import type { Destroyable } from '../../types/annotator';
 import { captureErrors, sendError } from '../frame-error-capture';
 import { isMessage, isMessageEqual, isSourceWindow } from './port-util';
@@ -61,7 +61,9 @@ type Channel =
  */
 export class PortProvider implements Destroyable {
   private _allowedMessages: Array<Partial<Message> & { allowedOrigin: string }>;
-  private _emitter: TinyEmitter;
+  private _emitter: EventEmitter<{
+    [event: string]: (...args: any) => void;
+  }>;
   private _hypothesisAppsOrigin: string;
 
   /**
@@ -87,7 +89,7 @@ export class PortProvider implements Destroyable {
    */
   constructor(hypothesisAppsOrigin: string) {
     this._hypothesisAppsOrigin = hypothesisAppsOrigin;
-    this._emitter = new TinyEmitter();
+    this._emitter = new EventEmitter();
 
     this._handledRequests = new Set();
 

--- a/src/shared/test/event-emitter-test.js
+++ b/src/shared/test/event-emitter-test.js
@@ -1,0 +1,53 @@
+import { EventEmitter } from '../event-emitter';
+
+describe('EventEmitter', () => {
+  describe('#on', () => {
+    it('registers a subscriber', () => {
+      const onFoo = sinon.stub();
+      const onBar = sinon.stub();
+      const emitter = new EventEmitter();
+
+      emitter.on('foo', onFoo);
+      emitter.on('bar', onBar);
+      emitter.emit('foo', 1, 2);
+      emitter.emit('bar', 3, 4);
+
+      assert.calledOnce(onFoo);
+      assert.calledWith(onFoo, 1, 2);
+      assert.calledOnce(onBar);
+      assert.calledWith(onBar, 3, 4);
+    });
+  });
+
+  describe('#off', () => {
+    it('removes a subscriber', () => {
+      const onFoo = sinon.stub();
+      const onFoo2 = sinon.stub();
+      const emitter = new EventEmitter();
+
+      emitter.on('foo', onFoo);
+      emitter.on('foo', onFoo2);
+      emitter.off('foo', onFoo);
+      emitter.emit('foo', 1, 2);
+
+      assert.notCalled(onFoo);
+      assert.calledWith(onFoo2, 1, 2);
+    });
+  });
+
+  describe('#destroy', () => {
+    it('removes all subscribers', () => {
+      const onFoo = sinon.stub();
+      const onFoo2 = sinon.stub();
+      const emitter = new EventEmitter();
+
+      emitter.on('foo', onFoo);
+      emitter.on('foo', onFoo2);
+      emitter.destroy();
+      emitter.emit('foo', 1, 2);
+
+      assert.notCalled(onFoo);
+      assert.notCalled(onFoo2);
+    });
+  });
+});

--- a/src/sidebar/search-client.ts
+++ b/src/sidebar/search-client.ts
@@ -1,5 +1,4 @@
-import { TinyEmitter } from 'tiny-emitter';
-
+import { EventEmitter } from '../shared/event-emitter';
 import type { Annotation, SearchQuery, SearchResponse } from '../types/api';
 
 /**
@@ -67,6 +66,13 @@ export type SearchOptions = {
   sortOrder?: SortOrder;
 };
 
+export type Events = {
+  resultCount(count: number): void;
+  results(anns: Annotation[]): void;
+  error(err: Error): void;
+  end(): void;
+};
+
 /**
  * Client for the Hypothesis annotation search API [1].
  *
@@ -77,7 +83,7 @@ export type SearchOptions = {
  *
  * [1] https://h.readthedocs.io/en/latest/api-reference/#tag/annotations/paths/~1search/get
  */
-export class SearchClient extends TinyEmitter {
+export class SearchClient extends EventEmitter<Events> {
   private _canceled: boolean;
   private _getPageSize: (pageIndex: number) => number;
   private _incremental: boolean;

--- a/src/sidebar/services/auth.ts
+++ b/src/sidebar/services/auth.ts
@@ -1,5 +1,4 @@
-import { TinyEmitter } from 'tiny-emitter';
-
+import { EventEmitter } from '../../shared/event-emitter';
 import type { SidebarSettings } from '../../types/config';
 import { serviceConfig } from '../config/service-config';
 import { OAuthClient } from '../util/oauth-client';
@@ -24,6 +23,10 @@ const isTokenInfo = (token: unknown): token is TokenInfo =>
   'expiresAt' in token &&
   typeof token.expiresAt === 'number';
 
+export type Events = {
+  oauthTokensChanged(): void;
+};
+
 /**
  * Authorization service.
  *
@@ -39,7 +42,7 @@ const isTokenInfo = (token: unknown): token is TokenInfo =>
  *
  * @inject
  */
-export class AuthService extends TinyEmitter {
+export class AuthService extends EventEmitter<Events> {
   /**
    * Authorization code from auth popup window. Set by the login method
    * and exchanged for an Access Token on the next API call.

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -1,6 +1,6 @@
 import { delay } from '@hypothesis/frontend-testing';
-import EventEmitter from 'tiny-emitter';
 
+import { EventEmitter } from '../../../shared/event-emitter';
 import { Injector } from '../../../shared/injector';
 import * as annotationFixtures from '../../test/annotation-fixtures';
 import { fakeReduxStore } from '../../test/fake-redux-store';

--- a/src/sidebar/services/test/load-annotations-test.js
+++ b/src/sidebar/services/test/load-annotations-test.js
@@ -1,5 +1,4 @@
-import EventEmitter from 'tiny-emitter';
-
+import { EventEmitter } from '../../../shared/event-emitter';
 import { LoadAnnotationsService, $imports } from '../load-annotations';
 
 let searchClients;

--- a/src/sidebar/services/test/router-test.js
+++ b/src/sidebar/services/test/router-test.js
@@ -1,5 +1,4 @@
-import EventEmitter from 'tiny-emitter';
-
+import { EventEmitter } from '../../../shared/event-emitter';
 import { RouterService } from '../router';
 
 const fixtures = [

--- a/src/sidebar/services/test/session-test.js
+++ b/src/sidebar/services/test/session-test.js
@@ -1,5 +1,4 @@
-import EventEmitter from 'tiny-emitter';
-
+import { EventEmitter } from '../../../shared/event-emitter';
 import { SessionService, $imports } from '../session';
 
 describe('SessionService', () => {

--- a/src/sidebar/services/test/streamer-test.js
+++ b/src/sidebar/services/test/streamer-test.js
@@ -1,7 +1,7 @@
 import { delay } from '@hypothesis/frontend-testing';
 import sinon from 'sinon';
-import EventEmitter from 'tiny-emitter';
 
+import { EventEmitter } from '../../../shared/event-emitter';
 import { promiseWithResolvers } from '../../../shared/promise-with-resolvers';
 import { fakeReduxStore } from '../../test/fake-redux-store';
 import { StreamerService, $imports } from '../streamer';

--- a/src/sidebar/services/toast-messenger.ts
+++ b/src/sidebar/services/toast-messenger.ts
@@ -1,6 +1,6 @@
 import type { ToastMessage } from '@hypothesis/frontend-shared';
-import { TinyEmitter } from 'tiny-emitter';
 
+import { EventEmitter } from '../../shared/event-emitter';
 import { generateHexString } from '../../shared/random';
 import type { SidebarStore } from '../store';
 
@@ -34,12 +34,17 @@ type MessageData = {
   options: MessageOptions;
 };
 
+export type Events = {
+  toastMessageAdded(msg: ToastMessage): void;
+  toastMessageDismissed(id: string): void;
+};
+
 /**
  * A service for managing toast messages. Added messages may be manually
  * dismissed with the `#dismiss()` method.
  */
 // @inject
-export class ToastMessengerService extends TinyEmitter {
+export class ToastMessengerService extends EventEmitter<Events> {
   private _store: SidebarStore;
   private _window: Window;
 

--- a/src/sidebar/test/cross-origin-rpc-test.js
+++ b/src/sidebar/test/cross-origin-rpc-test.js
@@ -1,5 +1,4 @@
-import EventEmitter from 'tiny-emitter';
-
+import { EventEmitter } from '../../shared/event-emitter';
 import { startServer, preStartServer, $imports } from '../cross-origin-rpc';
 
 class FakeWindow {

--- a/src/sidebar/util/test/postmessage-json-rpc-test.js
+++ b/src/sidebar/util/test/postmessage-json-rpc-test.js
@@ -1,5 +1,4 @@
-import EventEmitter from 'tiny-emitter';
-
+import { EventEmitter } from '../../../shared/event-emitter';
 import { call, notify, $imports } from '../postmessage-json-rpc';
 
 class FakeWindow {

--- a/src/sidebar/websocket.ts
+++ b/src/sidebar/websocket.ts
@@ -1,4 +1,4 @@
-import { TinyEmitter } from 'tiny-emitter';
+import { EventEmitter } from '../shared/event-emitter';
 
 // Status codes indicating the reason why a WebSocket connection closed.
 // See https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent and
@@ -14,6 +14,14 @@ export const CLOSE_ABNORMAL = 1006;
 // There are other possible close status codes not listed here. They are all
 // considered abnormal closures.
 
+export type SocketEvents = {
+  open(e: Event): void;
+  close(e: Event): void;
+  disconnect(): void;
+  message(e: MessageEvent): void;
+  error(e: Event): void;
+};
+
 /**
  * Socket is a minimal wrapper around {@link WebSocket} which provides:
  *
@@ -22,7 +30,7 @@ export const CLOSE_ABNORMAL = 1006;
  * - Queuing of messages passed to send() whilst the socket is
  *   connecting
  */
-export class Socket extends TinyEmitter {
+export class Socket extends EventEmitter<SocketEvents> {
   private _socket: WebSocket;
 
   /** Queue of JSON objects which have not yet been submitted. */

--- a/src/types/annotator.ts
+++ b/src/types/annotator.ts
@@ -1,5 +1,6 @@
-import type { TinyEmitter } from 'tiny-emitter';
+import type { ToastMessage } from '@hypothesis/frontend-shared';
 
+import type { EventEmitter } from '../shared/event-emitter';
 import type { APIAnnotationData, Selector, Target } from './api';
 import type { ClientAnnotationData } from './shared';
 
@@ -105,13 +106,17 @@ export type AnchorPosition = {
   bottom: number;
 };
 
+export type FeatureFlagsEvents = {
+  flagsChanged(): void;
+};
+
 /**
  * Interface for querying a collection of feature flags and subscribing to
  * flag updates.
  *
  * Emits a "flagsChanged" event when the flags are updated.
  */
-export type FeatureFlags = TinyEmitter & {
+export type FeatureFlags = EventEmitter<FeatureFlagsEvents> & {
   flagEnabled(flag: string): boolean;
 };
 
@@ -309,7 +314,15 @@ export type IntegrationBase = {
   supportedTools(): AnnotationTool[];
 };
 
-export type Integration = Destroyable & TinyEmitter & IntegrationBase;
+/** Events which {@link Integration}s may emit. */
+export type IntegrationEvents = {
+  supportedToolsChanged(tools: string[]): void;
+  uriChanged(uri: string): void;
+};
+
+export type Integration = Destroyable &
+  EventEmitter<IntegrationEvents> &
+  IntegrationBase;
 
 /**
  * Destroyable classes implement the `destroy` method to properly remove all
@@ -427,3 +440,16 @@ export type SideBySideMode = SideBySideOptions['mode'];
  * - "point" - Indicate a region of the document using a point (or "pin")
  */
 export type AnnotationTool = 'selection' | 'rect' | 'point';
+
+/**
+ * Set of events dispatched on the shared event bus used by various annotator
+ * components.
+ */
+export type Events = {
+  openNotebook(groupId: string): void;
+  closeNotebook(): void;
+  openProfile(): void;
+  closeProfile(): void;
+  toastMessageAdded(message: ToastMessage): void;
+  toastMessageDismissed(id: string): void;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -9102,7 +9102,6 @@ __metadata:
     showdown: ^2.0.0
     sinon: ^20.0.0
     tailwindcss: ^3.0.2
-    tiny-emitter: ^2.0.2
     typescript: ^5.0.2
     typescript-eslint: ^8.10.0
     wrap-text: ^1.0.7
@@ -14227,13 +14226,6 @@ __metadata:
   dependencies:
     any-promise: ^1.0.0
   checksum: 84e1b804bfec49f3531215f17b4a6e50fd4397b5f7c1bccc427b9c656e1ecfb13ea79d899930184f78bc2f57285c54d9a50a590c8868f4f0cef5c1d9f898b05e
-  languageName: node
-  linkType: hard
-
-"tiny-emitter@npm:^2.0.2":
-  version: 2.1.0
-  resolution: "tiny-emitter@npm:2.1.0"
-  checksum: fbcfb5145751a0e3b109507a828eb6d6d4501352ab7bb33eccef46e22e9d9ad3953158870a6966a59e57ab7c3f9cfac7cab8521db4de6a5e757012f4677df2dd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Replace the event emitter implementation from `tiny-emitter` with a local implementation with the same interface but stronger typing. This provides better documentation of the events used by each emitter and can help to catch errors during refactoring.

See the changes in `src/types/annotator.ts` for examples of how this can document the events used by various components.