### PR TITLE
Make EventEmitter covariant with respect to event type

### DIFF
--- a/src/annotator/components/NotebookModal.tsx
+++ b/src/annotator/components/NotebookModal.tsx
@@ -3,7 +3,6 @@ import classnames from 'classnames';
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 
 import { addConfigFragment } from '../../shared/config-fragment';
-import type { Events } from '../../types/annotator';
 import { createAppConfig } from '../config/app';
 import type { EventBus, Emitter } from '../util/emitter';
 import ModalDialog from './ModalDialog';
@@ -43,8 +42,13 @@ function NotebookIframe({ config, groupId }: NotebookIframeProps) {
   );
 }
 
+export type NotebookEvents = {
+  openNotebook(groupId: string): void;
+  closeNotebook(): void;
+};
+
 export type NotebookModalProps = {
-  eventBus: EventBus<Events>;
+  eventBus: EventBus<NotebookEvents>;
   config: NotebookConfig;
 };
 
@@ -63,7 +67,7 @@ export default function NotebookModal({
   const [isHidden, setIsHidden] = useState(true);
   const [groupId, setGroupId] = useState<string | null>(null);
   const originalDocumentOverflowStyle = useRef('');
-  const emitterRef = useRef<Emitter<Events> | null>(null);
+  const emitterRef = useRef<Emitter<NotebookEvents> | null>(null);
 
   // Stores the original overflow CSS property of document.body and reset it
   // when the component is destroyed

--- a/src/annotator/components/ProfileModal.tsx
+++ b/src/annotator/components/ProfileModal.tsx
@@ -2,20 +2,24 @@ import { CancelIcon, IconButton } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useEffect, useRef, useState } from 'preact/hooks';
 
-import type { Events } from '../../types/annotator';
 import type { Emitter, EventBus } from '../util/emitter';
 import ModalDialog from './ModalDialog';
 
 export type ProfileConfig = { profileAppUrl: string } & Record<string, unknown>;
 
+export type ProfileEvents = {
+  openProfile(): void;
+  closeProfile(): void;
+};
+
 type ProfileModalProps = {
-  eventBus: EventBus<Events>;
+  eventBus: EventBus<ProfileEvents>;
   config: ProfileConfig;
 };
 
 export default function ProfileModal({ eventBus, config }: ProfileModalProps) {
   const [isHidden, setIsHidden] = useState(true);
-  const emitterRef = useRef<Emitter<Events> | null>(null);
+  const emitterRef = useRef<Emitter<ProfileEvents> | null>(null);
 
   useEffect(() => {
     const emitter = eventBus.createEmitter();

--- a/src/annotator/components/ToastMessages.tsx
+++ b/src/annotator/components/ToastMessages.tsx
@@ -2,11 +2,15 @@ import { ToastMessages as BaseToastMessages } from '@hypothesis/frontend-shared'
 import type { ToastMessage } from '@hypothesis/frontend-shared';
 import { useCallback, useEffect, useState } from 'preact/hooks';
 
-import type { Events } from '../../types/annotator';
 import type { Emitter } from '../util/emitter';
 
+export type ToastMessagesEvents = {
+  toastMessageAdded(msg: ToastMessage): void;
+  toastMessageDismissed(id: string): void;
+};
+
 export type ToastMessagesProps = {
-  emitter: Emitter<Events>;
+  emitter: Emitter<ToastMessagesEvents>;
 };
 
 /**

--- a/src/annotator/notebook.tsx
+++ b/src/annotator/notebook.tsx
@@ -1,6 +1,9 @@
-import type { Destroyable, Events } from '../types/annotator';
+import type { Destroyable } from '../types/annotator';
 import NotebookModal from './components/NotebookModal';
-import type { NotebookConfig } from './components/NotebookModal';
+import type {
+  NotebookConfig,
+  NotebookEvents,
+} from './components/NotebookModal';
 import type { EventBus } from './util/emitter';
 import { PreactContainer } from './util/preact-container';
 
@@ -13,7 +16,7 @@ export class Notebook implements Destroyable {
    */
   constructor(
     element: HTMLElement,
-    eventBus: EventBus<Events>,
+    eventBus: EventBus<NotebookEvents>,
     config: NotebookConfig,
   ) {
     this._container = new PreactContainer('notebook', () => (

--- a/src/annotator/profile.tsx
+++ b/src/annotator/profile.tsx
@@ -1,5 +1,5 @@
-import type { Destroyable, Events } from '../types/annotator';
-import type { ProfileConfig } from './components/ProfileModal';
+import type { Destroyable } from '../types/annotator';
+import type { ProfileConfig, ProfileEvents } from './components/ProfileModal';
 import ProfileModal from './components/ProfileModal';
 import type { EventBus } from './util/emitter';
 import { PreactContainer } from './util/preact-container';
@@ -9,7 +9,7 @@ export class Profile implements Destroyable {
 
   constructor(
     element: HTMLElement,
-    eventBus: EventBus<Events>,
+    eventBus: EventBus<ProfileEvents>,
     config: ProfileConfig,
   ) {
     this._container = new PreactContainer('profile', () => (

--- a/src/annotator/util/emitter.ts
+++ b/src/annotator/util/emitter.ts
@@ -34,7 +34,7 @@ export class Emitter<Event extends EventMap> implements Destroyable {
   /**
    * Register an event listener.
    */
-  subscribe<K extends keyof Event>(event: K, callback: Event[K]) {
+  subscribe<K extends keyof Event & string>(event: K, callback: Event[K]) {
     this._emitter.on(event, callback);
     this._subscriptions.push([event as string, callback]);
   }

--- a/src/shared/event-emitter.ts
+++ b/src/shared/event-emitter.ts
@@ -13,10 +13,9 @@ export type EventMap = Record<string, (...args: any) => void>;
  * }
  * ```
  */
-export class EventEmitter<Event extends EventMap> {
+export class EventEmitter<out Event extends EventMap> {
   // Use a private field here to avoid conflicts with subclasses.
-  #listeners: Array<{ name: keyof Event; callback: (...args: any) => void }> =
-    [];
+  #listeners: Array<{ name: string; callback: (...args: any) => void }> = [];
 
   /** Remove all event listeners. */
   destroy() {
@@ -24,7 +23,7 @@ export class EventEmitter<Event extends EventMap> {
   }
 
   /** Add an event handler. */
-  on<K extends keyof Event>(name: K, callback: Event[K]) {
+  on<K extends keyof Event & string>(name: K, callback: Event[K]) {
     this.#listeners.push({ name, callback });
   }
 


### PR DESCRIPTION
This is a follow-up to https://github.com/hypothesis/client/pull/6976 which changes how `EventEmitter<T>` and `EventEmitter<U>` are related, so that the following works:

```ts
type AllEvents = {
  open(): void;
  close(): void;
}

type SomeEvents = {
  open(): void;
}

function useEmitter(emitter: EventEmitter<SomeEvents>) { ... }

const emitter = new EventEmitter<AllEvents>();
useEmitter(emitter);
```

The advantage is that the module containing `useEmitter` now only needs to know about the events it actually uses.