### PR TITLE
Do not show group type icons for third-party authorities

### DIFF
--- a/src/sidebar/components/GroupList/GroupList.tsx
+++ b/src/sidebar/components/GroupList/GroupList.tsx
@@ -109,9 +109,15 @@ function GroupList({ settings }: GroupListProps) {
     label = <span>…</span>;
   }
 
+  const isThirdParty = isThirdPartyService(settings);
+
+  // We don't show group type icons in the third-party context because the
+  // meaning may be unclear. See https://github.com/hypothesis/support/issues/183.
+  const showIcons = !isThirdParty;
+
   // If there is only one group and no actions available for that group,
   // just show the group name as a label.
-  const actionsAvailable = !isThirdPartyService(settings);
+  const actionsAvailable = !isThirdParty;
   if (
     !actionsAvailable &&
     currentGroups.length + featuredGroups.length + myGroups.length < 2
@@ -138,6 +144,7 @@ function GroupList({ settings }: GroupListProps) {
           onExpandGroup={setExpandedGroup}
           heading="Currently Viewing"
           groups={currentGroupsSorted}
+          showIcons={showIcons}
         />
       )}
       {featuredGroupsSorted.length > 0 && (
@@ -146,6 +153,7 @@ function GroupList({ settings }: GroupListProps) {
           onExpandGroup={setExpandedGroup}
           heading="Featured Groups"
           groups={featuredGroupsSorted}
+          showIcons={showIcons}
         />
       )}
       {myGroupsSorted.length > 0 && (
@@ -154,6 +162,7 @@ function GroupList({ settings }: GroupListProps) {
           onExpandGroup={setExpandedGroup}
           heading="My Groups"
           groups={myGroupsSorted}
+          showIcons={showIcons}
         />
       )}
 

--- a/src/sidebar/components/GroupList/GroupListItem.tsx
+++ b/src/sidebar/components/GroupList/GroupListItem.tsx
@@ -48,6 +48,9 @@ export type GroupListItemProps = {
   /** Callback invoked to expand or collapse the current group. */
   onExpand: (expand: boolean) => void;
 
+  /** Whether to show the group type icon. */
+  showIcon?: boolean;
+
   groups: GroupsService;
   toastMessenger: ToastMessengerService;
 };
@@ -63,6 +66,7 @@ function GroupListItem({
   group,
   groups: groupsService,
   onExpand,
+  showIcon = true,
   toastMessenger,
 }: GroupListItemProps) {
   const activityUrl = group.links.html;
@@ -130,7 +134,7 @@ function GroupListItem({
       label={
         <div className="grow flex items-center justify-between gap-x-2">
           {group.name}
-          <GroupIcon type={group.type} />
+          {showIcon && <GroupIcon type={group.type} />}
         </div>
       }
       leftChannelContent={leftChannelContent}

--- a/src/sidebar/components/GroupList/GroupListSection.tsx
+++ b/src/sidebar/components/GroupList/GroupListSection.tsx
@@ -12,6 +12,9 @@ export type GroupListSectionProps = {
   /** Heading displayed at top of section. */
   heading?: string;
 
+  /** Whether to show icons to indicate group types. */
+  showIcons?: boolean;
+
   /**
    * Callback invoked when a group is expanded or collapsed.
    *
@@ -29,6 +32,7 @@ export default function GroupListSection({
   onExpandGroup,
   groups,
   heading,
+  showIcons,
 }: GroupListSectionProps) {
   return (
     <MenuSection heading={heading}>
@@ -38,6 +42,7 @@ export default function GroupListSection({
           isExpanded={group === expandedGroup}
           onExpand={expanded => onExpandGroup(expanded ? group : null)}
           group={group}
+          showIcon={showIcons}
         />
       ))}
     </MenuSection>

--- a/src/sidebar/components/GroupList/test/GroupList-test.js
+++ b/src/sidebar/components/GroupList/test/GroupList-test.js
@@ -169,6 +169,14 @@ describe('GroupList', () => {
     assert.equal(newGroupButton.props().href, 'https://example.com/groups/new');
   });
 
+  it('shows group type icons', () => {
+    populateGroupSections();
+    const wrapper = createGroupList();
+    const sections = wrapper.find('GroupListSection');
+    assert.isTrue(sections.exists());
+    sections.forEach(section => assert.isTrue(section.prop('showIcons')));
+  });
+
   context('when `isThirdPartyService` is true', () => {
     beforeEach(() => {
       $imports.$mock({
@@ -194,6 +202,14 @@ describe('GroupList', () => {
       testGroup.organization = {};
       const wrapper = createGroupList();
       assert.equal(wrapper.find('img').prop('alt'), '');
+    });
+
+    it('does not show group icons', () => {
+      populateGroupSections();
+      const wrapper = createGroupList();
+      const sections = wrapper.find('GroupListSection');
+      assert.isTrue(sections.exists());
+      sections.forEach(section => assert.isFalse(section.prop('showIcons')));
     });
   });
 

--- a/src/sidebar/components/GroupList/test/GroupListItem-test.js
+++ b/src/sidebar/components/GroupList/test/GroupListItem-test.js
@@ -378,6 +378,10 @@ describe('GroupListItem', () => {
     assert.calledWith(fakeToastMessenger.error, 'Unable to copy link');
   });
 
+  const getIcon = label => {
+    return label.find('[data-testid="group-icon"]');
+  };
+
   [
     {
       type: 'private',
@@ -398,7 +402,7 @@ describe('GroupListItem', () => {
     it('shows the right icon for the group type', () => {
       const wrapper = createGroupListItem({ ...fakeGroup, type });
       const label = mount(wrapper.find('MenuItem').prop('label'));
-      const groupIcon = label.find('[data-testid="group-icon"]');
+      const groupIcon = getIcon(label);
 
       try {
         assert.equal(groupIcon.prop('title'), expectedTitle);
@@ -407,5 +411,20 @@ describe('GroupListItem', () => {
         label.unmount();
       }
     });
+  });
+
+  it('does not render group type icon if `showIcon` is false', () => {
+    const wrapper = createGroupListItem(
+      {
+        ...fakeGroup,
+        type: 'private',
+      },
+      {
+        showIcon: false,
+      },
+    );
+    const label = mount(wrapper.find('MenuItem').prop('label'));
+    const groupIcon = getIcon(label);
+    assert.isFalse(groupIcon.exists());
   });
 });

--- a/src/sidebar/components/GroupList/test/GroupListSection-test.js
+++ b/src/sidebar/components/GroupList/test/GroupListSection-test.js
@@ -43,6 +43,15 @@ describe('GroupListSection', () => {
     assert.equal(wrapper.find('GroupListItem').length, testGroups.length);
   });
 
+  [true, false].forEach(showIcons => {
+    it('renders icons if `showIcons` is true', () => {
+      const wrapper = createGroupListSection({ showIcons });
+      wrapper
+        .find('GroupListItem')
+        .forEach(item => assert.equal(item.prop('showIcon'), showIcons));
+    });
+  });
+
   it('expands group specified by `expandedGroup` prop', () => {
     const wrapper = createGroupListSection();
     for (let i = 0; i < testGroups.length; i++) {


### PR DESCRIPTION
In the LMS app, the group type icons were confusing for students since they didn't join the groups themselves (the LMS app added them) and thus they don't have a notion of having joined a private group, plus all the groups are private anyway, so the icon isn't informative.

Group type icons are primarily intended for use with the first-party authority. We might need to make it possible for third-party authorities to enable these icons in future, but for the moment hiding the icons for all third-party authorities is the simplest thing to do.

Fixes https://github.com/hypothesis/support/issues/183