### PR TITLE
Take PDF page border into account when creating shape selectors

### DIFF
--- a/src/annotator/anchoring/pdf.ts
+++ b/src/annotator/anchoring/pdf.ts
@@ -806,9 +806,14 @@ async function mapViewportToPDF(
       continue;
     }
     const pageIndex = getContainingPageIndex(el);
+
+    const pageStyle = getComputedStyle(el);
+    const leftBorder = parseFloat(pageStyle.borderLeftWidth);
+    const topBorder = parseFloat(pageStyle.borderTopWidth);
+
     const pageViewRect = el.getBoundingClientRect();
-    const pageViewX = x - pageViewRect.left;
-    const pageViewY = y - pageViewRect.top;
+    const pageViewX = x - pageViewRect.left - leftBorder;
+    const pageViewY = y - pageViewRect.top - topBorder;
     const pdfPageView = await getPageView(pageIndex);
     const [userX, userY] = pdfPageView.getPagePoint(pageViewX, pageViewY);
 

--- a/src/annotator/anchoring/test/pdf-test.js
+++ b/src/annotator/anchoring/test/pdf-test.js
@@ -965,7 +965,16 @@ describe('annotator/anchoring/pdf', () => {
   describe('describeShape', () => {
     let elementsFromPoint;
 
+    const borderLeft = 5;
+    const borderTop = 8;
+
     beforeEach(() => {
+      for (let i = 0; i < viewer.pdfViewer.pagesCount; i++) {
+        const pageDiv = viewer.pdfViewer.getPageView(i).div;
+        pageDiv.style.borderLeftWidth = `${borderLeft}px`;
+        pageDiv.style.borderTopWidth = `${borderTop}px`;
+      }
+
       // Dummy element to check that elements returned by `elementsFromPoint`,
       // which are not a PDF page container, are ignored.
       const dummy = document.createElement('div');
@@ -983,7 +992,9 @@ describe('annotator/anchoring/pdf', () => {
         if (pageIndex >= viewer.pdfViewer.pagesCount) {
           return [];
         }
-        return [dummy, viewer.pdfViewer.getPageView(pageIndex).div];
+
+        const pageDiv = viewer.pdfViewer.getPageView(pageIndex).div;
+        return [dummy, pageDiv];
       });
     });
 
@@ -1007,7 +1018,11 @@ describe('annotator/anchoring/pdf', () => {
         const pageView = viewer.pdfViewer.getPageView(0);
         const expected = pageView.getPagePoint(10, 10);
 
-        const selectors = await describeShape({ type: 'point', x: 10, y: 10 });
+        const selectors = await describeShape({
+          type: 'point',
+          x: 10 + borderLeft,
+          y: 10 + borderTop,
+        });
 
         assert.deepEqual(selectors, [
           {
@@ -1077,10 +1092,10 @@ describe('annotator/anchoring/pdf', () => {
 
         const selectors = await describeShape({
           type: 'rect',
-          left: 10,
-          top: 10,
-          right: 30,
-          bottom: 50,
+          left: 10 + borderLeft,
+          top: 10 + borderTop,
+          right: 30 + borderLeft,
+          bottom: 50 + borderTop,
         });
 
         assert.deepEqual(selectors, [

--- a/src/annotator/highlighter.ts
+++ b/src/annotator/highlighter.ts
@@ -209,9 +209,6 @@ function wholeTextNodesInRange(range: Range): Text[] {
 export function highlightShape(region: ShapeAnchor): HighlightElement[] {
   const { shape, anchor } = region;
 
-  const anchorStyles = getComputedStyle(anchor);
-  const borderWidth = parseInt(anchorStyles.borderWidth);
-
   const highlightEl = document.createElement('hypothesis-highlight');
 
   // Should match the width used by the `hypothesis-shape-highlight` class.
@@ -224,15 +221,17 @@ export function highlightShape(region: ShapeAnchor): HighlightElement[] {
   if (shape.type === 'rect') {
     const width = shape.right - shape.left;
     const height = shape.bottom - shape.top;
-    highlightEl.style.left = `calc(${shape.left * 100}% - ${borderWidth}px)`;
-    highlightEl.style.top = `calc(${shape.top * 100}% - ${borderWidth}px)`;
+    highlightEl.style.left = `${shape.left * 100}%`;
+    highlightEl.style.top = `${shape.top * 100}%`;
     highlightEl.style.width = `calc(${width * 100}% - ${2 * highlightBorderWidth}px)`;
     highlightEl.style.height = `calc(${height * 100}% - ${2 * highlightBorderWidth}px)`;
   } else if (shape.type === 'point') {
-    highlightEl.style.left = `calc(${shape.x * 100}% - ${borderWidth}px)`;
-    highlightEl.style.top = `calc(${shape.y * 100}% - ${borderWidth}px)`;
-    highlightEl.style.width = '10px';
-    highlightEl.style.height = '10px';
+    const radius = 5;
+    highlightEl.style.left = `calc(${shape.x * 100}% - ${radius + highlightBorderWidth}px)`;
+    highlightEl.style.top = `calc(${shape.y * 100}% - ${radius + highlightBorderWidth}px)`;
+    highlightEl.style.width = `${radius * 2}px`;
+    highlightEl.style.height = `${radius * 2}px`;
+    highlightEl.style.borderRadius = '50%';
   }
 
   anchor.append(highlightEl);

--- a/src/annotator/test/highlighter-test.js
+++ b/src/annotator/test/highlighter-test.js
@@ -416,8 +416,8 @@ describe('annotator/highlighter', () => {
           bottom: 1,
         },
         expected: {
-          top: 'calc(0% - 5px)',
-          left: 'calc(0% - 5px)',
+          top: '0%',
+          left: '0%',
           // 100% anchor width - 2 * 3px highlight border
           width: 'calc(100% - 6px)',
           // 100% anchor height - 2 * 3px highlight border
@@ -428,8 +428,9 @@ describe('annotator/highlighter', () => {
         // Point at top-left corner of anchor element.
         shape: { type: 'point', x: 0, y: 0 },
         expected: {
-          top: 'calc(0% - 5px)',
-          left: 'calc(0% - 5px)',
+          // Offset = 3px for highlight border, 5px for radius
+          top: 'calc(0% - 8px)',
+          left: 'calc(0% - 8px)',
           width: '10px',
           height: '10px',
         },


### PR DESCRIPTION
The border of the `.page` container elements was not taken into account when generating shape selectors for rect/pin annotations. This resulted in the coordinates of the shape being slightly down and to the right of where they should have been. This was corrected for when drawing highlights by subtracting the border size, but the error was actually when capturing the shape coordinates in PDF space. As a result the area shown in thumbnails was slightly offset from where the user clicked.

To make this easier to test with pin annotations, I have changed the style to a circle with the clicked location in the middle. Refinement of the highlight style for pin annotations is ongoing.

Note that highlights for existing shape annotations will shift slightly, because we no longer correct for the border width when drawing the highlight.

**Testing:**

1. Select the pin annotation tool
2. Click on a precise location in a page

The location where the pending pin appears when the mouse is pressed, the location where the pin highlight appears afterwards and the location of the pin shown on the thumbnail should match more closely on this branch than `main`.