### PR TITLE
Refine pin highlight styling

### DIFF
--- a/src/annotator/highlighter.ts
+++ b/src/annotator/highlighter.ts
@@ -55,7 +55,7 @@ export class Highlighter {
       highlightEl.style.width = `calc(${width * 100}% - ${2 * highlightBorderWidth}px)`;
       highlightEl.style.height = `calc(${height * 100}% - ${2 * highlightBorderWidth}px)`;
     } else if (shape.type === 'point') {
-      const radius = 5;
+      const radius = 7;
       highlightEl.style.left = `calc(${shape.x * 100}% - ${radius + highlightBorderWidth}px)`;
       highlightEl.style.top = `calc(${shape.y * 100}% - ${radius + highlightBorderWidth}px)`;
       highlightEl.style.width = `${radius * 2}px`;

--- a/src/annotator/test/highlighter-test.js
+++ b/src/annotator/test/highlighter-test.js
@@ -438,11 +438,11 @@ describe('annotator/highlighter', () => {
         // Point at top-left corner of anchor element.
         shape: { type: 'point', x: 0, y: 0 },
         expected: {
-          // Offset = 3px for highlight border, 5px for radius
-          top: 'calc(0% - 8px)',
-          left: 'calc(0% - 8px)',
-          width: '10px',
-          height: '10px',
+          // Offset = 3px for highlight border, 7px for radius
+          top: 'calc(0% - 10px)',
+          left: 'calc(0% - 10px)',
+          width: '14px',
+          height: '14px',
         },
       },
       // Unsupported shapes currently generate highlights with no position

--- a/src/styles/annotator/highlights.scss
+++ b/src/styles/annotator/highlights.scss
@@ -204,12 +204,14 @@
 .hypothesis-highlights-always-on .hypothesis-shape-highlight {
   // This color is similar to the default highlight fill, but darker so it has
   // more contrast when used as a border.
-  border-color: #edd72b;
+  --highlight-color: #edd72b;
+  border-color: var(--highlight-color);
+  background-color: color-mix(in srgb, var(--highlight-color) 30%, transparent);
   cursor: pointer;
   visibility: visible;
 
   &.hypothesis-highlight-focused {
-    border-color: var(--hypothesis-highlight-focused-color);
+    --highlight-color: var(--hypothesis-highlight-focused-color);
     background: var(--hypothesis-highlight-focused-color);
   }
 }


### PR DESCRIPTION
Make a couple of tweaks to pin highlight styles:

 - Add a semi-transparent fill color. This makes pins a little more eye catching while not obscuring content too much.
 - Make the highlight a little larger. This makes pins easier to click or tap, especially on mobile.

**Before:**

<img width="252" alt="Old pin styling" src="https://github.com/user-attachments/assets/8897ed96-dcec-4ff2-8730-280608b3f002" />

**After:**

<img width="320" alt="New pin styling" src="https://github.com/user-attachments/assets/5c1bcebe-97be-4c61-9e3d-62000cca9f71" />



