### PR TITLE
Use percentage positioning for PDF text highlights

### DIFF
--- a/src/annotator/highlighter.ts
+++ b/src/annotator/highlighter.ts
@@ -117,10 +117,16 @@ function drawHighlightsAbovePDFCanvas(
 
     // Create SVG element for the current highlight element.
     const rect = document.createElementNS(SVG_NAMESPACE, 'rect');
-    rect.setAttribute('x', (highlightRect.left - canvasRect.left).toString());
-    rect.setAttribute('y', (highlightRect.top - canvasRect.top).toString());
-    rect.setAttribute('width', highlightRect.width.toString());
-    rect.setAttribute('height', highlightRect.height.toString());
+
+    const x = (highlightRect.left - canvasRect.left) / canvasRect.width;
+    const y = (highlightRect.top - canvasRect.top) / canvasRect.height;
+    const width = highlightRect.width / canvasRect.width;
+    const height = highlightRect.height / canvasRect.height;
+
+    rect.setAttribute('x', `${x * 100}%`);
+    rect.setAttribute('y', `${y * 100}%`);
+    rect.setAttribute('width', `${width * 100}%`);
+    rect.setAttribute('height', `${height * 100}%`);
     rect.setAttribute(
       'class',
       classnames('hypothesis-svg-highlight', cssClass),


### PR DESCRIPTION
PDF text highlights are created using an `<svg>` positioned over the page's `<canvas>`. Use percentages rather than pixel values to position the `<rect>`s in this SVG layer. This keeps the highlights in the correct position when the `<canvas>` and `<svg>` change size as a result of zooming.

This fixes an issue with highlights becoming misplaced at high zoom levels, described in
https://github.com/hypothesis/client/issues/7015#issuecomment-2838091196.

**Testing:**

1. Annotate some text in a PDF
2. Zoom a long way in (past 300%)

On `main`, the highlight will start to become misplaced at a sufficiently high zoom level. On this branch it should remain in the correct place.