### PR TITLE
Add page labels to selectors for image annotations

### DIFF
--- a/src/annotator/anchoring/test/pdf-test.js
+++ b/src/annotator/anchoring/test/pdf-test.js
@@ -1009,6 +1009,7 @@ describe('annotator/anchoring/pdf', () => {
           {
             type: 'PageSelector',
             index: 0,
+            label: '1',
           },
           {
             type: 'ShapeSelector',


### PR DESCRIPTION
Add the page label (aka. page number) to the "PageSelector" selector for shape annotations on PDFs. This fixes an issue where page numbers were not displayed on annotation cards for rect or point annotations.

**Testing:**

Create a new rect or point annotation in a PDF. On `main`, no page number appears on the annotation card. On this branch, the page number should appear on the card.