### PR TITLE
Make rect drawing work on touch devices

### DIFF
--- a/src/annotator/draw-tool.tsx
+++ b/src/annotator/draw-tool.tsx
@@ -107,6 +107,10 @@ export class DrawTool implements Destroyable {
     surface.setAttribute('data-testid', 'surface');
     surface.style.cursor = 'crosshair';
 
+    // Allow the user to draw on the surface on touch devices using finger or
+    // stylus.
+    surface.style.touchAction = 'none';
+
     // Make the drawing surface fill the container.
     surface.style.position = 'absolute';
     surface.setAttribute('width', '100%');
@@ -126,7 +130,7 @@ export class DrawTool implements Destroyable {
     this._drawEnd = resolve;
     this._drawError = reject;
 
-    this._surface.addEventListener('mousedown', e => {
+    this._surface.addEventListener('pointerdown', e => {
       switch (this._tool) {
         case 'rect':
           this._shape = {
@@ -148,7 +152,7 @@ export class DrawTool implements Destroyable {
       this._renderSurface();
     });
 
-    this._surface.addEventListener('mousemove', e => {
+    this._surface.addEventListener('pointermove', e => {
       if (!this._shape) {
         return;
       }
@@ -165,7 +169,7 @@ export class DrawTool implements Destroyable {
       this._renderSurface();
     });
 
-    this._surface.addEventListener('mouseup', e => {
+    this._surface.addEventListener('pointerup', e => {
       if (!this._shape) {
         return;
       }

--- a/src/annotator/test/draw-tool-test.js
+++ b/src/annotator/test/draw-tool-test.js
@@ -28,9 +28,9 @@ describe('DrawTool', () => {
   // drawing.
   const getSurface = () => container.querySelector('svg[data-testid=surface]');
 
-  const sendMouseEvent = (event, x = 0, y = 0) => {
+  const sendPointerEvent = (event, x = 0, y = 0) => {
     getSurface().dispatchEvent(
-      new MouseEvent(event, { clientX: x, clientY: y }),
+      new PointerEvent(event, { clientX: x, clientY: y }),
     );
   };
 
@@ -43,8 +43,8 @@ describe('DrawTool', () => {
 
   it('removes SVG when drawing ends', async () => {
     const shape = tool.draw('point');
-    sendMouseEvent('mousedown');
-    sendMouseEvent('mouseup');
+    sendPointerEvent('pointerdown');
+    sendPointerEvent('pointerup');
     await shape;
     assert.notOk(getSurface());
   });
@@ -128,9 +128,9 @@ describe('DrawTool', () => {
   describe('drawing a point', () => {
     it('finishes drawing when mouse is released', async () => {
       const shapePromise = tool.draw('point');
-      sendMouseEvent('mousedown', 5, 5);
-      sendMouseEvent('mousemove', 10, 10);
-      sendMouseEvent('mouseup', 15, 20);
+      sendPointerEvent('pointerdown', 5, 5);
+      sendPointerEvent('pointermove', 10, 10);
+      sendPointerEvent('pointerup', 15, 20);
 
       const shape = await shapePromise;
 
@@ -145,9 +145,9 @@ describe('DrawTool', () => {
   describe('drawing a rect', () => {
     it('finishes drawing when mouse is released', async () => {
       const shapePromise = tool.draw('rect');
-      sendMouseEvent('mousedown');
-      sendMouseEvent('mousemove', 5, 5);
-      sendMouseEvent('mouseup', 10, 20);
+      sendPointerEvent('pointerdown');
+      sendPointerEvent('pointermove', 5, 5);
+      sendPointerEvent('pointerup', 10, 20);
 
       const shape = await shapePromise;
 
@@ -160,14 +160,14 @@ describe('DrawTool', () => {
       });
     });
 
-    it('ignores "mousemove" and "mouseup" events before an initial "mousedown"', async () => {
+    it('ignores "pointermove" and "pointerup" events before an initial "pointerdown"', async () => {
       const shapePromise = tool.draw('rect');
-      sendMouseEvent('mousemove', 5, 5);
-      sendMouseEvent('mouseup', 10, 20);
+      sendPointerEvent('pointermove', 5, 5);
+      sendPointerEvent('pointerup', 10, 20);
 
-      sendMouseEvent('mousedown');
-      sendMouseEvent('mousemove', 3, 3);
-      sendMouseEvent('mouseup', 6, 7);
+      sendPointerEvent('pointerdown');
+      sendPointerEvent('pointermove', 3, 3);
+      sendPointerEvent('pointerup', 6, 7);
       const shape = await shapePromise;
 
       assert.deepEqual(shape, {


### PR DESCRIPTION
Make a couple of changes so that it is possible to use the rect and pin tools on touch devices.

 - Set `touch-action: none` on the drawing surface so that touching and dragging sends pointer events rather than dragging the viewport.
 - Use pointer rather than mouse events so that drawing with a finger or stylus rather than a mouse works

These changes make it possible to use the rect and pin annotation tools on eg. an iPad, with some limitations:

 - Positioning is not as precise as when using a mouse. This could be addressed in future by providing the user with a way to refine the shape after the initial creation.
 - It is not possible to scroll the PDF while the drawing tool is active. On desktop, the scroll wheel can be used.
 - Behavior is funky if you start using multiple fingers. I will address this in a follow-up. This could possibly be used as a way to enable scrolling while drawing is active.