### PR TITLE
Improve handling of links inside PDFs

### DIFF
--- a/src/annotator/guest.ts
+++ b/src/annotator/guest.ts
@@ -66,8 +66,8 @@ function annotationsForSelection(): string[] {
 }
 
 /**
- * Return the annotation tags associated with highlights at given (clientX,
- * clientY) coordinates.
+ * Return the annotation tags associated with visible highlights at given
+ * (clientX, clientY) coordinates.
  */
 function annotationsAtPoint(x: number, y: number): string[] {
   return getHighlightsFromPoint(x, y)
@@ -435,7 +435,7 @@ export class Guest
     this._listeners.add(this.element, 'mouseup', event => {
       const { clientX, clientY, metaKey, ctrlKey } = event;
       const tags = annotationsAtPoint(clientX, clientY);
-      if (tags.length && this._highlightsVisible) {
+      if (tags.length) {
         const toggle = metaKey || ctrlKey;
         this.selectAnnotations(tags, { toggle });
       }
@@ -445,7 +445,7 @@ export class Guest
 
     this._listeners.add(this.element, 'mouseover', ({ clientX, clientY }) => {
       const tags = annotationsAtPoint(clientX, clientY);
-      if (tags.length && this._highlightsVisible) {
+      if (tags.length) {
         this._sidebarRPC.call('hoverAnnotations', tags);
       }
     });

--- a/src/annotator/highlighter.ts
+++ b/src/annotator/highlighter.ts
@@ -421,26 +421,32 @@ export function setHighlightsFocused(
   });
 }
 
+/** Class set on root element to make highlights visible. */
+const showHighlightsClass = 'hypothesis-highlights-always-on';
+
 /**
  * Set whether highlights under the given root element should be visible.
  */
 export function setHighlightsVisible(root: HTMLElement, visible: boolean) {
-  const showHighlightsClass = 'hypothesis-highlights-always-on';
   root.classList.toggle(showHighlightsClass, visible);
 }
 
 /**
- * Get the highlight elements at the given client coordinates.
+ * Get the visible highlight elements at the given client coordinates.
  */
 export function getHighlightsFromPoint(
   x: number,
   y: number,
 ): HighlightElement[] {
+  const showHighlightsSelector = `.${showHighlightsClass}`;
+
   // Text highlights can be found via `elementsFromPoint`.
   const textHighlights = document
     .elementsFromPoint(x, y)
     .filter(
-      el => el.localName === 'hypothesis-highlight',
+      el =>
+        el.localName === 'hypothesis-highlight' &&
+        el.closest(showHighlightsSelector),
     ) as HighlightElement[];
 
   // Shape highlights have `pointer-events: none` so users can interact with
@@ -450,6 +456,10 @@ export function getHighlightsFromPoint(
   for (const highlight of document.querySelectorAll(
     'hypothesis-highlight.hypothesis-shape-highlight',
   )) {
+    if (!highlight.closest(showHighlightsSelector)) {
+      continue;
+    }
+
     // Approximate the shape by its bounding rect. This works for the shapes we
     // currently support, but won't work for more complex shapes (eg.
     // arbitrary polygons) that we might introduce in future.

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -989,25 +989,6 @@ describe('Guest', () => {
       assert.notCalled(sidebarRPC().call);
     });
 
-    it('does not focus or select annotations in the sidebar if highlights are hidden', () => {
-      const guest = createGuest();
-      guest.setHighlightsVisible(false);
-
-      fakeHighlight.dispatchEvent(
-        new MouseEvent('mouseover', {
-          bubbles: true,
-          clientX: 50,
-          clientY: 60,
-        }),
-      );
-      fakeHighlight.dispatchEvent(
-        new MouseEvent('mouseup', { bubbles: true, clientX: 50, clientY: 60 }),
-      );
-
-      assert.calledWith(highlighter.getHighlightsFromPoint, 50, 60);
-      assert.notCalled(sidebarRPC().call);
-    });
-
     it('selects annotations in the sidebar when clicking on a highlight', () => {
       createGuest();
       fakeHighlight.dispatchEvent(new Event('mouseup', { bubbles: true }));

--- a/src/annotator/test/highlighter-test.js
+++ b/src/annotator/test/highlighter-test.js
@@ -836,7 +836,7 @@ describe('annotator/highlighter', () => {
       return hl;
     };
 
-    it('returns all the highlights at the given point', () => {
+    it('returns all the visible highlights at the given point', () => {
       const container = document.createElement('div');
       const elements = [
         createHighlight('text'),
@@ -851,11 +851,21 @@ describe('annotator/highlighter', () => {
       }
 
       try {
+        // Position with highlights, when visible.
+        const x = 105;
+        const y = 205;
+        setHighlightsVisible(container, true);
         assert.sameMembers(
-          getHighlightsFromPoint(105, 205),
+          getHighlightsFromPoint(x, y),
           elements.filter(hl => hl.localName === 'hypothesis-highlight'),
         );
+
+        // Position with no highlights, when visible.
         assert.deepEqual(getHighlightsFromPoint(0, 0), []);
+
+        // Position with highlights, when hidden.
+        setHighlightsVisible(container, false);
+        assert.deepEqual(getHighlightsFromPoint(x, y), []);
       } finally {
         container.remove();
       }


### PR DESCRIPTION
It is annoying when accidentally clicking a link inside a PDF navigates away
from the PDF and unloads Hypothesis. This is more likely when text containing a
link is highlighted. In the LMS context this is especially problematic because
the user doesn't have a way to navigate back.

Remedy this by:

 - Making all links open in a new tab when the Hypothesis PDF
   integration is active.
 - Disabling default behavior for highlighted links, when the highlights
   are visible. Clicking on a highlighted link will focus the highlight
   rather than following the link. When highlights are hidden, the link
   will become active but open in a new tab.

Fixes https://github.com/hypothesis/support/issues/181

**Testing:**

1. Open http://localhost:3000/pdf/nils-olav, which contains many image and text links
2. Annotate some text containing a link
3. Annotate an image which is a link
4. Click on an un-highlighted link (text or image). It should open in a new tab
5. Click on a highlighted link (text or image). It should focus the annotation
6. Turn off highlights and click on the places from step (5). The links should open in a new tab