### PR TITLE
Fix sidebar closing after drag-resize

### DIFF
--- a/src/annotator/sidebar.tsx
+++ b/src/annotator/sidebar.tsx
@@ -637,8 +637,9 @@ export class Sidebar implements Destroyable {
         // Disable animated transition of sidebar position
         frame.classList.add('sidebar-no-transition');
 
-        // Disable pointer events on the iframe.
-        frame.style.pointerEvents = 'none';
+        // Disable pointer events on the toolbar, so toolbar buttons don't
+        // receive clicks when the drag ends.
+        this.toolbar.container.style.pointerEvents = 'none';
 
         this._dragResizeState.initial = parseInt(
           getComputedStyle(frame).marginLeft,
@@ -648,8 +649,8 @@ export class Sidebar implements Destroyable {
       case 'dragend':
         frame.classList.remove('sidebar-no-transition');
 
-        // Re-enable pointer events on the iframe.
-        frame.style.pointerEvents = '';
+        // Re-enable pointer events on the toolbar.
+        this.toolbar.container.style.pointerEvents = '';
 
         // Snap open or closed.
         if (

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -165,6 +165,7 @@ describe('Sidebar', () => {
     const toggleButton = document.createElement('button');
     fakeToolbar = {
       activeTool: null,
+      container: document.createElement('div'),
       getWidth: sinon.stub().returns(100),
       useMinimalControls: false,
       sidebarOpen: false,
@@ -691,7 +692,7 @@ describe('Sidebar', () => {
         assert.isTrue(
           sidebar.iframeContainer.classList.contains('sidebar-no-transition'),
         );
-        assert.equal(sidebar.iframeContainer.style.pointerEvents, 'none');
+        assert.equal(fakeToolbar.container.style.pointerEvents, 'none');
       });
     });
 
@@ -708,7 +709,7 @@ describe('Sidebar', () => {
         assert.isFalse(
           sidebar.iframeContainer.classList.contains('sidebar-no-transition'),
         );
-        assert.equal(sidebar.iframeContainer.style.pointerEvents, '');
+        assert.equal(fakeToolbar.container.style.pointerEvents, '');
       });
 
       it('opens sidebar if final width is above threshold', () => {

--- a/src/annotator/toolbar.tsx
+++ b/src/annotator/toolbar.tsx
@@ -19,7 +19,8 @@ export type ToolbarOptions = {
  * highlight visibility etc.
  */
 export class ToolbarController {
-  private _container: HTMLElement;
+  container: HTMLElement;
+
   private _activeTool: AnnotationTool | null;
   private _newAnnotationType: 'annotation' | 'note';
   private _useMinimalControls: boolean;
@@ -39,7 +40,7 @@ export class ToolbarController {
   constructor(container: HTMLElement, options: ToolbarOptions) {
     const { createAnnotation, setSidebarOpen, setHighlightsVisible } = options;
 
-    this._container = container;
+    this.container = container;
     this._activeTool = null;
     this._useMinimalControls = false;
     this._newAnnotationType = 'note';
@@ -72,7 +73,7 @@ export class ToolbarController {
   }
 
   getWidth() {
-    const content = this._container.firstChild as HTMLElement;
+    const content = this.container.firstChild as HTMLElement;
     return content.getBoundingClientRect().width;
   }
 
@@ -172,7 +173,7 @@ export class ToolbarController {
         toggleSidebarRef={this._sidebarToggleButton}
         useMinimalControls={this.useMinimalControls}
       />,
-      this._container,
+      this.container,
     );
   }
 }


### PR DESCRIPTION
Fix an issue where the sidebar would close after clicking and dragging the sidebar toggle button in the toolbar.

Prior to 076594f85f09f4bd0c41d9064af266fdd7ffe058 the toolbar button was prevented from receiving a "click" event after the drag ended by applying `pointer-events: none` to the iframe container, an ancestor of the toolbar, during the drag. 076594f85f09f4bd0c41d9064af266fdd7ffe058 broke this by applying `pointer-events: auto` directly to the toolbar container, overriding the `pointer-events` style from the parent elements. The fix is to apply the `pointer-events` style change to the toolbar container directly during the drag.

Fixes https://github.com/hypothesis/client/issues/7058