### PR TITLE
Revise rectangle selection style

### DIFF
--- a/src/annotator/draw-tool.tsx
+++ b/src/annotator/draw-tool.tsx
@@ -209,16 +209,32 @@ export class DrawTool implements Destroyable {
       // Normalize rect because SVG rects must have positive width and height.
       const rect = normalizeRect(this._shape);
       render(
-        <rect
-          stroke="black"
-          stroke-dasharray="3"
-          stroke-width="3px"
-          fill="none"
-          x={rect.left}
-          y={rect.top}
-          width={rect.right - rect.left}
-          height={rect.bottom - rect.top}
-        />,
+        // Draw rects with dashed strokes that combine to form one rect with a
+        // border of alternating colors.
+        <>
+          <rect
+            stroke="white"
+            stroke-dasharray="5"
+            stroke-width="1px"
+            fill="grey"
+            fill-opacity="0.5"
+            x={rect.left}
+            y={rect.top}
+            width={rect.right - rect.left}
+            height={rect.bottom - rect.top}
+          />
+          <rect
+            stroke="grey"
+            stroke-dasharray="5"
+            stroke-dashoffset="5"
+            stroke-width="1px"
+            fill="none"
+            x={rect.left}
+            y={rect.top}
+            width={rect.right - rect.left}
+            height={rect.bottom - rect.top}
+          />
+        </>,
         this._surface,
       );
     } else {


### PR DESCRIPTION
Change the style of the selection rectangle to work better against a range of background colors:

 - Replace dashed black/transparent stroke with dashed black/white stroke
 - Add a translucent fill

<img width="1221" alt="new-rect-selection-style" src="https://github.com/user-attachments/assets/e567e90e-9dab-4624-a993-ac75e9ea16af" />
