### PR TITLE
Keep shape highlights in place when page is zoomed in far

### DIFF
--- a/src/annotator/highlighter.ts
+++ b/src/annotator/highlighter.ts
@@ -206,37 +206,25 @@ export function highlightShape(region: ShapeAnchor): HighlightElement[] {
   const anchorStyles = getComputedStyle(anchor);
   const borderWidth = parseInt(anchorStyles.borderWidth);
 
-  // "Outer" rect of the anchor that includes the border.
-  const anchorOuterBox = anchor.getBoundingClientRect();
-
-  // Inner rect of the anchor that does not include the border.
-  const anchorBox = new DOMRect(
-    anchorOuterBox.left,
-    anchorOuterBox.top,
-    anchorOuterBox.width - 2 * borderWidth,
-    anchorOuterBox.height - 2 * borderWidth,
-  );
-
   const highlightEl = document.createElement('hypothesis-highlight');
 
   // Should match the width used by the `hypothesis-shape-highlight` class.
   const highlightBorderWidth = 3;
   highlightEl.className = 'hypothesis-shape-highlight';
 
+  // The highlight shape is positioned relative to the anchor element using
+  // `calc` so that it stays in the same position if the anchor element is
+  // resized, eg. as a result of zooming the page.
   if (shape.type === 'rect') {
-    const left = shape.left * anchorBox.width - borderWidth;
-    const top = shape.top * anchorBox.height - borderWidth;
-    const width = (shape.right - shape.left) * anchorBox.width;
-    const height = (shape.bottom - shape.top) * anchorBox.height;
-    highlightEl.style.left = `${left}px`;
-    highlightEl.style.top = `${top}px`;
-    highlightEl.style.width = `${width - 2 * highlightBorderWidth}px`;
-    highlightEl.style.height = `${height - 2 * highlightBorderWidth}px`;
+    const width = shape.right - shape.left;
+    const height = shape.bottom - shape.top;
+    highlightEl.style.left = `calc(${shape.left * 100}% - ${borderWidth}px)`;
+    highlightEl.style.top = `calc(${shape.top * 100}% - ${borderWidth}px)`;
+    highlightEl.style.width = `calc(${width * 100}% - ${2 * highlightBorderWidth}px)`;
+    highlightEl.style.height = `calc(${height * 100}% - ${2 * highlightBorderWidth}px)`;
   } else if (shape.type === 'point') {
-    const x = shape.x * anchorBox.width - borderWidth;
-    const y = shape.y * anchorBox.height - borderWidth;
-    highlightEl.style.left = `${x}px`;
-    highlightEl.style.top = `${y}px`;
+    highlightEl.style.left = `calc(${shape.x * 100}% - ${borderWidth}px)`;
+    highlightEl.style.top = `calc(${shape.y * 100}% - ${borderWidth}px)`;
     highlightEl.style.width = '10px';
     highlightEl.style.height = '10px';
   }

--- a/src/annotator/test/highlighter-test.js
+++ b/src/annotator/test/highlighter-test.js
@@ -378,20 +378,20 @@ describe('annotator/highlighter', () => {
           bottom: 1,
         },
         expected: {
-          top: '-5px',
-          left: '-5px',
-          // 100 anchor width - 2 * 5 anchor border - 2 * 3 highlight border
-          width: '84px',
-          // 200 anchor height - 2 * 5 anchor border - 2 * 3 highlight border
-          height: '184px',
+          top: 'calc(0% - 5px)',
+          left: 'calc(0% - 5px)',
+          // 100% anchor width - 2 * 3px highlight border
+          width: 'calc(100% - 6px)',
+          // 100% anchor height - 2 * 3px highlight border
+          height: 'calc(100% - 6px)',
         },
       },
       {
         // Point at top-left corner of anchor element.
         shape: { type: 'point', x: 0, y: 0 },
         expected: {
-          top: '-5px',
-          left: '-5px',
+          top: 'calc(0% - 5px)',
+          left: 'calc(0% - 5px)',
           width: '10px',
           height: '10px',
         },


### PR DESCRIPTION
Position shape highlights using `calc` + percentages instead of absolute positions. This enables the shape's position to automatically adjust when the page is zoomed, even if PDF.js does not re-render the page. Previously updating the highlight position after zooming relied on PDF.js redrawing the page, triggering re-anchoring of the annotation. Beyond a certain zoom level however, zooming in further doesn't re-render the page.

There is a related issue that zooming far out can lead to highlights becoming offset. This starts to become noticeable at <50% zoom. I will fix that separately.

Fixes https://github.com/hypothesis/client/issues/7015. This doesn't fix the existing issue with text highlights mentioned in that issue.

**Testing:**

1. Create a rect or point annotation on a PDF
2. Zoom into the PDF a long way (> 280%)
3. The shape annotation should remain in the same position