### PR TITLE
Ensure adder is displayed above shape highlights

### DIFF
--- a/src/annotator/adder.tsx
+++ b/src/annotator/adder.tsx
@@ -280,13 +280,18 @@ export class Adder implements Destroyable {
       ...document.elementsFromPoint(left + adderWidth, top + adderHeight),
     ]);
 
-    const zIndexes = [...elements]
-      .map(element => +getComputedStyle(element).zIndex)
-      .filter(Number.isInteger);
+    const elementZIndex = (el: Element) => +getComputedStyle(el).zIndex;
 
-    // Make sure the array contains at least one element,
-    // otherwise `Math.max(...[])` results in +Infinity
-    zIndexes.push(0);
+    const zIndexes = [...elements].map(elementZIndex).filter(Number.isInteger);
+
+    // Make sure adder appears above any shape highlights. These are not found
+    // by `elementsFromPoint` because they have `pointer-events: none` set on
+    // them.
+    let minZIndex = 0;
+    for (const hl of document.querySelectorAll('hypothesis-highlight')) {
+      minZIndex = Math.max(minZIndex, elementZIndex(hl));
+    }
+    zIndexes.push(minZIndex);
 
     return Math.max(...zIndexes) + 1;
   }

--- a/src/annotator/test/adder-test.js
+++ b/src/annotator/test/adder-test.js
@@ -265,12 +265,12 @@ describe('Adder', () => {
       document.elementsFromPoint = elementsFromPointBackup;
     });
 
-    it('returns value of 1 if not elements are found', () => {
+    it('returns value of 1 if no elements are found', () => {
       assert.strictEqual(getAdderZIndex(-100000, -100000), 1);
       assert.strictEqual(getAdderZIndex(100000, 100000), 1);
     });
 
-    it('returns the greatest zIndex', () => {
+    it('returns a z-index greater than any elements under the adder', () => {
       const createComponent = (left, top, zIndex, attachTo) =>
         mount(
           <div
@@ -326,6 +326,18 @@ describe('Adder', () => {
       assert.strictEqual(getAdderZIndex(initLeft, initTop), 9);
 
       wrapper.unmount();
+    });
+
+    it('returns a z-index greater than any highlights', () => {
+      const fakeHighlight = document.createElement('hypothesis-highlight');
+      fakeHighlight.style.zIndex = '20';
+
+      try {
+        document.body.append(fakeHighlight);
+        assert.equal(getAdderZIndex(0, 0), 21);
+      } finally {
+        fakeHighlight.remove();
+      }
     });
   });
 


### PR DESCRIPTION
The existing logic for making the adder show above elements in the selected text did not work because shape highlights have `pointer-events: none` set on them, and `document.elementsFromPoint` ignores these.

There is no API to hit test elements with pointer events disabled, so we either have to test all elements in the document, or as in this commit, query for specific elements to test.

As an aside, we could replace the `Adder._findZIndex` method in future (maybe a year from now or so) with using the popover API. We could also just use the "maximum allowed" value for z-index (2^31 according to my searches) to try and emulate a popover.

Fixes https://github.com/hypothesis/client/issues/7052