### PR TITLE
Don't select annotations on click if there is a selection

### DIFF
--- a/src/annotator/guest.ts
+++ b/src/annotator/guest.ts
@@ -433,6 +433,12 @@ export class Guest
     };
 
     this._listeners.add(this.element, 'mouseup', event => {
+      // Don't select annotations if user makes a selection using the mouse
+      // which ends inside a highlight.
+      if (!document.getSelection()?.isCollapsed) {
+        return;
+      }
+
       const { clientX, clientY, metaKey, ctrlKey } = event;
       const tags = annotationsAtPoint(clientX, clientY);
       if (tags.length) {

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -1026,6 +1026,13 @@ describe('Guest', () => {
       assert.calledWith(sidebarRPC().call, 'openSidebar');
     });
 
+    it('does not select annotations in the sidebar if there is a selection', () => {
+      sandbox.stub(document, 'getSelection').returns({ isCollapsed: false });
+      createGuest();
+      fakeHighlight.dispatchEvent(new Event('mouseup', { bubbles: true }));
+      assert.notCalled(sidebarRPC().call);
+    });
+
     it('toggles selected annotations in the sidebar when Ctrl/Cmd-clicking a highlight', () => {
       createGuest();
       fakeHighlight.dispatchEvent(


### PR DESCRIPTION
If a text selection with the mouse ends inside an existing highlight, don't select the corresponding annotation in the sidebar. The annotation is instead only focused when the highlight is clicked without making a selection.

Fixes https://github.com/hypothesis/client/issues/7031

---

**Testing:**

1. Create a text or rectangle annotation
2. Make a text selection inside the highlighted area. The sidebar should not select the annotation created in step (1).
3. Click on the highlighted area. The annotation should be focused in the sidebar.