### PR TITLE
Extract text from annotated shapes and use it in thumbnail alt text

### DIFF
--- a/src/annotator/anchoring/test/text-in-rect-test.js
+++ b/src/annotator/anchoring/test/text-in-rect-test.js
@@ -1,0 +1,69 @@
+import { textInDOMRect } from '../text-in-rect';
+
+describe('textInDOMRect', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    container.style.position = 'fixed';
+
+    const leftColumn = document.createElement('p');
+    leftColumn.className = 'left-column';
+    Object.assign(leftColumn.style, {
+      position: 'absolute',
+      width: '200px',
+    });
+    leftColumn.append('Line one', document.createElement('br'), 'Line two');
+
+    const rightColumn = document.createElement('p');
+    rightColumn.className = 'right-column';
+    Object.assign(rightColumn.style, {
+      position: 'absolute',
+      width: '200px',
+      left: '200px',
+    });
+    rightColumn.append('Line three', document.createElement('br'), 'Line four');
+
+    container.append(leftColumn, rightColumn);
+
+    document.body.append(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  [
+    // Rect covering whole left column
+    {
+      rect: new DOMRect(0, 0, 200, 200),
+      expected: 'Line one Line two',
+    },
+    // Rect covering whole right column
+    {
+      rect: new DOMRect(200, 0, 200, 200),
+      expected: 'Line three Line four',
+    },
+    // Tiny rect touching first word in left column
+    {
+      rect: new DOMRect(10, 10, 1, 1),
+      expected: 'Line',
+    },
+    // Zero-sized rect touching first word in left column
+    {
+      rect: new DOMRect(10, 10, 0, 0),
+      expected: '',
+    },
+  ].forEach(({ rect, expected }) => {
+    it('returns text in rect', () => {
+      const text = textInDOMRect(container, rect);
+      assert.equal(text, expected);
+    });
+  });
+
+  it('only returns text from root container', () => {
+    const leftColumn = container.querySelector('.left-column');
+    const text = textInDOMRect(leftColumn, new DOMRect(0, 0, 500, 500));
+    assert.equal(text, 'Line one Line two');
+  });
+});

--- a/src/annotator/anchoring/text-in-rect.ts
+++ b/src/annotator/anchoring/text-in-rect.ts
@@ -1,0 +1,59 @@
+import { rectIntersects, rectsOverlapVertically } from '../util/geometry';
+
+/**
+ * Return the DOM text that intersects a given rect.
+ *
+ * The text nodes under {@link root} are split into words and the bounding
+ * rectangle of each word is intersected with {@link rect}. If the intersection
+ * is non-empty, the text of that word is added to the output string.
+ *
+ * @param root - Root element of the DOM tree to search
+ * @param rect - Client coordinates of the region
+ */
+export function textInDOMRect(root: Element, rect: DOMRect): string {
+  const iter = root.ownerDocument!.createNodeIterator(
+    root,
+    NodeFilter.SHOW_TEXT,
+  );
+
+  // Pieces of text that intersect the rect.
+  const textChunks = [];
+
+  // Rect for previous text chunk which was included in the output.
+  let prevChunkRect;
+
+  let currentNode;
+  while ((currentNode = iter.nextNode())) {
+    const textNode = currentNode as Text;
+
+    // We split on word boundaries here rather than spaces, so inter-word spaces
+    // are included in the "words".
+    const words = textNode.data.split(/\b/);
+    let offset = 0;
+
+    for (const word of words) {
+      const range = new Range();
+      range.setStart(textNode, offset);
+      const endOffset = offset + word.length;
+      range.setEnd(textNode, endOffset);
+      const wordRect = range.getBoundingClientRect();
+
+      if (rectIntersects(wordRect, rect)) {
+        // We assume that spaces are included in the text between words on a
+        // line, but not between lines.
+        const newLine =
+          prevChunkRect && !rectsOverlapVertically(prevChunkRect, wordRect);
+        if (newLine) {
+          textChunks.push(' ');
+        }
+
+        textChunks.push(word);
+        prevChunkRect = wordRect;
+      }
+
+      offset = endOffset;
+    }
+  }
+
+  return textChunks.join('');
+}

--- a/src/sidebar/components/Annotation/Annotation.tsx
+++ b/src/sidebar/components/Annotation/Annotation.tsx
@@ -124,7 +124,12 @@ function Annotation({
         replyCount={replyCount}
         threadIsCollapsed={threadIsCollapsed}
       />
-      {targetShape && <AnnotationThumbnail tag={annotation.$tag} />}
+      {targetShape && (
+        <AnnotationThumbnail
+          tag={annotation.$tag}
+          textInImage={targetShape.text}
+        />
+      )}
       {annotationQuote && (
         <AnnotationQuote
           quote={annotationQuote}

--- a/src/sidebar/components/Annotation/AnnotationThumbnail.tsx
+++ b/src/sidebar/components/Annotation/AnnotationThumbnail.tsx
@@ -31,7 +31,14 @@ function BitmapImage({ alt, bitmap, classes, scale = 1.0 }: BitmapImageProps) {
       width={bitmap.width}
       height={bitmap.height}
       role="img"
+      // The `alt` attribute on an `<img>` maps to aria-label. We might want to
+      // split this into a separate concise label and longer description in
+      // future.
       aria-label={alt}
+      // Set the title attribute to make it easy to inspect the alt text on
+      // desktop. Screen readers will only read `aria-label` since it has the
+      // same value.
+      title={alt}
       className={classes}
       style={{
         width: `${bitmap.width / scale}px`,
@@ -44,9 +51,17 @@ function BitmapImage({ alt, bitmap, classes, scale = 1.0 }: BitmapImageProps) {
 export type AnnotationThumbnailProps = {
   tag: string;
   thumbnailService: ThumbnailService;
+
+  /**
+   * Text contained in the thumbnail.
+   *
+   * This is used when generating alt text for the thumbnail.
+   */
+  textInImage?: string;
 };
 
 function AnnotationThumbnail({
+  textInImage,
   tag,
   thumbnailService,
 }: AnnotationThumbnailProps) {
@@ -69,6 +84,13 @@ function AnnotationThumbnail({
     }
   }, [error, devicePixelRatio, tag, thumbnail, thumbnailService]);
 
+  let altText;
+  if (textInImage) {
+    altText = `Thumbnail. Contains text: ${textInImage}`;
+  } else {
+    altText = 'Thumbnail';
+  }
+
   return (
     <div
       className="flex flex-row justify-center"
@@ -76,7 +98,7 @@ function AnnotationThumbnail({
     >
       {thumbnail && (
         <BitmapImage
-          alt="annotated content thumbnail"
+          alt={altText}
           bitmap={thumbnail}
           classes="border rounded-md"
           scale={devicePixelRatio}

--- a/src/sidebar/components/Annotation/test/Annotation-test.js
+++ b/src/sidebar/components/Annotation/test/Annotation-test.js
@@ -157,12 +157,14 @@ describe('Annotation', () => {
             right: 10,
             bottom: 0,
           },
+          text: 'Some text',
         },
       ];
       const wrapper = createComponent({ annotation });
       const thumbnail = wrapper.find('AnnotationThumbnail');
       assert.isTrue(thumbnail.exists());
       assert.equal(thumbnail.prop('tag'), annotation.$tag);
+      assert.equal(thumbnail.prop('textInImage'), 'Some text');
     });
   });
 

--- a/src/sidebar/components/Annotation/test/AnnotationThumbnail-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationThumbnail-test.js
@@ -38,6 +38,24 @@ describe('AnnotationThumbnail', () => {
     assert.isTrue(wrapper.exists('BitmapImage'));
   });
 
+  [
+    {
+      textInImage: undefined,
+      expectedAlt: 'Thumbnail',
+    },
+    {
+      textInImage: 'Foo bar',
+      expectedAlt: 'Thumbnail. Contains text: Foo bar',
+    },
+  ].forEach(({ textInImage, expectedAlt }) => {
+    it('sets alt text for thumbnail', () => {
+      fakeThumbnailService.get.returns(fakeThumbnail);
+      const wrapper = createComponent({ textInImage });
+      const image = wrapper.find('canvas');
+      assert.equal(image.prop('aria-label'), expectedAlt);
+    });
+  });
+
   it('requests thumbnail and then renders it if not cached', async () => {
     const wrapper = createComponent();
     assert.calledOnce(fakeThumbnailService.fetch);

--- a/src/sidebar/helpers/annotation-metadata.ts
+++ b/src/sidebar/helpers/annotation-metadata.ts
@@ -4,7 +4,6 @@ import type {
   EPUBContentSelector,
   PageSelector,
   SavedAnnotation,
-  Shape,
   ShapeSelector,
   TextQuoteSelector,
 } from '../../types/api';
@@ -401,11 +400,11 @@ export function quote(annotation: APIAnnotationData): string | null {
  * This will return `null` if the annotation is associated with a text
  * selection instead of a shape.
  */
-export function shape(annotation: APIAnnotationData): Shape | null {
+export function shape(annotation: APIAnnotationData): ShapeSelector | null {
   const shapeSelector = annotation.target[0]?.selector?.find(
     s => s.type === 'ShapeSelector',
   ) as ShapeSelector | undefined;
-  return shapeSelector?.shape ?? null;
+  return shapeSelector ?? null;
 }
 
 /**

--- a/src/sidebar/helpers/test/annotation-metadata-test.js
+++ b/src/sidebar/helpers/test/annotation-metadata-test.js
@@ -726,15 +726,18 @@ describe('sidebar/helpers/annotation-metadata', () => {
           },
         ],
         expected: {
-          type: 'rect',
-          left: 0,
-          top: 10,
-          right: 10,
-          bottom: 0,
+          type: 'ShapeSelector',
+          shape: {
+            type: 'rect',
+            left: 0,
+            top: 10,
+            right: 10,
+            bottom: 0,
+          },
         },
       },
     ].forEach(({ selectors, expected }) => {
-      it('returns shape from shape selector', () => {
+      it('returns shape selector', () => {
         const annotation = {
           target: [
             {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -212,6 +212,9 @@ export type ShapeSelector = {
     right: number;
     bottom: number;
   };
+
+  /** The text contained inside this shape. */
+  text?: string;
 };
 
 /**


### PR DESCRIPTION
When the area selected for a rect or pin annotations contains PDF text, extract that text and store it in the shape selector. This is then used to generate better alt text for the thumbnail in the sidebar:

<img width="723" alt="Text in image" src="https://github.com/user-attachments/assets/aa4c2468-f1ca-4607-8e3a-42758514d517" />

The length of the extracted text is capped to stop the selector JSON from becoming too large.

In future we plan to enable users to enter a text description for the thumbnail. That description will either replace or be combined with the extracted text.

Fixes https://github.com/hypothesis/client/issues/6974