### PR TITLE
Don't report error in console if shape drawing is canceled

### DIFF
--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -579,6 +579,33 @@ describe('Guest', () => {
         assert.calledWith(sidebarRPC().call, 'createAnnotation');
       });
 
+      ['canceled', 'restarted'].forEach(kind => {
+        it('does not create annotation if `tool` is "rect" and drawing is canceled', async () => {
+          createGuest();
+          fakeDrawTool.draw.rejects(new DrawError(kind));
+          const annotation = await emitHostEvent('createAnnotation', {
+            tool: 'rect',
+          });
+          assert.isNull(annotation);
+          assert.notCalled(sidebarRPC().call);
+        });
+      });
+
+      it('throws if unexpected error occurs during drawing', async () => {
+        const expectedError = new Error('Oh no');
+        createGuest();
+        fakeDrawTool.draw.rejects(expectedError);
+
+        let err;
+        try {
+          await emitHostEvent('createAnnotation', { tool: 'rect' });
+        } catch (e) {
+          err = e;
+        }
+
+        assert.equal(err, expectedError);
+      });
+
       it('creates annotation if `tool` is "rect"', async () => {
         const guest = createGuest();
         hostRPC().call.resetHistory();


### PR DESCRIPTION
Handle cancelation of drawing differently to unexpected errors. This avoids 'Drawing canceled' errors appearing the console if drawing is canceled or restarted by the user.

**Testing:**

1. In a PDF, activate the rect or pin annotation tools
2. Press Escape to cancel drawing

Drawing should be canceled and no error should be logged in the console.