### PR TITLE
Revise thread sorting APIs to decouple sort keys and item labels

### DIFF
--- a/src/sidebar/components/NotebookView.tsx
+++ b/src/sidebar/components/NotebookView.tsx
@@ -79,7 +79,7 @@ function NotebookView({ loadAnnotationsService, streamer }: NotebookViewProps) {
     // within the Notebook to change the `focusedGroup`. If the focused group
     // is changed within the sidebar and the Notebook re-opened, an entirely
     // new iFrame/app is created. This will need to be revisited.
-    store.setSortKey('Newest');
+    store.setSortKey('newest');
     if (groupId) {
       loadAnnotationsService.load({
         groupId,

--- a/src/sidebar/components/SortMenu.tsx
+++ b/src/sidebar/components/SortMenu.tsx
@@ -1,8 +1,15 @@
 import { SortIcon } from '@hypothesis/frontend-shared';
 
 import { useSidebarStore } from '../store';
+import type { SortKey } from '../store/modules/selection';
 import Menu from './Menu';
 import MenuItem from './MenuItem';
+
+export const itemLabels: Record<SortKey, string> = {
+  newest: 'Newest',
+  oldest: 'Oldest',
+  location: 'Location',
+};
 
 /**
  * A drop-down menu of sorting options for a collection of annotations.
@@ -19,7 +26,7 @@ export default function SortMenu() {
     return (
       <MenuItem
         key={sortOption}
-        label={sortOption}
+        label={itemLabels[sortOption]}
         onClick={() => store.setSortKey(sortOption)}
         isSelected={sortOption === sortKey}
       />

--- a/src/sidebar/components/StreamView.tsx
+++ b/src/sidebar/components/StreamView.tsx
@@ -51,7 +51,7 @@ function StreamView({ api, toastMessenger }: StreamViewProps) {
   // the search query is updated.
   useEffect(() => {
     // Sort the stream so that the newest annotations are at the top
-    store.setSortKey('Newest');
+    store.setSortKey('newest');
     store.clearAnnotations();
     loadAnnotations(currentQuery ?? '').catch(err => {
       toastMessenger.error(`Unable to fetch annotations: ${err.message}`);

--- a/src/sidebar/components/test/NotebookView-test.js
+++ b/src/sidebar/components/test/NotebookView-test.js
@@ -77,7 +77,7 @@ describe('NotebookView', () => {
         onError: sinon.match.func,
       }),
     );
-    assert.calledWith(fakeStore.setSortKey, 'Newest');
+    assert.calledWith(fakeStore.setSortKey, 'newest');
   });
 
   it('loads annotations for the direct-linked group if there is no focused group', () => {

--- a/src/sidebar/components/test/SortMenu-test.js
+++ b/src/sidebar/components/test/SortMenu-test.js
@@ -1,7 +1,7 @@
 import { mockImportedComponents } from '@hypothesis/frontend-testing';
 import { mount } from '@hypothesis/frontend-testing';
 
-import SortMenu from '../SortMenu';
+import SortMenu, { itemLabels } from '../SortMenu';
 import { $imports } from '../SortMenu';
 
 describe('SortMenu', () => {
@@ -14,8 +14,8 @@ describe('SortMenu', () => {
   beforeEach(() => {
     fakeStore = {
       setSortKey: sinon.stub(),
-      sortKey: sinon.stub().returns('Location'),
-      sortKeys: sinon.stub().returns(['Newest', 'Oldest', 'Location']),
+      sortKey: sinon.stub().returns('location'),
+      sortKeys: sinon.stub().returns(['newest', 'oldest', 'location']),
     };
 
     $imports.$mock(mockImportedComponents());
@@ -36,7 +36,7 @@ describe('SortMenu', () => {
     assert.lengthOf(menuItems, fakeStore.sortKeys().length);
     fakeStore.sortKeys().forEach(sortKey => {
       assert.lengthOf(
-        menuItems.filterWhere(menuItem => menuItem.prop('label') === sortKey),
+        menuItems.filterWhere(menuItem => menuItem.key() === sortKey),
         1,
       );
     });
@@ -47,7 +47,9 @@ describe('SortMenu', () => {
 
     const currentSortKeyMenuItem = wrapper
       .find('MenuItem')
-      .filterWhere(menuItem => menuItem.prop('label') === fakeStore.sortKey());
+      .filterWhere(
+        menuItem => menuItem.prop('label') === itemLabels[fakeStore.sortKey()],
+      );
     assert.isTrue(currentSortKeyMenuItem.prop('isSelected'));
   });
 
@@ -61,7 +63,7 @@ describe('SortMenu', () => {
       callback();
 
       const lastCall = fakeStore.setSortKey.lastCall;
-      assert.calledWith(lastCall, menuItem.prop('label'));
+      assert.calledWith(lastCall, menuItem.key());
     });
   });
 });

--- a/src/sidebar/helpers/test/thread-sorters-test.js
+++ b/src/sidebar/helpers/test/thread-sorters-test.js
@@ -1,4 +1,4 @@
-import { sorters, $imports } from '../thread-sorters';
+import { compareThreads, $imports } from '../thread-sorters';
 
 describe('sidebar/util/thread-sorters', () => {
   let fakeRootAnnotations;
@@ -41,10 +41,10 @@ describe('sidebar/util/thread-sorters', () => {
       },
     ].forEach(testCase => {
       it('sorts by newest created root annotation', () => {
-        // Disable eslint: `sorters` properties start with capital letters
-        // to match their displayed sort option values
-        /* eslint-disable-next-line new-cap */
-        assert.equal(sorters.Newest(testCase.a, testCase.b), testCase.expected);
+        assert.equal(
+          compareThreads(testCase.a, testCase.b, { sortBy: 'newest' }),
+          testCase.expected,
+        );
       });
     });
   });
@@ -68,10 +68,10 @@ describe('sidebar/util/thread-sorters', () => {
       },
     ].forEach(testCase => {
       it('sorts by oldest created root annotation', () => {
-        // Disable eslint: `sorters` properties start with capital letters
-        // to match their displayed sort option values
-        /* eslint-disable-next-line new-cap */
-        assert.equal(sorters.Oldest(testCase.a, testCase.b), testCase.expected);
+        assert.equal(
+          compareThreads(testCase.a, testCase.b, { sortBy: 'oldest' }),
+          testCase.expected,
+        );
       });
     });
   });
@@ -96,7 +96,8 @@ describe('sidebar/util/thread-sorters', () => {
       return { cfi, charOffset: pos };
     }
 
-    const compareLocation = sorters.Location;
+    const compareLocation = (a, b) =>
+      compareThreads(a, b, { sortBy: 'location' });
 
     it('sorts by CFI', () => {
       const a = thread(cfiLocation('/2/2'));

--- a/src/sidebar/helpers/thread-annotations.ts
+++ b/src/sidebar/helpers/thread-annotations.ts
@@ -7,7 +7,7 @@ import { filterAnnotations } from './filter-annotations';
 import { parseFilterQuery } from './query-parser';
 import type { FilterField, ParsedQuery } from './query-parser';
 import { tabForAnnotation } from './tabs';
-import { sorters } from './thread-sorters';
+import { compareThreads } from './thread-sorters';
 
 export type ThreadState = {
   annotations: Annotation[];
@@ -18,7 +18,7 @@ export type ThreadState = {
     filters: Partial<Record<FilterField, string>>;
     forcedVisible: string[];
     selected: string[];
-    sortKey: keyof typeof sorters;
+    sortKey: 'oldest' | 'newest' | 'location';
     selectedTab: 'annotation' | 'note' | 'orphan';
   };
 };
@@ -54,7 +54,8 @@ function threadAnnotationsImpl(
     expanded: selection.expanded,
     forcedVisible: selection.forcedVisible,
     selected: selection.selected,
-    sortCompareFn: sorters[selection.sortKey],
+    sortCompareFn: (a, b) =>
+      compareThreads(a, b, { sortBy: selection.sortKey }),
   };
 
   // Is there a filter query present, or an applied user (focus) filter?

--- a/src/sidebar/store/modules/selection.ts
+++ b/src/sidebar/store/modules/selection.ts
@@ -9,15 +9,15 @@ import { countIf, trueKeys, toTrueMap } from '../../util/collections';
 import { createStoreModule, makeAction } from '../create-store';
 
 type BooleanMap = Record<string, boolean>;
-type SortKey = 'Location' | 'Newest' | 'Oldest';
+export type SortKey = 'location' | 'newest' | 'oldest';
 
 /**
  * Default sort keys for each tab.
  */
 const TAB_SORTKEY_DEFAULT: Record<TabName, SortKey> = {
-  annotation: 'Location',
-  note: 'Oldest',
-  orphan: 'Location',
+  annotation: 'location',
+  note: 'oldest',
+  orphan: 'location',
 };
 
 function initialSelection(settings: SidebarSettings): BooleanMap {
@@ -367,10 +367,10 @@ function sortKey(state: State) {
 const sortKeys = createSelector(
   (state: State) => state.selectedTab,
   selectedTab => {
-    const sortKeysForTab: SortKey[] = ['Newest', 'Oldest'];
+    const sortKeysForTab: SortKey[] = ['newest', 'oldest'];
     if (selectedTab !== 'note') {
       // Location is inapplicable to Notes tab
-      sortKeysForTab.push('Location');
+      sortKeysForTab.push('location');
     }
     return sortKeysForTab;
   },

--- a/src/sidebar/store/modules/test/selection-test.js
+++ b/src/sidebar/store/modules/test/selection-test.js
@@ -234,43 +234,43 @@ describe('sidebar/store/modules/selection', () => {
 
     it('allows sorting annotations by time and document location', () => {
       store.selectTab('annotation');
-      assert.deepEqual(store.sortKeys(), ['Newest', 'Oldest', 'Location']);
+      assert.deepEqual(store.sortKeys(), ['newest', 'oldest', 'location']);
     });
 
     it('allows sorting page notes by time', () => {
       store.selectTab('note');
-      assert.deepEqual(store.sortKeys(), ['Newest', 'Oldest']);
+      assert.deepEqual(store.sortKeys(), ['newest', 'oldest']);
     });
 
     it('allows sorting orphans by time and document location', () => {
       store.selectTab('orphan');
-      assert.deepEqual(store.sortKeys(), ['Newest', 'Oldest', 'Location']);
+      assert.deepEqual(store.sortKeys(), ['newest', 'oldest', 'location']);
     });
 
     it('sorts annotations by document location by default', () => {
       store.selectTab('annotation');
-      assert.deepEqual(getSelectionState().sortKey, 'Location');
+      assert.deepEqual(getSelectionState().sortKey, 'location');
     });
 
     it('sorts page notes from oldest to newest by default', () => {
       store.selectTab('note');
-      assert.deepEqual(getSelectionState().sortKey, 'Oldest');
+      assert.deepEqual(getSelectionState().sortKey, 'oldest');
     });
 
     it('sorts orphans by document location by default', () => {
       store.selectTab('orphan');
-      assert.deepEqual(getSelectionState().sortKey, 'Location');
+      assert.deepEqual(getSelectionState().sortKey, 'location');
     });
 
     it('does not reset the sort key unless necessary', () => {
       // Select the tab, setting sort key to 'Oldest', and then manually
       // override the sort key.
       store.selectTab('note');
-      store.setSortKey('Newest');
+      store.setSortKey('newest');
 
       store.selectTab('note');
 
-      assert.equal(getSelectionState().sortKey, 'Newest');
+      assert.equal(getSelectionState().sortKey, 'newest');
     });
   });
 

--- a/src/sidebar/store/test/index-test.js
+++ b/src/sidebar/store/test/index-test.js
@@ -87,7 +87,7 @@ describe('createSidebarStore', () => {
     it('sets `sortKey` to default annotation sort key if set to Orphans', () => {
       store.selectTab('orphan');
       store.clearSelection();
-      assert.equal(store.getState().selection.sortKey, 'Location');
+      assert.equal(store.getState().selection.sortKey, 'location');
     });
 
     it('does not change `selectedTab` if set to something other than Orphans', () => {

--- a/src/sidebar/test/integration/threading-test.js
+++ b/src/sidebar/test/integration/threading-test.js
@@ -121,11 +121,11 @@ describe('integration: annotation threading', () => {
 
   [
     {
-      sortKey: 'Oldest',
+      sortKey: 'oldest',
       expectedOrder: ['1', '2'],
     },
     {
-      sortKey: 'Newest',
+      sortKey: 'newest',
       expectedOrder: ['2', '1'],
     },
   ].forEach(testCase => {


### PR DESCRIPTION
This is some refactoring of the internal APIs for sorting threads. There are no functional changes.

 - Decouple the item labels used in the sort menu from the internal sort key identifier. This will make it easier to localize these labels in future.
 - Revise the API of `thread-sorters.ts` to have a more conventional API for a comparison function.

   Before:

   ``` thread_sorters_exports.{Location, Newest, Oldest}(a, b)` ```

   After:

   ``` compareThreads(a, b, { sortBy: 'newest' | 'oldest' | 'location' } ```