### PR TITLE
Remove unused `diff` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "classnames": "^2.2.4",
     "commander": "^13.0.0",
     "cross-env": "^7.0.0",
-    "diff": "^7.0.0",
     "dompurify": "^3.0.0",
     "enzyme": "^3.8.0",
     "enzyme-adapter-preact-pure": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7746,7 +7746,6 @@ __metadata:
     classnames: ^2.2.4
     commander: ^13.0.0
     cross-env: ^7.0.0
-    diff: ^7.0.0
     dompurify: ^3.0.0
     enzyme: ^3.8.0
     enzyme-adapter-preact-pure: ^4.0.1


### PR DESCRIPTION
This was previously used by Karma. See 5d35d536ef184c7e7812aab8abe1ca3303d1daae.

sinon still has a dependency on diff, so the package still exists in node_modules (see `yarn why diff`).