### PR TITLE
Introduce `Result` type to result of fallible RPCs between frames

### DIFF
--- a/src/annotator/guest.ts
+++ b/src/annotator/guest.ts
@@ -14,7 +14,6 @@ import type {
   Destroyable,
   DocumentInfo,
   Integration,
-  RenderToBitmapOptions,
   ShapeAnchor,
   SidebarLayout,
   SideBySideOptions,
@@ -654,36 +653,29 @@ export class Guest
       this._integration.navigateToSegment?.(annotation),
     );
 
-    this._sidebarRPC.on(
-      'renderThumbnail',
-      (
-        tag: string,
-        options: RenderToBitmapOptions,
-        callback: (err: string | null, bitmap: ImageBitmap | null) => void,
-      ) => {
-        const renderThumbnail = async () => {
-          if (!this._integration.renderToBitmap) {
-            throw new Error(
-              'Thumbnail rendering not supported for document type',
-            );
-          }
+    this._sidebarRPC.on('renderThumbnail', (tag, options, callback) => {
+      const renderThumbnail = async () => {
+        if (!this._integration.renderToBitmap) {
+          throw new Error(
+            'Thumbnail rendering not supported for document type',
+          );
+        }
 
-          // There is a race condition here that thumbnail rendering can fail if
-          // anchoring is still in progress. What we should do is defer rendering
-          // until anchoring completes.
-          const anchor = this.anchors.find(a => a.annotation.$tag === tag);
-          if (!anchor) {
-            throw new Error('Annotation not anchored in guest');
-          }
+        // There is a race condition here that thumbnail rendering can fail if
+        // anchoring is still in progress. What we should do is defer rendering
+        // until anchoring completes.
+        const anchor = this.anchors.find(a => a.annotation.$tag === tag);
+        if (!anchor) {
+          throw new Error('Annotation not anchored in guest');
+        }
 
-          return this._integration.renderToBitmap(anchor, options);
-        };
+        return this._integration.renderToBitmap(anchor, options);
+      };
 
-        renderThumbnail()
-          .then(bitmap => callback(null, bitmap))
-          .catch(err => callback(err.message, null));
-      },
-    );
+      renderThumbnail()
+        .then(bitmap => callback({ ok: true, value: bitmap }))
+        .catch(error => callback({ ok: false, error: error.message }));
+    });
 
     // Connect to sidebar and send document info/URIs to it.
     //

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -725,7 +725,8 @@ describe('Guest', () => {
     describe('on "renderThumbnail" event', () => {
       const makeCallback = () => {
         const { promise, resolve, reject } = Promise.withResolvers();
-        const callback = (err, result) => (err ? reject(err) : resolve(result));
+        const callback = result =>
+          result.ok ? resolve(result.value) : reject(result.error);
         return { promise, callback };
       };
 

--- a/src/sidebar/services/frame-sync.ts
+++ b/src/sidebar/services/frame-sync.ts
@@ -693,18 +693,13 @@ export class FrameSyncService {
     }
 
     return new Promise((resolve, reject) => {
-      guest.call(
-        'renderThumbnail',
-        tag,
-        options,
-        (err: string | null, bitmap: ImageBitmap | null) => {
-          if (!bitmap) {
-            reject(new Error(err ?? 'No bitmap received'));
-          } else {
-            resolve(bitmap);
-          }
-        },
-      );
+      guest.call('renderThumbnail', tag, options, result => {
+        if (result.ok) {
+          resolve(result.value);
+        } else {
+          reject(new Error(result.error));
+        }
+      });
     });
   }
 

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -1225,7 +1225,7 @@ describe('FrameSyncService', () => {
       const fakeBitmap = {};
       guestRPC().call.callsFake((method, tag, options, callback) => {
         if (method === 'renderThumbnail') {
-          delay(0).then(() => callback(null, fakeBitmap));
+          delay(0).then(() => callback({ ok: true, value: fakeBitmap }));
         }
       });
 
@@ -1256,7 +1256,9 @@ describe('FrameSyncService', () => {
       await connectGuest();
       guestRPC().call.callsFake((method, tag, options, callback) => {
         if (method === 'renderThumbnail') {
-          delay(0).then(() => callback('Something went wrong', null));
+          delay(0).then(() =>
+            callback({ ok: false, error: 'Something went wrong' }),
+          );
         }
       });
 

--- a/src/types/port-rpc-calls.d.ts
+++ b/src/types/port-rpc-calls.d.ts
@@ -29,6 +29,28 @@ export type CommonCalls = {
   close(): void;
 };
 
+/** Represents an operation that succeeded. */
+export type Success<T> = {
+  ok: true;
+  value: T;
+};
+
+/** Represents an operation that failed. */
+export type Failure<E> = {
+  ok: false;
+  error: E;
+};
+
+/**
+ * Result of an RPC call between frames.
+ *
+ * The payload on success or error must be a type that is serializable or
+ * transferable. For errors note that {@link Error} is *not* serializable in
+ * some older browsers. See
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#browser_compatibility.
+ */
+export type Result<T, E = string> = Success<T> | Failure<E>;
+
 /** Calls that guests make to the host. */
 export type GuestToHostCalls = CommonCalls & {
   /** Text has been deselected in the guest frame. */
@@ -151,7 +173,7 @@ export type SidebarToGuestCalls = {
   renderThumbnail(
     tag: string,
     options: RenderToBitmapOptions,
-    callback: (err: string | null, bitmap: ImageBitmap | null) => void,
+    callback: (result: Result<ImageBitmap>) => void,
   ): void;
 
   /** Scroll an annotation into view. */


### PR DESCRIPTION
As suggested in [^1], using a `Result` type rather than the older `(err, result)` pair works better with TypeScript, which can reason that there are two possibilities for the value (success, failure) instead of 4 (null/not-null err and value).

The error variant is named `Failure` to avoid a conflict with the built-in `Error` type, and `Success` is the counterpart to that.

[^1]: https://github.com/hypothesis/client/pull/6984#discussion_r2052123485