### PR TITLE
Change border and background color for focused shape highlights

### DIFF
--- a/src/styles/annotator/highlights.scss
+++ b/src/styles/annotator/highlights.scss
@@ -207,6 +207,11 @@
   border-color: #edd72b;
   cursor: pointer;
   visibility: visible;
+
+  &.hypothesis-highlight-focused {
+    border-color: var(--hypothesis-highlight-focused-color);
+    background: var(--hypothesis-highlight-focused-color);
+  }
 }
 
 // Apply focused-highlight styling


### PR DESCRIPTION
Change the border and background color when shape highlights are hovered in the sidebar, similar to how the background for text highlights changes.

Preview of a shape highlight when the corresponding card (on the right) is hovered:

<img width="962" alt="focused-shape" src="https://github.com/user-attachments/assets/4e4edc36-b03a-4326-bdca-9bb6caf5aa95" />
