### PR TITLE
Fix annotating when even/odd page spreads are used

### DIFF
--- a/src/annotator/anchoring/pdf.ts
+++ b/src/annotator/anchoring/pdf.ts
@@ -71,18 +71,6 @@ function quotePositionCacheKey(quote: string, pos?: number) {
 }
 
 /**
- * Return offset of `node` among its siblings.
- */
-function getSiblingIndex(node: Node) {
-  let index = 0;
-  while (node.previousSibling) {
-    ++index;
-    node = node.previousSibling;
-  }
-  return index;
-}
-
-/**
  * Return the text layer element of the PDF page containing `node`.
  */
 function getNodeTextLayer(node: Node | Element): Element | null {
@@ -729,6 +717,22 @@ export function canDescribe(range: Range) {
   }
 }
 
+/** Return the index of the PDF page which contains `el`. */
+function getContainingPageIndex(el: Element): number {
+  const page = el.closest('.page');
+
+  // `data-page-number` contains the 1-based page number. If the visible page
+  // number is not numeric (eg. "i"), that will be stored in `data-page-label`.
+  const pageNumber = parseInt(page?.getAttribute('data-page-number') ?? '');
+
+  /* istanbul ignore next */
+  if (!Number.isInteger(pageNumber)) {
+    throw new Error('Unable to get page number from element');
+  }
+
+  return pageNumber - 1;
+}
+
 /**
  * Convert a DOM Range object into a set of selectors.
  *
@@ -751,7 +755,7 @@ export async function describe(range: Range): Promise<Selector[]> {
     textRange.endOffset,
   ).relativeTo(textLayer);
 
-  const startPageIndex = getSiblingIndex(textLayer.parentNode!);
+  const startPageIndex = getContainingPageIndex(textLayer);
   const pageOffset = await getPageOffset(startPageIndex);
 
   const pageView = await getPageView(startPageIndex);
@@ -788,7 +792,7 @@ async function mapViewportToPDF(
     if (!el.classList.contains('page')) {
       continue;
     }
-    const pageIndex = getSiblingIndex(el);
+    const pageIndex = getContainingPageIndex(el);
     const pageViewRect = el.getBoundingClientRect();
     const pageViewX = x - pageViewRect.left;
     const pageViewY = y - pageViewRect.top;

--- a/src/annotator/anchoring/test/fake-pdf-viewer-application.js
+++ b/src/annotator/anchoring/test/fake-pdf-viewer-application.js
@@ -31,9 +31,10 @@ import { RenderingStates } from '../pdf';
  * @param {PDFJSConfig} config
  * @return {Element} - The root Element for the page
  */
-function createPage(content, rendered, config) {
+function createPage(index, content, rendered, config) {
   const pageEl = document.createElement('div');
   pageEl.classList.add('page');
+  pageEl.setAttribute('data-page-number', index + 1);
 
   if (!rendered) {
     return pageEl;
@@ -161,11 +162,12 @@ class FakeRenderTask {
  */
 class FakePDFPageView {
   /**
+   * @param {number} index - Index of the page
    * @param {string} text - Text of the page
    * @param {FakePDFPageViewOptions} options
    */
-  constructor(text, { rendered, config }) {
-    const pageEl = createPage(text, rendered, config);
+  constructor(index, text, { rendered, config }) {
+    const pageEl = createPage(index, text, rendered, config);
     const textLayerEl = pageEl.querySelector('.textLayer');
 
     this.div = pageEl;
@@ -250,7 +252,7 @@ class FakePDFViewer {
 
     const pages = this._content.map(
       (text, idx) =>
-        new FakePDFPageView(text, {
+        new FakePDFPageView(idx, text, {
           rendered: idx >= index && idx <= lastRenderedPage,
           config: this._config,
         }),


### PR DESCRIPTION
When creating an annotation the index of the page containing the text layer was determined by getting the index of the containing `.page` element amongst its siblings. This doesn't work when the Even Spreads or Odd Spreads layout modes are used as the DOM structure changes and the `.page` elements are no longer all under one parent. The solution is to get the page number from the `data-page-number` attribute on the element instead.

Fixes https://github.com/hypothesis/support/issues/192