### PR TITLE
Enable type checking for RPC message calls and handlers

### DIFF
--- a/src/annotator/annotation-counts.ts
+++ b/src/annotator/annotation-counts.ts
@@ -1,4 +1,5 @@
-import type { PortRPC } from '../shared/messaging';
+import type { CallMap, PortRPC } from '../shared/messaging';
+import type { SidebarToHostCalls } from '../types/port-rpc-calls';
 
 const ANNOTATION_COUNT_ATTR = 'data-hypothesis-annotation-count';
 
@@ -17,7 +18,7 @@ const ANNOTATION_COUNT_ATTR = 'data-hypothesis-annotation-count';
  */
 export function annotationCounts(
   rootEl: Element,
-  rpc: PortRPC<'publicAnnotationCountChanged', string>,
+  rpc: PortRPC<SidebarToHostCalls, CallMap>,
 ) {
   rpc.on('publicAnnotationCountChanged', updateAnnotationCountElems);
 

--- a/src/annotator/bucket-bar-client.ts
+++ b/src/annotator/bucket-bar-client.ts
@@ -3,12 +3,12 @@ import { ListenerCollection } from '@hypothesis/frontend-shared';
 import type { PortRPC } from '../shared/messaging';
 import type { Anchor, Destroyable } from '../types/annotator';
 import type {
-  HostToGuestEvent,
-  GuestToHostEvent,
-} from '../types/port-rpc-events';
+  HostToGuestCalls,
+  GuestToHostCalls,
+} from '../types/port-rpc-calls';
 import { computeAnchorPositions } from './util/buckets';
 
-type HostRPC = PortRPC<HostToGuestEvent, GuestToHostEvent>;
+type HostRPC = PortRPC<HostToGuestCalls, GuestToHostCalls>;
 
 export type BucketBarClientOptions = {
   /**

--- a/src/annotator/guest.ts
+++ b/src/annotator/guest.ts
@@ -20,11 +20,11 @@ import type {
 } from '../types/annotator';
 import type { Target } from '../types/api';
 import type {
-  HostToGuestEvent,
-  GuestToHostEvent,
-  GuestToSidebarEvent,
-  SidebarToGuestEvent,
-} from '../types/port-rpc-events';
+  HostToGuestCalls,
+  GuestToHostCalls,
+  GuestToSidebarCalls,
+  SidebarToGuestCalls,
+} from '../types/port-rpc-calls';
 import { Adder } from './adder';
 import { TextRange } from './anchoring/text-range';
 import { BucketBarClient } from './bucket-bar-client';
@@ -247,10 +247,10 @@ export class Guest
   private _integration: Integration;
 
   /** Channel for host-guest communication. */
-  private _hostRPC: PortRPC<HostToGuestEvent, GuestToHostEvent>;
+  private _hostRPC: PortRPC<HostToGuestCalls, GuestToHostCalls>;
 
   /** Channel for guest-sidebar communication. */
-  private _sidebarRPC: PortRPC<SidebarToGuestEvent, GuestToSidebarEvent>;
+  private _sidebarRPC: PortRPC<SidebarToGuestCalls, GuestToSidebarCalls>;
 
   /**
    * The most recently received sidebar layout information from the host frame.

--- a/src/annotator/sidebar.tsx
+++ b/src/annotator/sidebar.tsx
@@ -15,11 +15,11 @@ import type {
 } from '../types/annotator';
 import type { Service } from '../types/config';
 import type {
-  GuestToHostEvent,
-  HostToGuestEvent,
-  HostToSidebarEvent,
-  SidebarToHostEvent,
-} from '../types/port-rpc-events';
+  GuestToHostCalls,
+  HostToGuestCalls,
+  HostToSidebarCalls,
+  SidebarToHostCalls,
+} from '../types/port-rpc-calls';
 import { annotationCounts } from './annotation-counts';
 import { BucketBar } from './bucket-bar';
 import ToastMessages from './components/ToastMessages';
@@ -121,15 +121,15 @@ export class Sidebar implements Destroyable {
    * the first connected guest frame.
    */
   private _guestWithSelection: PortRPC<
-    GuestToHostEvent,
-    HostToGuestEvent
+    GuestToHostCalls,
+    HostToGuestCalls
   > | null;
 
   /** Channel for host-sidebar communication. */
-  private _sidebarRPC: PortRPC<SidebarToHostEvent, HostToSidebarEvent>;
+  private _sidebarRPC: PortRPC<SidebarToHostCalls, HostToSidebarCalls>;
 
   /** Channels for host-guest communication. */
-  private _guestRPC: PortRPC<GuestToHostEvent, HostToGuestEvent>[];
+  private _guestRPC: PortRPC<GuestToHostCalls, HostToGuestCalls>[];
 
   bucketBar: BucketBar | null;
   features: FeatureFlags;
@@ -363,7 +363,7 @@ export class Sidebar implements Destroyable {
   }
 
   _connectGuest(port: MessagePort) {
-    const guestRPC = new PortRPC<GuestToHostEvent, HostToGuestEvent>();
+    const guestRPC = new PortRPC<GuestToHostCalls, HostToGuestCalls>();
 
     guestRPC.on('textSelected', () => {
       this._guestWithSelection = guestRPC;
@@ -482,8 +482,10 @@ export class Sidebar implements Destroyable {
 
     // Suppressing ban-types here because the functions are originally defined
     // as `Function` somewhere else. To be fixed when that is migrated to TS
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-    const eventHandlers: Array<[SidebarToHostEvent, Function | undefined]> = [
+    const eventHandlers: Array<
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+      [keyof SidebarToHostCalls, Function | undefined]
+    > = [
       ['loginRequested', this.onLoginRequest],
       ['logoutRequested', this.onLogoutRequest],
       ['signupRequested', this.onSignupRequest],

--- a/src/shared/messaging/index.ts
+++ b/src/shared/messaging/index.ts
@@ -1,6 +1,7 @@
 export { PortFinder } from './port-finder';
 export { PortProvider } from './port-provider';
 export { PortRPC, installPortCloseWorkaroundForSafari } from './port-rpc';
+export type { CallMap, HandlerMap } from './port-rpc';
 export { isMessage, isMessageEqual } from './port-util';
 
 export type { Message } from './port-util';

--- a/src/sidebar/components/UserMenu.tsx
+++ b/src/sidebar/components/UserMenu.tsx
@@ -56,7 +56,10 @@ function UserMenu({ frameSync, onLogout, settings }: UserMenuProps) {
   const isProfileEnabled = store.isFeatureEnabled('client_user_profile');
 
   const onSelectNotebook = () => {
-    frameSync.notifyHost('openNotebook', store.focusedGroupId());
+    const groupId = store.focusedGroupId();
+    if (groupId) {
+      frameSync.notifyHost('openNotebook', groupId);
+    }
   };
   const onSelectProfile = () => frameSync.notifyHost('openProfile');
 

--- a/src/sidebar/services/frame-sync.ts
+++ b/src/sidebar/services/frame-sync.ts
@@ -14,11 +14,11 @@ import type { Message } from '../../shared/messaging';
 import type { AnnotationData, DocumentInfo } from '../../types/annotator';
 import type { Annotation } from '../../types/api';
 import type {
-  SidebarToHostEvent,
-  HostToSidebarEvent,
-  SidebarToGuestEvent,
-  GuestToSidebarEvent,
-} from '../../types/port-rpc-events';
+  SidebarToHostCalls,
+  HostToSidebarCalls,
+  SidebarToGuestCalls,
+  GuestToSidebarCalls,
+} from '../../types/port-rpc-calls';
 import { isReply, isPublic } from '../helpers/annotation-metadata';
 import {
   annotationMatchesSegment,
@@ -111,7 +111,7 @@ export class FrameSyncService {
    */
   private _guestRPC: Map<
     string | null,
-    PortRPC<GuestToSidebarEvent, SidebarToGuestEvent>
+    PortRPC<GuestToSidebarCalls, SidebarToGuestCalls>
   >;
 
   /** Whether highlights are visible in guest frames. */
@@ -120,7 +120,7 @@ export class FrameSyncService {
   /**
    * Channel for sidebar-host communication.
    */
-  private _hostRPC: PortRPC<HostToSidebarEvent, SidebarToHostEvent>;
+  private _hostRPC: PortRPC<HostToSidebarCalls, SidebarToHostCalls>;
 
   /**
    * Tags of annotations that are currently loaded into guest frames.
@@ -353,7 +353,7 @@ export class FrameSyncService {
    * @param sourceId - Identifier for the guest frame
    */
   private _connectGuest(port: MessagePort, sourceId: string | null) {
-    const guestRPC = new PortRPC<GuestToSidebarEvent, SidebarToGuestEvent>();
+    const guestRPC = new PortRPC<GuestToSidebarCalls, SidebarToGuestCalls>();
 
     this._guestRPC.set(sourceId, guestRPC);
 
@@ -598,7 +598,10 @@ export class FrameSyncService {
   /**
    * Send an RPC message to the host frame.
    */
-  notifyHost(method: SidebarToHostEvent, ...args: unknown[]) {
+  notifyHost<M extends keyof SidebarToHostCalls>(
+    method: M,
+    ...args: Parameters<SidebarToHostCalls[M]>
+  ) {
     this._hostRPC.call(method, ...args);
   }
 


### PR DESCRIPTION
Using similar patterns to https://github.com/hypothesis/client/pull/6976, parametrize `PortRPC` by object types specifying the signatures of handled methods and called methods. Calls to the `on` and `call` method are then type checked. Previously the method names were checked/documented, but not the arguments.

One bug was uncovered in the process where the account menu's "Open notebook" menu item could potentially send an `openNotebook` call to the host frame with a null group ID. This happened to have been handled gracefully in `NotebookModal`, but nevertheless code on the receiving side did not expect a null value.