### PR TITLE
Center PDF highlights in viewport when scrolling to them

### DIFF
--- a/src/annotator/integrations/pdf.tsx
+++ b/src/annotator/integrations/pdf.tsx
@@ -39,7 +39,7 @@ import ContentInfoBanner from '../components/ContentInfoBanner';
 import WarningBanner from '../components/WarningBanner';
 import { getHighlightsFromPoint } from '../highlighter';
 import { PreactContainer } from '../util/preact-container';
-import { offsetRelativeTo, scrollElement } from '../util/scroll';
+import { computeScrollOffset, scrollElement } from '../util/scroll';
 import { PDFMetadata } from './pdf-metadata';
 
 /**
@@ -574,8 +574,8 @@ export class PDFIntegration
   }
 
   /**
-   * Return the offset that the PDF content container would need to be scrolled
-   * to, in order to make an anchor visible.
+   * Return a scroll offset for the PDF content container that would make an
+   * anchor visible.
    *
    * @return - Target offset or `null` if this anchor was not resolved
    */
@@ -585,7 +585,9 @@ export class PDFIntegration
       return null;
     }
     const highlight = anchor.highlights[0];
-    return offsetRelativeTo(highlight, this.contentContainer());
+    return computeScrollOffset(this.contentContainer(), highlight, {
+      position: 'center',
+    });
   }
 
   async renderToBitmap(

--- a/src/annotator/integrations/test/pdf-test.js
+++ b/src/annotator/integrations/test/pdf-test.js
@@ -102,7 +102,7 @@ describe('annotator/integrations/pdf', () => {
       };
 
       fakeScrollUtils = {
-        offsetRelativeTo: sinon.stub().returns(0),
+        computeScrollOffset: sinon.stub().returns(0),
         scrollElement: sinon.stub().resolves(),
       };
 
@@ -553,8 +553,10 @@ describe('annotator/integrations/pdf', () => {
         const highlight = document.createElement('div');
         const offset = 42;
         const integration = createPDFIntegration();
-        fakeScrollUtils.offsetRelativeTo
-          .withArgs(highlight, integration.contentContainer())
+        fakeScrollUtils.computeScrollOffset
+          .withArgs(integration.contentContainer(), highlight, {
+            position: 'center',
+          })
           .returns(offset);
 
         const anchor = { highlights: [highlight] };
@@ -592,8 +594,8 @@ describe('annotator/integrations/pdf', () => {
       it('waits for anchors in placeholders to be re-anchored and scrolls to final highlight', async () => {
         const placeholderHighlight = createPlaceholderHighlight();
         const integration = createPDFIntegration();
-        fakeScrollUtils.offsetRelativeTo
-          .withArgs(placeholderHighlight, integration.contentContainer())
+        fakeScrollUtils.computeScrollOffset
+          .withArgs(integration.contentContainer(), placeholderHighlight)
           .returns(50);
         const annotation = { $tag: 'tag1' };
         const anchor = { annotation, highlights: [placeholderHighlight] };
@@ -618,8 +620,8 @@ describe('annotator/integrations/pdf', () => {
           annotation,
           highlights: [finalHighlight],
         });
-        fakeScrollUtils.offsetRelativeTo
-          .withArgs(finalHighlight, integration.contentContainer())
+        fakeScrollUtils.computeScrollOffset
+          .withArgs(integration.contentContainer(), finalHighlight)
           .returns(150);
 
         await scrollDone;

--- a/src/annotator/util/scroll.ts
+++ b/src/annotator/util/scroll.ts
@@ -18,20 +18,41 @@ function interpolate(a: number, b: number, fraction: number): number {
   return a + fraction * (b - a);
 }
 
+export type ScrollOffsetOptions = {
+  /**
+   * Specifies how to position the target relative to the visible area of the
+   * container.
+   */
+  position?: 'top' | 'center';
+};
+
 /**
- * Return the offset of `element` from the top of a positioned ancestor `parent`.
+ * Return the offset that a container element should be scrolled to in order
+ * to make a target element visible.
  *
- * @param parent - Positioned ancestor of `element`
+ * @param container - Container, which must be a positioned ancestor of `target`
+ * @param target - Descendant element
  */
-export function offsetRelativeTo(
-  element: HTMLElement,
-  parent: HTMLElement,
+export function computeScrollOffset(
+  container: HTMLElement,
+  target: HTMLElement,
+  options: ScrollOffsetOptions = {},
 ): number {
   let offset = 0;
-  while (element !== parent && parent.contains(element)) {
+
+  let element = target;
+  while (element !== container && container.contains(element)) {
     offset += element.offsetTop;
     element = element.offsetParent as HTMLElement;
   }
+
+  if (options.position === 'center') {
+    const containerRect = container.getBoundingClientRect();
+    const targetRect = target.getBoundingClientRect();
+    const adjustment = containerRect.height / 2 - targetRect.height / 2;
+    offset -= adjustment;
+  }
+
   return offset;
 }
 

--- a/src/annotator/util/test/scroll-test.js
+++ b/src/annotator/util/test/scroll-test.js
@@ -1,5 +1,5 @@
 import {
-  offsetRelativeTo,
+  computeScrollOffset,
   scrollElement,
   scrollElementIntoView,
 } from '../scroll';
@@ -25,32 +25,51 @@ describe('annotator/util/scroll', () => {
     return el;
   }
 
-  describe('offsetRelativeTo', () => {
+  describe('computeScrollOffset', () => {
     it('returns the offset of an element relative to the given ancestor', () => {
-      const parent = createContainer();
-      parent.style.position = 'relative';
+      const container = createContainer();
+      container.style.position = 'relative';
 
       const child = document.createElement('div');
       child.style.position = 'absolute';
       child.style.top = '100px';
-      parent.append(child);
+      container.append(child);
 
       const grandchild = document.createElement('div');
       grandchild.style.position = 'absolute';
       grandchild.style.top = '150px';
       child.append(grandchild);
 
-      assert.equal(offsetRelativeTo(child, parent), 100);
-      assert.equal(offsetRelativeTo(grandchild, parent), 250);
+      assert.equal(computeScrollOffset(container, child), 100);
+      assert.equal(computeScrollOffset(container, grandchild), 250);
     });
 
     it('returns 0 if the parent is not an ancestor of the element', () => {
-      const parent = document.createElement('div');
+      const container = document.createElement('div');
       const child = document.createElement('div');
       child.style.position = 'absolute';
       child.style.top = '100px';
 
-      assert.equal(offsetRelativeTo(child, parent), 0);
+      assert.equal(computeScrollOffset(container, child), 0);
+    });
+
+    it('adjusts offset if `position: center` is specified', () => {
+      const container = createContainer();
+      container.style.position = 'relative';
+      container.style.height = '100px';
+
+      const child = document.createElement('div');
+      child.style.position = 'absolute';
+      child.style.top = '150px';
+      child.style.height = '20px';
+      container.append(child);
+
+      const adjustment = 100 / 2 - 20 / 2;
+
+      assert.equal(
+        computeScrollOffset(container, child, { position: 'center' }),
+        150 - adjustment,
+      );
     });
   });
 


### PR DESCRIPTION
When scrolling a highlight into view in a PDF, scroll so that the highlight is in the middle of the viewport rather than right at the top.

Fixes https://github.com/hypothesis/client/issues/7028