### PR TITLE
Use common container for sidebar buckets and toolbar

### DIFF
--- a/src/annotator/components/Toolbar.tsx
+++ b/src/annotator/components/Toolbar.tsx
@@ -146,7 +146,19 @@ export default function Toolbar({
   return (
     <div
       className={classnames(
-        'absolute left-[-33px] w-[33px] z-2',
+        {
+          // For minimal controls, display the toolbar to the left, fully
+          // outside the sidebar
+          'absolute right-full': useMinimalControls,
+          // When the full toolbar is displayed, we position it relative to its
+          // container, so that it takes vertical space and pushes next elements
+          // down (eg. the buckets list).
+          // The toolbar is wider than its parent, so we need to adjust the
+          // right position so that the right edge of the toolbar aligns with
+          // the right edge of the parent.
+          'relative right-[11px]': !useMinimalControls,
+        },
+        'w-[33px] z-2',
         'text-px-base leading-none', // non-scaling sizing
       )}
     >

--- a/src/annotator/util/buckets.ts
+++ b/src/annotator/util/buckets.ts
@@ -191,7 +191,7 @@ export function computeBuckets(
   // Add an upper "navigation" bucket with offscreen-above anchors
   const above: Bucket = {
     anchors: aboveAnchors,
-    position: vMargin,
+    position: vMargin - 5,
   };
 
   // Add a lower "navigation" bucket with offscreen-below anchors


### PR DESCRIPTION
Closes #6945 

Combine buckets and toolbar in the sidebar in the same absolute-positioned container (the `sidebar-edge` element), instead of making each one of them be absolutely-positioned on its own.

That allows us to display the buckets right after the toolbar, regardless its size.

Before:

https://github.com/user-attachments/assets/1e6154dc-ecf4-4310-976e-bea6d952500b

After:

https://github.com/user-attachments/assets/17743fa4-d634-48ab-ad8f-e069b0488dae

https://github.com/user-attachments/assets/8f868af7-4e92-437e-8e75-1f15244d05a1

### Test steps

Check that everything keeps working as in `main` for:

1. Regular sidebar: http://localhost:3000/
2. External container: http://localhost:3000/document/sidebar-external-container
3. Clean theme: apply this diff to enable `clean` theme, then open http://localhost:3000
    ```diff
        diff --git a/dev-server/templates/client-config.js.mustache b/dev-server/templates/client-config.js.mustache
    index b258f6043..82000c3e1 100644
    --- a/dev-server/templates/client-config.js.mustache
    +++ b/dev-server/templates/client-config.js.mustache
    @@ -3,7 +3,7 @@
         return {
           // enableExperimentalNewNoteButton: true,
           // showHighlights: 'always',
    -      // theme: 'clean',
    +      theme: 'clean',
     
           // Example branding:
           // branding: {
    ```

Check that for PDFs, when image annotations is enabled and the toolbar shows extra button, the buckets now properly show right under the toolbar, with no overlapping.

### Todo

- [x] Toolbar buttons are no longer clickable
- [x] Fix tests
- [x] Fix clean theme