### PR TITLE
Make toolbar buttons taller when using touch input

### DIFF
--- a/src/annotator/components/Toolbar.tsx
+++ b/src/annotator/components/Toolbar.tsx
@@ -43,7 +43,11 @@ function ToolbarButton({
     <Button
       classes={classnames(
         'justify-center rounded',
-        'w-[30px] h-[30px]',
+        // On mobile, 40px is slightly smaller than the 44px minimum we usually
+        // use, but works in this context as the buttons have spacing between
+        // them. The width is not changed on mobile as this requires additional
+        // work to make the whole toolbar wider.
+        'w-[30px] h-[30px] touch:h-[40px]',
         'shadow border bg-white text-grey-6 hover:text-grey-9',
         pressedBackground && 'aria-pressed:bg-grey-3',
       )}


### PR DESCRIPTION
Make the annotation toolbar buttons taller on mobile to reduce taps triggering the wrong button. Ideally the buttons would be made wider as well, but this requires some additional work to enable making the whole toolbar wider. As noted in comments, the 40px height is slightly smaller than we normally use for touch targets, but works in this context and also aligns with the toggle button that opens and closes the sidebar.

**Preview on simulated iPad:**

<img width="118" alt="Touch toolbar" src="https://github.com/user-attachments/assets/08be0cc3-4478-4d1d-8a97-4f548b5ab204" />
