### PR TITLE
Warn when closing tab if there is an unsaved, non-empty draft

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationEditor.tsx
+++ b/src/sidebar/components/Annotation/AnnotationEditor.tsx
@@ -28,6 +28,7 @@ import { useSidebarStore } from '../../store';
 import type { Draft } from '../../store/modules/drafts';
 import MarkdownEditor from '../MarkdownEditor';
 import TagEditor from '../TagEditor';
+import { useUnsavedChanges } from '../hooks/unsaved-changes';
 import AnnotationLicense from './AnnotationLicense';
 import AnnotationPublishControl from './AnnotationPublishControl';
 
@@ -74,6 +75,12 @@ function AnnotationEditor({
   const tags = draft.tags;
   const text = draft.text;
   const isEmpty = !text && !tags.length;
+
+  // Warn user if they try to close the tab while there is an open, non-empty
+  // draft.
+  //
+  // WARNING: This does not work in all browsers. See hook docs for details.
+  useUnsavedChanges(!isEmpty);
 
   const onEditTags = useCallback(
     (tags: string[]) => {

--- a/src/sidebar/components/hooks/test/unsaved-changes-test.js
+++ b/src/sidebar/components/hooks/test/unsaved-changes-test.js
@@ -1,0 +1,62 @@
+import { mount } from '@hypothesis/frontend-testing';
+
+import { useUnsavedChanges, hasUnsavedChanges } from '../unsaved-changes';
+
+function TestUseUnsavedChanges({ unsaved, fakeWindow }) {
+  useUnsavedChanges(unsaved, fakeWindow);
+  return <div />;
+}
+
+describe('useUnsavedChanges', () => {
+  let fakeWindow;
+
+  function dispatchBeforeUnload() {
+    const event = new Event('beforeunload', { cancelable: true });
+    fakeWindow.dispatchEvent(event);
+    return event;
+  }
+
+  function createWidget(unsaved) {
+    return mount(
+      <TestUseUnsavedChanges fakeWindow={fakeWindow} unsaved={unsaved} />,
+    );
+  }
+
+  beforeEach(() => {
+    // Use a dummy window to avoid triggering any handlers that respond to
+    // "beforeunload" on the real window.
+    fakeWindow = new EventTarget();
+  });
+
+  it('does not increment unsaved-changes count if argument is false', () => {
+    createWidget(false);
+    assert.isFalse(hasUnsavedChanges());
+  });
+
+  it('does not register "beforeunload" handler if argument is false', () => {
+    createWidget(false);
+    const event = dispatchBeforeUnload();
+    assert.isFalse(event.defaultPrevented);
+  });
+
+  it('increments unsaved-changes count if argument is true', () => {
+    const wrapper = createWidget(true);
+    assert.isTrue(hasUnsavedChanges());
+    wrapper.unmount();
+    assert.isFalse(hasUnsavedChanges());
+  });
+
+  it('registers "beforeunload" handler if argument is true', () => {
+    const wrapper = createWidget(true);
+    const event = dispatchBeforeUnload();
+    assert.isTrue(event.defaultPrevented);
+
+    // We don't test `event.returnValue` here because it returns `false` after
+    // assignment in Chrome, even though the handler assigns it `true`.
+
+    // Unmount the widget, this should remove the handler.
+    wrapper.unmount();
+    const event2 = dispatchBeforeUnload();
+    assert.isFalse(event2.defaultPrevented);
+  });
+});

--- a/src/sidebar/components/hooks/unsaved-changes.ts
+++ b/src/sidebar/components/hooks/unsaved-changes.ts
@@ -1,0 +1,55 @@
+import { useEffect } from 'preact/hooks';
+
+/** Count of components with unsaved changes. */
+let unsavedCount = 0;
+
+function preventUnload(e: BeforeUnloadEvent) {
+  // `preventDefault` is the modern API for preventing unload.
+  e.preventDefault();
+
+  // Setting `returnValue` to a truthy value is a legacy method needed for
+  // Firefox. Note that in Chrome, reading `returnValue` will return false
+  // afterwards.
+  e.returnValue = true;
+}
+
+/**
+ * Return true if any active components have indicated they have unsaved changes
+ * using {@link useUnsavedChanges}.
+ */
+export function hasUnsavedChanges() {
+  return unsavedCount > 0;
+}
+
+/**
+ * Hook that registers the current component as having unsaved changes that
+ * would be lost in the event of a navigation.
+ *
+ * WARNING: As of May 2025, this works in Chrome and Firefox, but not Safari.
+ * See https://github.com/hypothesis/support/issues/59#issuecomment-2886335334.
+ *
+ * @param hasUnsavedChanges - True if current component has unsaved changes
+ * @param window_ - Test seam
+ */
+export function useUnsavedChanges(
+  hasUnsavedChanges: boolean,
+  /* istanbul ignore next - test seam */
+  window_ = window,
+) {
+  useEffect(() => {
+    if (!hasUnsavedChanges) {
+      return () => {};
+    }
+
+    unsavedCount += 1;
+    if (unsavedCount === 1) {
+      window_.addEventListener('beforeunload', preventUnload);
+    }
+    return () => {
+      unsavedCount -= 1;
+      if (unsavedCount === 0) {
+        window_.removeEventListener('beforeunload', preventUnload);
+      }
+    };
+  }, [hasUnsavedChanges, window_]);
+}


### PR DESCRIPTION
Copy the `useUnsavedChanges` hook from the h repository and use it in AnnotationEditor to enable a warning if the user tries to close the tab while there is a non-empty draft. In the process, fix a bug where `returnValue` was set to an empty string when according to MDN, it must be set to a truthy value. Without this change, the hook works in Chrome but not Firefox.

This change works in Chrome and Firefox, but not Safari. In Safari, the tab closes even when the `beforeunload` handler is active.

Part of https://github.com/hypothesis/support/issues/59.

---

<img width="932" alt="Chrome unsaved changes warning" src="https://github.com/user-attachments/assets/b985e88a-f2c7-4c0f-9b5e-4f180ff1641d" />

---

**Testing:**

1. In Chrome or Firefox, go to http://localhost:3000
2. Close the tab, there should be no warning
3. Go to http://localhost:3000 again, create a new annotation and enter some text or tags but don't save
4. Try to close the tab, and you should see a warning like the above
