### PR TITLE
Replace "Search annotations..." with just "Search..."

### DIFF
--- a/src/sidebar/components/search/SearchField.tsx
+++ b/src/sidebar/components/search/SearchField.tsx
@@ -98,7 +98,7 @@ export default function SearchField({
           disabled={disabled}
         />
         <Input
-          aria-label="Search annotations"
+          aria-label="Search"
           classes={classnames(
             'pl-8 pr-8', // Add padding so input does not overlap search/clear buttons.
             'disabled:text-grey-6', // Dim text when input is disabled
@@ -107,7 +107,7 @@ export default function SearchField({
           data-testid="search-input"
           dir="auto"
           name="query"
-          placeholder={(isLoading && 'Loading…') || 'Search annotations…'}
+          placeholder={(isLoading && 'Loading…') || 'Search…'}
           disabled={disabled || isLoading}
           elementRef={input}
           value={pendingQuery || ''}

--- a/src/sidebar/components/search/SearchIconButton.tsx
+++ b/src/sidebar/components/search/SearchIconButton.tsx
@@ -66,7 +66,7 @@ export default function SearchIconButton() {
           expanded={isSearchPanelOpen}
           pressed={isSearchPanelOpen}
           onClick={toggleSearchPanel}
-          title="Search annotations"
+          title="Search"
         />
       )}
     </>

--- a/src/sidebar/components/search/SearchPanel.tsx
+++ b/src/sidebar/components/search/SearchPanel.tsx
@@ -20,7 +20,7 @@ export default function SearchPanel() {
     <SidebarPanel
       panelName="searchAnnotations"
       variant="custom"
-      title="Search annotations"
+      title="Search"
       initialFocus={inputRef}
       onActiveChanged={active => {
         if (!active) {

--- a/src/sidebar/components/search/test/SearchField-test.js
+++ b/src/sidebar/components/search/test/SearchField-test.js
@@ -99,7 +99,7 @@ describe('SearchField', () => {
     const wrapper = createSearchField();
     const { placeholder, disabled } = wrapper.find('Input').props();
 
-    assert.equal(placeholder, 'Search annotations…');
+    assert.equal(placeholder, 'Search…');
     assert.isFalse(disabled);
   });
 


### PR DESCRIPTION
For bioRxiv we're going to have to implement a "comments-only" mode
where all references to "annotation(s)" in the client's UI are hidden or
changed to refer to "comments" (see https://github.com/hypothesis/client/issues/7065).

This PR simply replaces the "Search annotations..." placeholder in the
search field (and various labels etc) with just "Search...". If
acceptable this should be simpler than having a config setting to change
it to "Search comments..."

I think the "annotations" / "comments" in these labels and placeholders
is probably unnecessary: "search" on its own should be clear enough?
