### PR TITLE
Update browser baseline

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "vitest": "^3.1.1",
     "wrap-text": "^1.0.7"
   },
-  "browserslist": "chrome 92, firefox 90, safari 14.1",
+  "browserslist": "chrome 110, firefox 115, safari 16.4",
   "prettier": {
     "arrowParens": "avoid",
     "singleQuote": true,


### PR DESCRIPTION
The new baseline corresponds to the current requirements for the PDF.js legacy build. See
https://github.com/hypothesis/client/issues/6784#issuecomment-2883162200.

The changes in the generated code are fairly small. The annotator bundle is unchanged and the sidebar bundle is 1KB smaller (in production) due to removal of some transpilation (eg. of private fields) that is no longer required.