### PR TITLE
Improve handling when creating a new pin annotation inside an existing rect annotation

### DIFF
--- a/src/annotator/draw-tool.tsx
+++ b/src/annotator/draw-tool.tsx
@@ -182,6 +182,11 @@ export class DrawTool implements Destroyable {
           break;
       }
       this._abortDraw?.abort();
+
+      // Prevent event from propagating to the Guest's event handlers, as this
+      // will trigger selection of any existing highlights containing the
+      // position of this event.
+      e.stopPropagation();
     });
 
     // Enable user to scroll elements under the drawing surface by translating

--- a/src/annotator/test/draw-tool-test.js
+++ b/src/annotator/test/draw-tool-test.js
@@ -44,6 +44,7 @@ describe('DrawTool', () => {
   it('removes SVG when drawing ends', async () => {
     const shape = tool.draw('point');
     sendMouseEvent('mousedown');
+    sendMouseEvent('mouseup');
     await shape;
     assert.notOk(getSurface());
   });
@@ -125,31 +126,18 @@ describe('DrawTool', () => {
   });
 
   describe('drawing a point', () => {
-    it('finishes drawing when mouse is pressed', async () => {
+    it('finishes drawing when mouse is released', async () => {
       const shapePromise = tool.draw('point');
-      sendMouseEvent('mousedown');
+      sendMouseEvent('mousedown', 5, 5);
+      sendMouseEvent('mousemove', 10, 10);
+      sendMouseEvent('mouseup', 15, 20);
 
       const shape = await shapePromise;
 
       assert.deepEqual(shape, {
         type: 'point',
-        x: 0,
-        y: 0,
-      });
-    });
-
-    it('ignores mousemove and mouseup events while drawing a point', async () => {
-      const shapePromise = tool.draw('point');
-
-      sendMouseEvent('mouseup');
-      sendMouseEvent('mousemove');
-      sendMouseEvent('mousedown', 20, 30);
-
-      const shape = await shapePromise;
-      assert.deepEqual(shape, {
-        type: 'point',
-        x: 20,
-        y: 30,
+        x: 15,
+        y: 20,
       });
     });
   });


### PR DESCRIPTION
Fix an issue where creating a new pin annotation inside an existing rect annotation would show the rect annotation's card in the sidebar after releasing the mouse, instead of the card for the new pin annotation.

There are two parts to this:
- The first commit changes drawing of pin annotations to work more like rect annotations, where drawing finishes on mouse up rather than mouse down. This is not strictly required but makes it a bit easier to reason about the events elsewhere in the code. Also it allows the user to fine-tune the position of the pin after they press the mouse.
- The second commit fixes the problem by stopping propagation of "mouseup" events from the drawing layer `<svg>` to event handlers in the `Guest`

**Testing:**

1. Create a new rect annotation in a PDF
2. Create a new pin annotation inside the rect
3. Save the new pin annotation

After step (2), the card for the new pin annotation should be visible in the sidebar. It should remain visible after step 3.