### PR TITLE
Add page labels to pin annotations

### DIFF
--- a/src/annotator/anchoring/pdf.ts
+++ b/src/annotator/anchoring/pdf.ts
@@ -870,10 +870,7 @@ export async function describeShape(shape: Shape): Promise<Selector[]> {
       const pageView = await getPageView(point.pageIndex);
 
       return [
-        {
-          type: 'PageSelector',
-          index: point.pageIndex,
-        },
+        createPageSelector(pageView, point.pageIndex),
         {
           type: 'ShapeSelector',
           anchor: 'page',

--- a/src/annotator/anchoring/test/pdf-test.js
+++ b/src/annotator/anchoring/test/pdf-test.js
@@ -943,6 +943,7 @@ describe('annotator/anchoring/pdf', () => {
           {
             type: 'PageSelector',
             index: 0,
+            label: '1',
           },
           {
             type: 'ShapeSelector',


### PR DESCRIPTION
Pin annotations had a `PageSelector` with a page index, but not a page label. As a result, pin annotations were sorted correctly, using the page index, but no page number was displayed on annotation cards, as this uses the page label.

**Testing:**

Create a pin annotation on a PDF. A page number should be displayed on the annotation card.