### PR TITLE
Fix thumbnail rendering with extreme rect dimensions

### DIFF
--- a/src/annotator/integrations/pdf.tsx
+++ b/src/annotator/integrations/pdf.tsx
@@ -661,7 +661,9 @@ export class PDFIntegration
     });
 
     // Render page into an offscreen canvas
-    const canvas = new OffscreenCanvas(width, height);
+    const canvasWidth = Math.max(width, 1);
+    const canvasHeight = Math.max(height, 1);
+    const canvas = new OffscreenCanvas(canvasWidth, canvasHeight);
     const ctx = canvas.getContext('2d')!;
     const task = pageView.pdfPage.render({
       canvasContext: ctx as unknown as CanvasRenderingContext2D,

--- a/src/annotator/integrations/pdf.tsx
+++ b/src/annotator/integrations/pdf.tsx
@@ -609,6 +609,19 @@ export class PDFIntegration
         throw new Error('Unsupported shape type');
     }
 
+    // Ensure rect is non-empty and normalized such that right > left and top >
+    // bottom (since Y goes up).
+    const minSize = 1;
+    if (right < left) {
+      [left, right] = [right, left];
+    }
+    right = Math.max(right, left + minSize);
+
+    if (top < bottom) {
+      [top, bottom] = [bottom, top];
+    }
+    top = Math.max(top, bottom + minSize);
+
     // Conversion factor from PDF pixels per inch to CSS pixels per inch.
     // See https://github.com/mozilla/pdf.js/blob/2f7d163dfdf40225479d1cc8f6d8ebd9e5273ca6/src/display/display_utils.js#L31.
     const CSS_PPI = 96.0;

--- a/src/annotator/integrations/test/pdf-test.js
+++ b/src/annotator/integrations/test/pdf-test.js
@@ -811,7 +811,45 @@ describe('annotator/integrations/pdf', () => {
             viewBox: [0, 0, 100, 100],
           },
         },
-      ].forEach(({ renderOptions, shapeSelector, expectedViewport }) => {
+        // Empty rectangle
+        {
+          shapeSelector: {
+            type: 'ShapeSelector',
+            shape: {
+              type: 'rect',
+              left: 0,
+              right: 0,
+              top: 0,
+              bottom: 0,
+            },
+          },
+          expectedViewport: {
+            rotation: 0,
+            scale: 96 / 72,
+            userUnit: 1 / 72,
+            viewBox: [0, 0, 1, 1],
+          },
+        },
+        // Rectangle with negative width and height
+        {
+          shapeSelector: {
+            type: 'ShapeSelector',
+            shape: {
+              type: 'rect',
+              left: 100,
+              right: 0,
+              top: 0,
+              bottom: 100,
+            },
+          },
+          expectedViewport: {
+            rotation: 0,
+            scale: 96 / 72,
+            userUnit: 1 / 72,
+            viewBox: [0, 0, 100, 100],
+          },
+        },
+      ].forEach(({ renderOptions = {}, shapeSelector, expectedViewport }) => {
         it('renders bitmap with given options', async () => {
           pdfIntegration = createPDFIntegration();
           const anchor = {

--- a/src/annotator/integrations/test/pdf-test.js
+++ b/src/annotator/integrations/test/pdf-test.js
@@ -696,6 +696,16 @@ describe('annotator/integrations/pdf', () => {
         index: pageIndex,
       };
 
+      const createShapeSelector = (type, coords) => {
+        return {
+          type: 'ShapeSelector',
+          shape: {
+            type,
+            ...coords,
+          },
+        };
+      };
+
       it('rejects if anchor has no shape selector', async () => {
         pdfIntegration = createPDFIntegration();
         const anchor = {
@@ -813,16 +823,12 @@ describe('annotator/integrations/pdf', () => {
         },
         // Empty rectangle
         {
-          shapeSelector: {
-            type: 'ShapeSelector',
-            shape: {
-              type: 'rect',
-              left: 0,
-              right: 0,
-              top: 0,
-              bottom: 0,
-            },
-          },
+          shapeSelector: createShapeSelector('rect', {
+            left: 0,
+            right: 0,
+            top: 0,
+            bottom: 0,
+          }),
           expectedViewport: {
             rotation: 0,
             scale: 96 / 72,
@@ -832,21 +838,36 @@ describe('annotator/integrations/pdf', () => {
         },
         // Rectangle with negative width and height
         {
-          shapeSelector: {
-            type: 'ShapeSelector',
-            shape: {
-              type: 'rect',
-              left: 100,
-              right: 0,
-              top: 0,
-              bottom: 100,
-            },
-          },
+          shapeSelector: createShapeSelector('rect', {
+            left: 100,
+            right: 0,
+            top: 0,
+            bottom: 100,
+          }),
           expectedViewport: {
             rotation: 0,
             scale: 96 / 72,
             userUnit: 1 / 72,
             viewBox: [0, 0, 100, 100],
+          },
+        },
+        // Rectangle with a very wide aspect ratio, such that after scaling
+        // the thumbnail to fit `maxWidth`, the height is zero.
+        {
+          shapeSelector: createShapeSelector('rect', {
+            left: 0,
+            right: 101,
+            top: 0,
+            bottom: 0,
+          }),
+          renderOptions: {
+            maxWidth: 100,
+          },
+          expectedViewport: {
+            rotation: 0,
+            scale: sinon.match.number,
+            userUnit: 1 / 72,
+            viewBox: [0, 0, 101, 1],
           },
         },
       ].forEach(({ renderOptions = {}, shapeSelector, expectedViewport }) => {


### PR DESCRIPTION
Fix thumbnail rendering for rect annotations if:

- The rect has zero or negative width or height
- The rect has a very wide aspect ratio, such that after scaling the thumbnail size to fit the maximum width, the thumbnail height is zero

Thumbnails of these extreme shapes are not really useful, but the rendering shouldn't fail.

Fixes https://github.com/hypothesis/client/issues/7016