### PR TITLE
WIP - Use relative coordinates for shapes

### DIFF
--- a/src/sidebar/helpers/annotation-metadata.ts
+++ b/src/sidebar/helpers/annotation-metadata.ts
@@ -352,16 +352,15 @@ export function location(annotation: Annotation): LocationKey {
 }
 
 /**
- * Return the distance of the top of a shape from the top of the containing
- * page, image or document.
+ * Return the relative distance of the top of a shape from the top of the
+ * containing page, image or document.
  */
 function distanceFromTopOfView(selector: ShapeSelector): number | undefined {
-  const pageTop = selector.view?.top ?? 0;
   switch (selector.shape.type) {
     case 'rect':
-      return Math.abs(pageTop - selector.shape.top);
+      return Math.abs(selector.shape.top);
     case 'point':
-      return Math.abs(pageTop - selector.shape.y);
+      return Math.abs(selector.shape.y);
     default:
       return undefined;
   }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -161,17 +161,25 @@ export type Shape = RectShape | PointShape;
  * coordinates alone (such as images, but not PDFs or HTML documents), the
  * anchor is optional.
  *
- * # Coordinate systems
+ * # Coordinates
  *
- * Shape selectors should be defined using the natural coordinate system for the
- * anchor element in the document, enabling an annotation made in one viewer to
- * be resolved to the same location in a different viewer, with different view
- * settings (zoom, rotation etc.). For common document and anchor types, these
- * are as follows:
+ * Coordinates are relative either to the anchor element or the document as a
+ * whole, with coordinates of (0, 0) at the top-left corner and (1, 1) at the
+ * bottom right corner of the page or image.
  *
- * - For PDFs, PDF user space coordinates (points), with the origin at the
- *   bottom-left corner of the page.
- * - For images, pixels with the origin at the top-left
+ * For viewers which allow rotation of pages or the whole document, coordinates
+ * are expressed in terms of the un-rotated page. This means that to translate
+ * a coordinate from an annotation to the view, you need to:
+ *
+ * 1. Map the coordinate to the document's native units (eg. PDF points or
+ *    image pixels), relative to the top-left corner of the page.
+ * 2. Map the native units to the viewport, according to the current transform
+ *    (scale, rotation etc.) of the view.
+ *
+ * Some formats may define multiple bounding boxes for a page. For PDFs, the
+ * page corners are based on the crop box. This is the area of the page that PDF
+ * viewers display on screen. See
+ * https://www.pdf2go.com/blog/what-are-pdf-boxes.
  */
 export type ShapeSelector = {
   type: 'ShapeSelector';
@@ -189,29 +197,6 @@ export type ShapeSelector = {
    * - "page" - The page identified by the annotation's {@link PageSelector}.
    */
   anchor?: 'page';
-
-  /**
-   * Specifies the bounding box of the visible area of the anchor element,
-   * in the same coordinates used by {@link ShapeSelector.shape}.
-   *
-   * This enables interpreting the coordinates in the shape relative to the
-   * anchor element as a whole.
-   *
-   * Examples of how the visible area is determined for common document and
-   * anchor types:
-   *
-   * - For a PDF page, the box is the intersection of the media and crop box,
-   *   which is usually equal to the crop box. See https://www.pdf2go.com/blog/what-are-pdf-boxes.
-   * - For an SVG, these are the coordinates of the `viewBox` element
-   * - For an image, `left` and `top` are zero and `right` and `bottom` are the
-   *   width and height of the image in pixels.
-   */
-  view?: {
-    left: number;
-    top: number;
-    right: number;
-    bottom: number;
-  };
 };
 
 /**


### PR DESCRIPTION
This is an exploration of using relative rather than absolute coordinates for shape annotations. Relative coordinates have (0, 0) at the top-left corner of the page, image or document and (1, 1) at the bottom-right corner. Previously shape coordinates were using PDF units.

This has pros and cons:

Pros:
- This coordinate system works the same across multiple formats (PDF, standalone images, images within web pages)
- You can sort annotations by location by looking at the Y coordinates alone, since the Y direction is the same for all formats. Previously this required computing the relative Y coordinate from the absolute coordinates
- It aligns with the [Web Annotation Data Model](https://www.w3.org/TR/annotation-model/#svg-selector)
- For images which are provided in different resolutions depending on the viewer, resolution works the same regardless of what the current resolution happens to be.

Cons:
- Some formats offer multiple choices of bounding box. PDFs have [5 bounding boxes](https://www.pdf2go.com/blog/what-are-pdf-boxes). In this case implementations need to standardize which one is used.
- It means for PDFs we're no longer using the standard PDF units coordinate system that eg. native annotations use
- More care needs to be taken to make sure that captured coordinates are independent of the rotation of the viewer
- Relative coordinates won't work for document formats where there isn't a canvas with a definite size and origin for coordinates to be relative to, or at least it may be unclear what the size and origin should be. Take a map for example, it seems more obvious to express points in terms of longitude and latitude than as eg. `(longitude - minLongitude) / (maxLongtiude - minLongitude)`.

I suppose we could follow an approach where we use relative coordinates in contexts where there is a canvas with a definite size and origin, and absolute coordinates otherwise.

Relates to https://github.com/hypothesis/client/issues/6987.