### PR TITLE
Fix positioning of shape highlights when PDF page is rotated

### DIFF
--- a/src/annotator/anchoring/test/pdf-test.js
+++ b/src/annotator/anchoring/test/pdf-test.js
@@ -729,9 +729,39 @@ describe('annotator/anchoring/pdf', () => {
           shape: {
             type: 'rect',
             left: 0,
-            top: 1,
+            top: 0.95,
             right: 0.1,
-            bottom: 0.95,
+            bottom: 1,
+          },
+          coordinates: 'anchor',
+        },
+      },
+      // Rect annotation with inverted left / right
+      {
+        pageBoundingBox: [5, 9, 105, 209],
+        selectors: [
+          {
+            type: 'ShapeSelector',
+
+            // Rect at bottom-left corner of page.
+            shape: {
+              type: 'rect',
+              left: 15,
+              top: 9,
+              right: 5,
+              bottom: 19,
+            },
+          },
+          { type: 'PageSelector', index: 0 },
+        ],
+        expected: {
+          anchor: 0,
+          shape: {
+            type: 'rect',
+            left: 0,
+            top: 0.95,
+            right: 0.1,
+            bottom: 1,
           },
           coordinates: 'anchor',
         },
@@ -818,10 +848,8 @@ describe('annotator/anchoring/pdf', () => {
       },
     ].forEach(({ pageBoundingBox, selectors, expected }) => {
       it('anchors shape selectors', async () => {
+        initViewer(fixtures.pdfPages, { pageBoundingBox });
         const pageView = viewer.pdfViewer.getPageView(expected.anchor);
-
-        // Set page bounding box in PDF user space coordinates.
-        pageView.pdfPage.setPageBoundingBox(pageBoundingBox);
 
         const anchor = await pdfAnchoring.anchor(selectors);
         const expectedAnchor = {

--- a/src/types/pdfjs.ts
+++ b/src/types/pdfjs.ts
@@ -110,6 +110,9 @@ export type PageViewport = {
   userUnit: number;
   width: number;
   height: number;
+
+  /** Convert an (x, y) coordinate in PDF units to viewport coordinates. */
+  convertToViewportPoint(x: number, y: number): [number, number];
 };
 
 /**
@@ -165,6 +168,12 @@ export type PDFPageView = {
   textLayer: TextLayer | null;
   /** See `RenderingStates` enum in src/annotator/anchoring/pdf.js */
   renderingState: number;
+
+  /**
+   * Return the viewport describing the transformation between the PDF page
+   * coordinate space and the view.
+   */
+  viewport: PageViewport;
 
   /**
    * Return the `[x, y]` coordinates in PDF user space that correspond to a


### PR DESCRIPTION
Use PDF.js APIs to handle PDF-to-viewport transforms so that the rotation of the viewport is taken into account. This fixes shape highlights being positioned incorrectly if the page is rotated in the viewer.

**Testing:**

1. Create a rect annotation in a PDF
2. Rotate the page via `Tools -> {Rotate Clockwise, Rotate Anti-clockwise}` in PDF.js's menu bar

After each rotation, the shape highlight should be adjusted and positioned to match the new location of the selected content.