### PR TITLE
Limit size of thumbnail cache

### DIFF
--- a/src/sidebar/services/test/thumbnail-test.js
+++ b/src/sidebar/services/test/thumbnail-test.js
@@ -24,6 +24,17 @@ describe('ThumbnailService', () => {
       await svc.fetch('ann123');
       assert.instanceOf(svc.get('ann123'), ImageBitmap);
     });
+
+    it('moves thumbnail to back of least-recently-used list', async () => {
+      const svc = createService();
+      await svc.fetch('ann0');
+      await svc.fetch('ann1');
+      assert.deepEqual(svc.cachedThumbnailTags(), ['ann0', 'ann1']);
+
+      svc.get('ann0');
+
+      assert.deepEqual(svc.cachedThumbnailTags(), ['ann1', 'ann0']);
+    });
   });
 
   describe('#fetch', () => {
@@ -42,6 +53,23 @@ describe('ThumbnailService', () => {
       await svc.fetch('ann123');
 
       assert.notCalled(fakeFrameSyncService.requestThumbnail);
+    });
+
+    it('prunes old entries from thumbnail cache', async () => {
+      const svc = createService();
+      svc.cacheSize = 3;
+      assert.equal(svc.cacheSize, 3);
+
+      await svc.fetch('ann0');
+      await svc.fetch('ann1');
+      await svc.fetch('ann2');
+      assert.deepEqual(svc.cachedThumbnailTags(), ['ann0', 'ann1', 'ann2']);
+
+      await svc.fetch('ann3');
+      assert.deepEqual(svc.cachedThumbnailTags(), ['ann1', 'ann2', 'ann3']);
+
+      await svc.fetch('ann4');
+      assert.deepEqual(svc.cachedThumbnailTags(), ['ann2', 'ann3', 'ann4']);
     });
   });
 });


### PR DESCRIPTION
Add a size limit to the thumbnail cache and expire the least-recently-used entries when new thumbnails are fetched. Thumbnails are moved to the back of the cache's key list (ie. marked as most-recently-used) when the thumbnail is first added, or an entry is fetched for use in an `AnnotationThumbnail` via calls to `get` or `fetch`.