### PR TITLE
Enable scrolling viewport while drawing tool is active

### DIFF
--- a/src/annotator/draw-tool.tsx
+++ b/src/annotator/draw-tool.tsx
@@ -154,6 +154,26 @@ export class DrawTool implements Destroyable {
       this._abortDraw?.abort();
     });
 
+    // Enable user to scroll elements under the drawing surface by translating
+    // wheel events to scroll actions.
+    this._surface.addEventListener('wheel', e => {
+      // Remaining amount of scroll delta.
+      let scrollDeltaY = Math.abs(e.deltaY);
+      let scrollDeltaX = Math.abs(e.deltaX);
+
+      // Visit elements from top-most to bottom-most and transfer remaining
+      // unused scroll delta to them.
+      for (const elem of document.elementsFromPoint(e.clientX, e.clientY)) {
+        const prevScrollLeft = elem.scrollLeft;
+        elem.scrollLeft += scrollDeltaX * Math.sign(e.deltaX);
+        scrollDeltaX -= Math.abs(elem.scrollLeft - prevScrollLeft);
+
+        const prevScrollTop = elem.scrollTop;
+        elem.scrollTop += scrollDeltaY * Math.sign(e.deltaY);
+        scrollDeltaY -= Math.abs(elem.scrollTop - prevScrollTop);
+      }
+    });
+
     // Cancel drawing if user presses "Escape"
     this._abortDraw = new AbortController();
     document.body.addEventListener(

--- a/src/annotator/test/draw-tool-test.js
+++ b/src/annotator/test/draw-tool-test.js
@@ -8,6 +8,13 @@ describe('DrawTool', () => {
 
   beforeEach(() => {
     container = document.createElement('div');
+    Object.assign(container.style, {
+      position: 'fixed',
+      top: '0',
+      left: '0',
+      width: '100px',
+      height: '100px',
+    });
     document.body.append(container);
     tool = new DrawTool(container);
   });
@@ -163,5 +170,44 @@ describe('DrawTool', () => {
         bottom: 7,
       });
     });
+  });
+
+  it('scrolls elements underneath drawing surface when "wheel" events are received', async () => {
+    // Add scrollable container that can scroll in both X and Y directions.
+    const scrollable = document.createElement('div');
+    Object.assign(scrollable.style, {
+      height: '100px',
+      width: '100px',
+      overflow: 'scroll',
+    });
+    const child = document.createElement('div');
+    Object.assign(child.style, {
+      width: '200px',
+      height: '200px',
+    });
+    scrollable.append(child);
+    container.append(scrollable);
+
+    const shapePromise = tool.draw('rect');
+
+    // Simulate user scrolling the drawing surface with a wheel or touchpad.
+    const event = new WheelEvent('wheel', {
+      clientX: 5,
+      clientY: 5,
+      deltaY: 10,
+      deltaX: 20,
+    });
+    getSurface().dispatchEvent(event);
+
+    // Check the scroll was transferred to the element underneath.
+    assert.equal(scrollable.scrollLeft, event.deltaX);
+    assert.equal(scrollable.scrollTop, event.deltaY);
+
+    tool.cancel();
+    try {
+      await shapePromise;
+    } catch {
+      /* noop */
+    }
   });
 });


### PR DESCRIPTION
The shape annotation tools create a hidden drawing surface over the viewport which is used to display the drawing cursor and selection rectangle. This has a side effect of preventing scrolling the PDF page underneath while the drawing tool is active. We can't turn off pointer events for the surface as this will prevent changing the cursor or responding to mouse events to update the selection.

To work around this, add a wheel event handler to the drawing surface which translates wheel events into scroll actions on the elements underneath. The resulting scrolling behavior may not be exactly the same, but it should be close enough.

This won't work on mobile where wheel events are not dispatched, but the drawing tool is going to need to work differently there anyway.

**Testing:**

1. Go into a PDF and activate either the rect or point annotation tool
2. Attempt to scroll the page, in all directions with the mouse wheel or trackpad before drawing a selection.

On `main`, the page will not be scrollable while the drawing tool is active. On this branch it should be.