### PR TITLE
Add details to thumbnail rendering error message

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationThumbnail.tsx
+++ b/src/sidebar/components/Annotation/AnnotationThumbnail.tsx
@@ -88,7 +88,7 @@ function AnnotationThumbnail({
         <span data-testid="placeholder">Loading thumbnail...</span>
       )}
       {!thumbnail && error && (
-        <span data-testid="error">Unable to render thumbnail</span>
+        <span data-testid="error">Unable to render thumbnail: {error}</span>
       )}
     </div>
   );

--- a/src/sidebar/components/Annotation/test/AnnotationThumbnail-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationThumbnail-test.js
@@ -46,9 +46,13 @@ describe('AnnotationThumbnail', () => {
   });
 
   it('renders error indicator if thumbnail rendering failed', async () => {
-    fakeThumbnailService.fetch.rejects(new Error('Thumbnail rendering failed'));
+    fakeThumbnailService.fetch.rejects(new Error('Something went wrong'));
     const wrapper = createComponent();
     await new Promise(resolve => setTimeout(resolve, 1));
-    await waitForElement(wrapper, '[data-testid="error"]');
+    const error = await waitForElement(wrapper, '[data-testid="error"]');
+    assert.equal(
+      error.text(),
+      'Unable to render thumbnail: Something went wrong',
+    );
   });
 });


### PR DESCRIPTION
If rendering a thumbnail fails, show the error that occurred. I have needed to make this change a few times locally for debugging purposes, adding it to the production code should help with debugging issues encountered by end users.