### PR TITLE
Generate thumbnails correctly for rotated pages

### DIFF
--- a/src/annotator/anchoring/test/fake-pdf-viewer-application.ts
+++ b/src/annotator/anchoring/test/fake-pdf-viewer-application.ts
@@ -84,11 +84,14 @@ function createPage(
 class FakePDFPageProxy implements PDFPageProxy {
   pageText: string;
 
+  rotate: number;
+
   private _config: PDFJSConfig;
   private _view: [number, number, number, number];
 
   constructor(pageText: string, config: PDFJSConfig) {
     this.pageText = pageText;
+    this.rotate = 0;
     this._config = config;
     this._view = config.pageBoundingBox ?? [0, 0, 100, 200]; // [left, bottom, right, top]
   }

--- a/src/annotator/integrations/test/pdf-test.js
+++ b/src/annotator/integrations/test/pdf-test.js
@@ -904,33 +904,54 @@ describe('annotator/integrations/pdf', () => {
             viewBox: [0, 0, 101, 1],
           },
         },
-      ].forEach(({ renderOptions = {}, shapeSelector, expectedViewport }) => {
-        it('renders bitmap with given options', async () => {
-          pdfIntegration = createPDFIntegration();
-          const anchor = {
-            target: {
-              selector: [shapeSelector, pageSelector],
-            },
-          };
-          const pageView =
-            fakePDFViewerApplication.pdfViewer.getPageView(pageIndex);
-          const renderSpy = sinon.spy(pageView.pdfPage, 'render');
+        // Rotated page
+        {
+          shapeSelector: rectShapeSelector,
+          renderOptions: {},
+          pageRotation: 90,
+          expectedViewport: {
+            rotation: 90,
+            scale: 96 / 72,
+            userUnit: 1 / 72,
+            viewBox: [0, 0, 100, 100],
+          },
+        },
+      ].forEach(
+        ({
+          renderOptions = {},
+          shapeSelector,
+          expectedViewport,
+          pageRotation = 0,
+        }) => {
+          it('renders bitmap with given options', async () => {
+            pdfIntegration = createPDFIntegration();
+            const anchor = {
+              target: {
+                selector: [shapeSelector, pageSelector],
+              },
+            };
+            const pageView =
+              fakePDFViewerApplication.pdfViewer.getPageView(pageIndex);
+            pageView.pdfPage.rotate = pageRotation;
 
-          const bitmap = await pdfIntegration.renderToBitmap(
-            anchor,
-            renderOptions,
-          );
+            const renderSpy = sinon.spy(pageView.pdfPage, 'render');
 
-          assert.instanceOf(bitmap, ImageBitmap);
-          assert.calledOnce(renderSpy);
-          const renderArgs = renderSpy.lastCall.args[0];
-          assert.instanceOf(
-            renderArgs.canvasContext,
-            OffscreenCanvasRenderingContext2D,
-          );
-          assert.match(renderArgs.viewport, sinon.match(expectedViewport));
-        });
-      });
+            const bitmap = await pdfIntegration.renderToBitmap(
+              anchor,
+              renderOptions,
+            );
+
+            assert.instanceOf(bitmap, ImageBitmap);
+            assert.calledOnce(renderSpy);
+            const renderArgs = renderSpy.lastCall.args[0];
+            assert.instanceOf(
+              renderArgs.canvasContext,
+              OffscreenCanvasRenderingContext2D,
+            );
+            assert.match(renderArgs.viewport, sinon.match(expectedViewport));
+          });
+        },
+      );
     });
   });
 });

--- a/src/types/pdfjs.ts
+++ b/src/types/pdfjs.ts
@@ -144,6 +144,9 @@ export type RenderParameters = {
 };
 
 export type PDFPageProxy = {
+  /** Return the number of degrees the page is rotated clockwise. */
+  get rotate(): number;
+
   getTextContent(o?: GetTextContentParameters): Promise<TextContent>;
 
   /**


### PR DESCRIPTION
Make rendering of thumbnails reflect the PDF page's built-in rotation. Rotations are assumed to always be a multiple of 90 degrees. PDF.js also assumes this.

 - Pass the page's built-in rotation as part of the viewport configuration when rendering thumbnails
 - When a page is rotated by 90 or 270 degrees, swap the width and height when calculating the thumbnail dimensions.

Fixes https://github.com/hypothesis/client/issues/7063

**Testing:**

1. Go to http://localhost:3000/pdf/rotated and create a rect annotation. The thumbnail's orientation should match the PDF page and should show the correct region.
2. Open `dev-server/documents/pdf/rotated.pdf` in a local PDF viewer/editor (I used macOS Preview), rotate the page 90 degrees and save, then reload the PDF in the Hypothesis dev server. The page should appear rotated and the thumbnails should still show the correct region.
3. Repeat step 2 for two more iterations to test 180 and 270 degree rotation.