### PR TITLE
Add initial implementation of thumbnail rendering

### DIFF
--- a/src/annotator/anchoring/test/fake-pdf-viewer-application.js
+++ b/src/annotator/anchoring/test/fake-pdf-viewer-application.js
@@ -115,6 +115,36 @@ class FakePDFPageProxy {
 
     return Promise.resolve(textContent);
   }
+
+  getViewport(options) {
+    return new FakePageViewport(options);
+  }
+
+  /** Render the page and return a task for tracking progress. */
+  render(options) {
+    return new FakeRenderTask(options);
+  }
+}
+
+class FakePageViewport {
+  constructor({
+    rotation = 0,
+    scale = 1.0,
+    userUnit = 1 / 72,
+    viewBox = [0, 0, 0, 0],
+  }) {
+    this.rotation = rotation;
+    this.scale = scale;
+    this.userUnit = userUnit;
+    this.viewBox = viewBox;
+  }
+}
+
+class FakeRenderTask {
+  constructor(options) {
+    this._options = options;
+    this.promise = Promise.resolve();
+  }
 }
 
 /**

--- a/src/sidebar/components/Annotation/Annotation.tsx
+++ b/src/sidebar/components/Annotation/Annotation.tsx
@@ -111,7 +111,7 @@ function Annotation({
     ? ' - Highlighted'
     : '';
 
-  const targetShape = shape(annotation);
+  const targetShape = useMemo(() => shape(annotation), [annotation]);
 
   return (
     <article

--- a/src/sidebar/components/Annotation/Annotation.tsx
+++ b/src/sidebar/components/Annotation/Annotation.tsx
@@ -8,6 +8,7 @@ import {
   isOrphan,
   isSaved,
   quote,
+  shape,
 } from '../../helpers/annotation-metadata';
 import { annotationDisplayName } from '../../helpers/annotation-user';
 import { withServices } from '../../service-context';
@@ -19,6 +20,7 @@ import AnnotationEditor from './AnnotationEditor';
 import AnnotationHeader from './AnnotationHeader';
 import AnnotationQuote from './AnnotationQuote';
 import AnnotationReplyToggle from './AnnotationReplyToggle';
+import AnnotationThumbnail from './AnnotationThumbnail';
 
 function SavingMessage() {
   return (
@@ -109,6 +111,8 @@ function Annotation({
     ? ' - Highlighted'
     : '';
 
+  const targetShape = shape(annotation);
+
   return (
     <article
       className="space-y-4"
@@ -120,7 +124,7 @@ function Annotation({
         replyCount={replyCount}
         threadIsCollapsed={threadIsCollapsed}
       />
-
+      {targetShape && <AnnotationThumbnail tag={annotation.$tag} />}
       {annotationQuote && (
         <AnnotationQuote
           quote={annotationQuote}

--- a/src/sidebar/components/Annotation/AnnotationThumbnail.tsx
+++ b/src/sidebar/components/Annotation/AnnotationThumbnail.tsx
@@ -1,0 +1,97 @@
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'preact/hooks';
+
+import { withServices } from '../../service-context';
+import type { ThumbnailService } from '../../services/thumbnail';
+
+type BitmapImageProps = {
+  alt: string;
+  bitmap: ImageBitmap;
+  classes?: string;
+  scale?: number;
+};
+
+/** An `<img>`-like component which renders an {@link ImageBitmap}. */
+function BitmapImage({ alt, bitmap, classes, scale = 1.0 }: BitmapImageProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useLayoutEffect(() => {
+    const ctx = canvasRef.current!.getContext('2d')!;
+    ctx.drawImage(bitmap, 0, 0, bitmap.width, bitmap.height);
+  }, [bitmap]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={bitmap.width}
+      height={bitmap.height}
+      role="img"
+      aria-label={alt}
+      className={classes}
+      style={{
+        width: `${bitmap.width / scale}px`,
+        height: `${bitmap.height / scale}px`,
+      }}
+    />
+  );
+}
+
+export type AnnotationThumbnailProps = {
+  tag: string;
+  thumbnailService: ThumbnailService;
+};
+
+function AnnotationThumbnail({
+  tag,
+  thumbnailService,
+}: AnnotationThumbnailProps) {
+  // If a cached thumbnail is available then render it immediately, otherwise
+  // we'll request one be generated.
+  const [thumbnail, setThumbnail] = useState<ImageBitmap | null>(() =>
+    thumbnailService.get(tag),
+  );
+  const [error, setError] = useState<string>();
+
+  const devicePixelRatio = useMemo(() => window.devicePixelRatio, []);
+  const maxWidth = 196;
+
+  useEffect(() => {
+    if (!thumbnail && !error) {
+      thumbnailService
+        .fetch(tag, { maxWidth: maxWidth * devicePixelRatio, devicePixelRatio })
+        .then(setThumbnail)
+        .catch(err => setError(err.message));
+    }
+  }, [error, devicePixelRatio, tag, thumbnail, thumbnailService]);
+
+  return (
+    <div
+      className="flex flex-row justify-center"
+      data-testid="thumbnail-container"
+    >
+      {thumbnail && (
+        <BitmapImage
+          alt="annotated content thumbnail"
+          bitmap={thumbnail}
+          classes="border rounded-md"
+          scale={devicePixelRatio}
+        />
+      )}
+      {!thumbnail && !error && (
+        // TODO - Adjust size here so it matches the thumbnail after it has
+        // finished loading.
+        <span data-testid="placeholder">Loading thumbnail...</span>
+      )}
+      {!thumbnail && error && (
+        <span data-testid="error">Unable to render thumbnail</span>
+      )}
+    </div>
+  );
+}
+
+export default withServices(AnnotationThumbnail, ['thumbnailService']);

--- a/src/sidebar/components/Annotation/test/Annotation-test.js
+++ b/src/sidebar/components/Annotation/test/Annotation-test.js
@@ -139,6 +139,33 @@ describe('Annotation', () => {
     });
   });
 
+  describe('annotation thumbnail', () => {
+    it('does not render a thumbnail if annotation has no shape selector', () => {
+      const wrapper = createComponent();
+      assert.isFalse(wrapper.exists('AnnotationThumbnail'));
+    });
+
+    it('renders a thumbnail if annotation has a shape selector', () => {
+      const annotation = fixtures.defaultAnnotation();
+      annotation.target[0].selector = [
+        {
+          type: 'ShapeSelector',
+          shape: {
+            type: 'rect',
+            left: 0,
+            top: 10,
+            right: 10,
+            bottom: 0,
+          },
+        },
+      ];
+      const wrapper = createComponent({ annotation });
+      const thumbnail = wrapper.find('AnnotationThumbnail');
+      assert.isTrue(thumbnail.exists());
+      assert.equal(thumbnail.prop('tag'), annotation.$tag);
+    });
+  });
+
   it('should show a "Saving" message when annotation is saving', () => {
     fakeStore.isSavingAnnotation.returns(true);
 

--- a/src/sidebar/components/Annotation/test/AnnotationThumbnail-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationThumbnail-test.js
@@ -1,0 +1,54 @@
+import { mount, waitForElement } from '@hypothesis/frontend-testing';
+
+import AnnotationThumbnail from '../AnnotationThumbnail';
+
+describe('AnnotationThumbnail', () => {
+  let fakeThumbnail;
+  let fakeThumbnailService;
+
+  const createComponent = (props = {}) => {
+    return mount(
+      <AnnotationThumbnail
+        tag="ann123"
+        thumbnailService={fakeThumbnailService}
+        {...props}
+      />,
+    );
+  };
+
+  beforeEach(async () => {
+    const imageData = new ImageData(32, 32);
+    fakeThumbnail = await createImageBitmap(imageData);
+    fakeThumbnailService = {
+      get: sinon.stub().returns(null),
+      fetch: sinon.stub().resolves(fakeThumbnail),
+    };
+  });
+
+  it('renders a placeholder if thumbnail is not available', () => {
+    const wrapper = createComponent();
+    assert.isFalse(wrapper.exists('BitmapImage'));
+    assert.isTrue(wrapper.exists('[data-testid="placeholder"]'));
+  });
+
+  it('renders thumbnail immediately if cached', () => {
+    fakeThumbnailService.get.returns(fakeThumbnail);
+    const wrapper = createComponent();
+    assert.isFalse(wrapper.exists('[data-testid="placeholder"]'));
+    assert.isTrue(wrapper.exists('BitmapImage'));
+  });
+
+  it('requests thumbnail and then renders it if not cached', async () => {
+    const wrapper = createComponent();
+    assert.calledOnce(fakeThumbnailService.fetch);
+    const thumbnail = await waitForElement(wrapper, 'BitmapImage');
+    assert.equal(thumbnail.prop('bitmap'), fakeThumbnail);
+  });
+
+  it('renders error indicator if thumbnail rendering failed', async () => {
+    fakeThumbnailService.fetch.rejects(new Error('Thumbnail rendering failed'));
+    const wrapper = createComponent();
+    await new Promise(resolve => setTimeout(resolve, 1));
+    await waitForElement(wrapper, '[data-testid="error"]');
+  });
+});

--- a/src/sidebar/helpers/annotation-metadata.ts
+++ b/src/sidebar/helpers/annotation-metadata.ts
@@ -4,6 +4,8 @@ import type {
   EPUBContentSelector,
   PageSelector,
   SavedAnnotation,
+  Shape,
+  ShapeSelector,
   TextQuoteSelector,
 } from '../../types/api';
 
@@ -345,6 +347,19 @@ export function quote(annotation: APIAnnotationData): string | null {
     | TextQuoteSelector
     | undefined;
   return quoteSel ? quoteSel.exact : null;
+}
+
+/**
+ * Return the shape of an annotation's target, if there is one.
+ *
+ * This will return `null` if the annotation is associated with a text
+ * selection instead of a shape.
+ */
+export function shape(annotation: APIAnnotationData): Shape | null {
+  const shapeSelector = annotation.target[0]?.selector?.find(
+    s => s.type === 'ShapeSelector',
+  ) as ShapeSelector | undefined;
+  return shapeSelector?.shape ?? null;
 }
 
 /**

--- a/src/sidebar/helpers/test/annotation-metadata-test.js
+++ b/src/sidebar/helpers/test/annotation-metadata-test.js
@@ -6,6 +6,7 @@ import {
   domainAndTitle,
   isSaved,
   pageLabel,
+  shape,
 } from '../annotation-metadata';
 
 describe('sidebar/helpers/annotation-metadata', () => {
@@ -586,6 +587,49 @@ describe('sidebar/helpers/annotation-metadata', () => {
         ],
       };
       assert.equal(annotationMetadata.quote(ann), null);
+    });
+  });
+
+  describe('shape', () => {
+    [
+      {
+        selectors: [],
+        expected: null,
+      },
+      {
+        selectors: [
+          {
+            type: 'ShapeSelector',
+            shape: {
+              type: 'rect',
+              left: 0,
+              top: 10,
+              right: 10,
+              bottom: 0,
+            },
+          },
+        ],
+        expected: {
+          type: 'rect',
+          left: 0,
+          top: 10,
+          right: 10,
+          bottom: 0,
+        },
+      },
+    ].forEach(({ selectors, expected }) => {
+      it('returns shape from shape selector', () => {
+        const annotation = {
+          target: [
+            {
+              source: 'https://example.org/dummy.pdf',
+              selector: selectors,
+            },
+          ],
+        };
+        const annShape = shape(annotation);
+        assert.deepEqual(annShape, expected);
+      });
     });
   });
 

--- a/src/sidebar/index.tsx
+++ b/src/sidebar/index.tsx
@@ -39,6 +39,7 @@ import { StreamFilter } from './services/stream-filter';
 import { StreamerService } from './services/streamer';
 import { TagsService } from './services/tags';
 import { ThreadsService } from './services/threads';
+import { ThumbnailService } from './services/thumbnail';
 import { ToastMessengerService } from './services/toast-messenger';
 import { createSidebarStore } from './store';
 import type { SidebarStore } from './store';
@@ -163,6 +164,7 @@ function startApp(settings: SidebarSettings, appEl: HTMLElement) {
     .register('streamFilter', StreamFilter)
     .register('tags', TagsService)
     .register('threadsService', ThreadsService)
+    .register('thumbnailService', ThumbnailService)
     .register('toastMessenger', ToastMessengerService)
     .register('store', { factory: createSidebarStore });
 

--- a/src/sidebar/services/frame-sync.ts
+++ b/src/sidebar/services/frame-sync.ts
@@ -676,7 +676,11 @@ export class FrameSyncService {
     guest.call('scrollToAnnotation', ann.$tag);
   }
 
-  /** Request a thumbnail from an annotated region of the document. */
+  /**
+   * Request a thumbnail from an annotated region of the document.
+   *
+   * @param tag - Annotation identifier. See {@link Annotation.$tag}.
+   */
   async requestThumbnail(
     tag: string,
     options: RenderToBitmapOptions = {},

--- a/src/sidebar/services/test/thumbnail-test.js
+++ b/src/sidebar/services/test/thumbnail-test.js
@@ -1,0 +1,47 @@
+import { ThumbnailService } from '../thumbnail';
+
+describe('ThumbnailService', () => {
+  let fakeFrameSyncService;
+
+  beforeEach(async () => {
+    const data = new ImageData(32, 32);
+    const bitmap = await createImageBitmap(data);
+    fakeFrameSyncService = {
+      requestThumbnail: sinon.stub().resolves(bitmap),
+    };
+  });
+
+  const createService = () => new ThumbnailService(fakeFrameSyncService);
+
+  describe('#get', () => {
+    it('returns `null` if no thumbnail is cached', () => {
+      const svc = createService();
+      assert.isNull(svc.get('ann123'));
+    });
+
+    it('returns thumbnail if cached', async () => {
+      const svc = createService();
+      await svc.fetch('ann123');
+      assert.instanceOf(svc.get('ann123'), ImageBitmap);
+    });
+  });
+
+  describe('#fetch', () => {
+    it('requests thumbnail if not cached', async () => {
+      const svc = createService();
+      const opts = {};
+      await svc.fetch('ann123', opts);
+      assert.calledWith(fakeFrameSyncService.requestThumbnail, 'ann123', opts);
+    });
+
+    it('returns thumbnail if cached', async () => {
+      const svc = createService();
+      await svc.fetch('ann123');
+
+      fakeFrameSyncService.requestThumbnail.resetHistory();
+      await svc.fetch('ann123');
+
+      assert.notCalled(fakeFrameSyncService.requestThumbnail);
+    });
+  });
+});

--- a/src/sidebar/services/thumbnail.ts
+++ b/src/sidebar/services/thumbnail.ts
@@ -1,0 +1,54 @@
+import type { RenderToBitmapOptions } from '../../types/annotator';
+import type { FrameSyncService } from './frame-sync';
+
+/**
+ * Service for managing thumbnails for annotated sections of a document.
+ *
+ * @inject
+ */
+export class ThumbnailService {
+  /** Map of annotation tag to thumbnail image. */
+  #cache = new Map<string, ImageBitmap>();
+  #frameSync: FrameSyncService;
+
+  constructor(frameSync: FrameSyncService) {
+    this.#frameSync = frameSync;
+  }
+
+  /**
+   * Request a thumbnail for an annotation.
+   *
+   * The annotation must have been anchored in the document before a thumbnail
+   * can be fetched.
+   *
+   * @param tag - Tag identifying the annotation to fetch a thumbnail for
+   * @return Thumbnail image
+   */
+  async fetch(
+    tag: string,
+    options: RenderToBitmapOptions = {},
+  ): Promise<ImageBitmap> {
+    const entry = this.#cache.get(tag);
+    if (entry) {
+      return entry;
+    }
+
+    // TODO - Implement a mechanism to remove old cache entries when annotations
+    // are unloaded or thumbnails have been unused for long enough.
+
+    const bitmap = await this.#frameSync.requestThumbnail(tag, options);
+    this.#cache.set(tag, bitmap);
+    return bitmap;
+  }
+
+  /**
+   * Return the cached thumbnail for an annotation.
+   *
+   * Returns `null` if there is no cached entry, in which case
+   * {@link ThumbnailService.fetch} must be called to generate and cache a new
+   * thumbnail.
+   */
+  get(tag: string): ImageBitmap | null {
+    return this.#cache.get(tag) ?? null;
+  }
+}

--- a/src/types/annotator.ts
+++ b/src/types/annotator.ts
@@ -192,6 +192,25 @@ export type ShapeAnchor = {
   coordinates: 'anchor';
 };
 
+export type RenderToBitmapOptions = {
+  /**
+   * Ratio of device pixels to CSS pixels.
+   *
+   * This is used when determining the natural width of the image. See
+   * {@link window.devicePixelRatio}.
+   */
+  devicePixelRatio?: number;
+
+  /**
+   * Maximum width to render the image at, in pixels.
+   *
+   * The size of the resulting image will be the smaller of this and the
+   * natural width, which is the width of the image in the PDF viewer at 100%
+   * zoom.
+   */
+  maxWidth?: number;
+};
+
 /**
  * Interface for document type/viewer integrations that handle all the details
  * of supporting a specific document type (web page, PDF, ebook, etc.).
@@ -312,6 +331,12 @@ export type IntegrationBase = {
 
   /** Query the annotation tools supported by this integration. */
   supportedTools(): AnnotationTool[];
+
+  /** Render an annotated region of the document to a bitmap. */
+  renderToBitmap?(
+    anchor: Anchor,
+    opts: RenderToBitmapOptions,
+  ): Promise<ImageBitmap>;
 };
 
 /** Events which {@link Integration}s may emit. */

--- a/src/types/pdfjs.ts
+++ b/src/types/pdfjs.ts
@@ -91,14 +91,63 @@ export type TextContent = {
   items: TextContentItem[];
 };
 
+export type GetViewportParameters = {
+  scale: number;
+  rotation?: number;
+};
+
+export type PageViewportParameters = {
+  viewBox: number[];
+  userUnit: number;
+  scale: number;
+  rotation: number;
+};
+
+export type PageViewport = {
+  new (params: PageViewportParameters): PageViewport;
+
+  viewBox: number[];
+  userUnit: number;
+  width: number;
+  height: number;
+};
+
+/**
+ * Tracks page rendering progress.
+ *
+ * See https://github.com/mozilla/pdf.js/blob/2f7d163dfdf40225479d1cc8f6d8ebd9e5273ca6/src/display/api.js#L3267.
+ */
+export type RenderTask = {
+  get promise(): Promise<void>;
+};
+
+/**
+ * Page rendering parameters.
+ *
+ * See https://github.com/mozilla/pdf.js/blob/2f7d163dfdf40225479d1cc8f6d8ebd9e5273ca6/src/display/api.js#L1284.
+ */
+export type RenderParameters = {
+  canvasContext: CanvasRenderingContext2D;
+  viewport: PageViewport;
+};
+
 export type PDFPageProxy = {
   getTextContent(o?: GetTextContentParameters): Promise<TextContent>;
+
+  /**
+   * Render a page to a canvas context.
+   *
+   * See https://github.com/mozilla/pdf.js/blob/2f7d163dfdf40225479d1cc8f6d8ebd9e5273ca6/src/display/api.js#L1509.
+   */
+  render(params: RenderParameters): RenderTask;
 
   /**
    * Return the visible portion of this page in user space units as an
    * `[x1, y1, x2, y2]` tuple.
    */
   get view(): [number, number, number, number];
+
+  getViewport(params: GetViewportParameters): PageViewport;
 };
 
 export type PDFPageView = {

--- a/src/types/port-rpc-calls.d.ts
+++ b/src/types/port-rpc-calls.d.ts
@@ -12,6 +12,7 @@ import type {
   AnnotationTool,
   ContentInfoConfig,
   DocumentInfo,
+  RenderToBitmapOptions,
   SidebarLayout,
 } from './annotator';
 
@@ -142,6 +143,16 @@ export type SidebarToGuestCalls = {
 
   /** Navigate to the segment of a book associated with an annotation. */
   navigateToSegment(ann: AnnotationData): void;
+
+  /**
+   * Render a thumbnail of the region of a document associated with an
+   * annotation.
+   */
+  renderThumbnail(
+    tag: string,
+    options: RenderToBitmapOptions,
+    callback: (err: string | null, bitmap: ImageBitmap | null) => void,
+  ): void;
 
   /** Scroll an annotation into view. */
   scrollToAnnotation(tag: string): void;


### PR DESCRIPTION
Add initial fetch and display of thumbnails on annotation cards, for annotations on PDFs made using the rect tool.

## Preview

<img width="1224" alt="Celestial eyes preview" src="https://github.com/user-attachments/assets/1ab5e30f-8caf-4d88-8c69-b8535e0ace65" />

## Testing

1. Open a PDF and create a new rectangle annotation
2. A thumbnail preview should be shown on the annotation card
3. Reload the page and the thumbnail should be re-generated and shown on the card as in the previous step

## Implementation details

The overall flow of events is:

1. An annotation card is rendered. If it has a shape selector, an
   `AnnotationThumbnail` component is included
5. The `AnnotationThumbnail` component requests a thumbnail from a new
   `ThumbnailService`
6. The `ThumbnailService` will return a cached image if available or otherwise call
   `FrameSyncService.requestThumbnail` to request a thumbnail. This in turn
   sends a `renderThumbnail` RPC to the guest
7. On the guest side, the `renderThumbnail` message is handled by calling the
   integration's `renderToBitmap` method, if present.
8. In the PDF integration `renderToBitmap` finds the page containing the shape
   and schedules rendering of the associated page region into an
   `OffscreenCanvas`.
9. When rendering completes, the `OffscreenCanvas` content is transferred to an
   `ImageBitmap` and returned to the sidebar
10. In the sidebar, the thumbnail service receives the bitmap and caches it
11. The `AnnotationThumbnail` component re-renders, using a `<canvas>` to display
   the bitmap

## Known limitations / issues

 - Entries are never purged from the thumbnail cache
 - Rendering of thumbnails is only supported for annotations made with the
   "rect" tool, not the "point" tool
 - Rendering of placeholders and rendering error indicators is rudimentary
 - The thumbnail shows a section of the image that is slightly shifted compared with the original selection. There is a detail somewhere that I need to adjust for
 - The use of [OffscreenCanvas](https://caniuse.com/offscreencanvas) requires Safari 16.2 / Firefox 105 or newer. We may need to implement some fallback for older browsers, such as just skipping thumbnail rendering.