### PR TITLE
Remove focus-visible polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "express": "^5.0.1",
     "fancy-log": "^2.0.0",
     "fetch-mock": "11",
-    "focus-visible": "^5.0.0",
     "globals": "^16.0.0",
     "gulp": "^5.0.0",
     "gulp-changed": "^5.0.1",

--- a/src/annotator/index.ts
+++ b/src/annotator/index.ts
@@ -1,5 +1,3 @@
-// Load polyfill for :focus-visible pseudo-class.
-import 'focus-visible';
 // Enable debug checks for Preact. Removed in prod builds by Rollup config.
 import 'preact/debug';
 

--- a/src/annotator/util/shadow-root.ts
+++ b/src/annotator/util/shadow-root.ts
@@ -28,13 +28,5 @@ function loadStyles(shadowRoot: ShadowRoot) {
 export function createShadowRoot(container: HTMLElement): ShadowRoot {
   const shadowRoot = container.attachShadow({ mode: 'open' });
   loadStyles(shadowRoot);
-
-  // @ts-ignore The window doesn't know about the polyfill
-  // applyFocusVisiblePolyfill comes from the `focus-visible` package.
-  const applyFocusVisible = window.applyFocusVisiblePolyfill;
-  if (applyFocusVisible) {
-    applyFocusVisible(shadowRoot);
-  }
-
   return shadowRoot;
 }

--- a/src/annotator/util/test/shadow-root-test.js
+++ b/src/annotator/util/test/shadow-root-test.js
@@ -1,7 +1,6 @@
 import { createShadowRoot } from '../shadow-root';
 
 describe('annotator/util/shadow-root', () => {
-  let applyFocusVisiblePolyfill;
   let container;
   let preloadedStylesheet;
 
@@ -14,15 +13,11 @@ describe('annotator/util/shadow-root', () => {
     document.head.append(preloadedStylesheet);
 
     container = document.createElement('div');
-    applyFocusVisiblePolyfill = window.applyFocusVisiblePolyfill;
-    window.applyFocusVisiblePolyfill = sinon.stub();
   });
 
   afterEach(() => {
     preloadedStylesheet.remove();
-
     container.remove();
-    window.applyFocusVisiblePolyfill = applyFocusVisiblePolyfill;
   });
 
   describe('createShadowRoot', () => {
@@ -39,12 +34,6 @@ describe('annotator/util/shadow-root', () => {
       const linkEl = container.shadowRoot.querySelector('link[rel=stylesheet]');
       assert.ok(linkEl);
       assert.include(linkEl.href, 'annotator.css');
-    });
-
-    it('applies the applyFocusVisiblePolyfill if exists', () => {
-      const shadowRoot = createShadowRoot(container);
-
-      assert.calledWith(window.applyFocusVisiblePolyfill, shadowRoot);
     });
 
     it('does not inject stylesheets into the shadow root if style is not found', () => {

--- a/src/sidebar/index.tsx
+++ b/src/sidebar/index.tsx
@@ -1,5 +1,3 @@
-// Load polyfill for :focus-visible pseudo-class.
-import 'focus-visible';
 import { render } from 'preact';
 // Enable debugging checks for Preact. Removed in prod builds by Rollup config.
 import 'preact/debug';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6944,13 +6944,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"focus-visible@npm:^5.0.0":
-  version: 5.2.1
-  resolution: "focus-visible@npm:5.2.1"
-  checksum: 9da7388e703315a8f933bb4fec4e2be5f1d655dfc91c388d1802ad53a99e1fa31a5be90866b7db83d48d8f7f771dd2df7d51445a37f48f7069823eceb5f34e64
-  languageName: node
-  linkType: hard
-
 "for-each@npm:^0.3.3":
   version: 0.3.3
   resolution: "for-each@npm:0.3.3"
@@ -7712,7 +7705,6 @@ __metadata:
     express: ^5.0.1
     fancy-log: ^2.0.0
     fetch-mock: 11
-    focus-visible: ^5.0.0
     globals: ^16.0.0
     gulp: ^5.0.0
     gulp-changed: ^5.0.1


### PR DESCRIPTION
The `:focus-visible` pseudo-class has been supported in major browsers for over 3 years [^1], so we can simplify our dependencies and code slightly by removing it.

[^1]: https://caniuse.com/?search=focus-visible