### PR TITLE
Change how boot script gets asset root URLs

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,6 +10,7 @@ import changed from 'gulp-changed';
 
 import { serveDev } from './dev-server/serve-dev.js';
 import { servePackage } from './dev-server/serve-package.js';
+import { renderBootTemplate } from './scripts/render-boot-template.js';
 import annotatorTailwindConfig from './tailwind-annotator.config.js';
 import sidebarTailwindConfig from './tailwind-sidebar.config.js';
 import tailwindConfig from './tailwind.config.js';
@@ -98,8 +99,12 @@ gulp.task(
 const manifestSourceFiles = 'build/{scripts,styles}/*.{css,js,map}';
 
 gulp.task('build-boot-script', async () => {
+  // Generate the manifest containing cache-busted asset URLs
   await generateManifest({ pattern: manifestSourceFiles });
+  // Generate the boot script template
   await buildJS('./rollup-boot.config.js');
+  // Replace variables in the template with real URLs
+  renderBootTemplate('build/boot-template.js', 'build/boot.js');
 });
 
 gulp.task('watch-boot-script', () => {

--- a/rollup-boot.config.js
+++ b/rollup-boot.config.js
@@ -1,9 +1,7 @@
 import { babel } from '@rollup/plugin-babel';
 import json from '@rollup/plugin-json';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
-import replace from '@rollup/plugin-replace';
 import terser from '@rollup/plugin-terser';
-import { readFileSync } from 'fs';
 
 const isProd = process.env.NODE_ENV === 'production';
 const prodPlugins = [];
@@ -11,33 +9,10 @@ if (isProd) {
   prodPlugins.push(terser());
 }
 
-const { version } = JSON.parse(readFileSync('./package.json').toString());
-
-// URL template which is expanded by the boot script. See `src/boot/url-template.js`.
-const localhost = '{current_scheme}://{current_host}';
-
-const notebookAppUrl = process.env.NOTEBOOK_APP_URL
-  ? `${process.env.NOTEBOOK_APP_URL}`
-  : `${localhost}:5000/notebook`;
-
-const profileAppUrl = process.env.PROFILE_APP_URL
-  ? `${process.env.PROFILE_APP_URL}`
-  : `${localhost}:5000/user-profile`;
-
-const sidebarAppUrl = process.env.SIDEBAR_APP_URL
-  ? `${process.env.SIDEBAR_APP_URL}`
-  : `${localhost}:5000/app.html`;
-
-// nb. Replace `isProd` with `false` here to test a production build of the client
-// served locally.
-const assetRoot = isProd
-  ? `https://cdn.hypothes.is/hypothesis/${version}/`
-  : `${localhost}:3001/hypothesis/${version}/`;
-
 export default {
   input: 'src/boot/index.ts',
   output: {
-    file: 'build/boot.js',
+    file: 'build/boot-template.js',
 
     // Built as an IIFE rather than ES module because there are many existing
     // <script> tags on websites that load it as a non-module script.
@@ -50,15 +25,6 @@ export default {
   treeshake: isProd,
 
   plugins: [
-    replace({
-      preventAssignment: true,
-      values: {
-        __ASSET_ROOT__: assetRoot,
-        __NOTEBOOK_APP_URL__: notebookAppUrl,
-        __PROFILE_APP_URL__: profileAppUrl,
-        __SIDEBAR_APP_URL__: sidebarAppUrl,
-      },
-    }),
     babel({
       // Rollup docs recommend against "inline", but for this tiny bundle it
       // produces a prod bundle of the same size and dev bundle that has less cruft in it.

--- a/scripts/render-boot-template.js
+++ b/scripts/render-boot-template.js
@@ -1,0 +1,52 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+
+/**
+ * Replace placeholders in the client's boot script with real URLs.
+ *
+ * Placeholders are single or double-quoted string literals of the form
+ * `"__VARIABLE_NAME__"`.
+ */
+export function renderBootTemplate(src, dest) {
+  // URL template which is expanded by the boot script. See `src/boot/url-template.js`.
+  const localhost = '{current_scheme}://{current_host}';
+
+  const notebookAppUrl = process.env.NOTEBOOK_APP_URL
+    ? `${process.env.NOTEBOOK_APP_URL}`
+    : `${localhost}:5000/notebook`;
+
+  const profileAppUrl = process.env.PROFILE_APP_URL
+    ? `${process.env.PROFILE_APP_URL}`
+    : `${localhost}:5000/user-profile`;
+
+  const sidebarAppUrl = process.env.SIDEBAR_APP_URL
+    ? `${process.env.SIDEBAR_APP_URL}`
+    : `${localhost}:5000/app.html`;
+
+  const { version } = JSON.parse(readFileSync('./package.json').toString());
+
+  // nb. Replace `isProd` with `false` here to test a production build of the client
+  // served locally.
+  const isProd = process.env.NODE_ENV === 'production';
+  const assetRoot = isProd
+    ? `https://cdn.hypothes.is/hypothesis/${version}/`
+    : `${localhost}:3001/hypothesis/${version}/`;
+
+  const replacements = {
+    __ASSET_ROOT__: assetRoot,
+    __NOTEBOOK_APP_URL__: notebookAppUrl,
+    __PROFILE_APP_URL__: profileAppUrl,
+    __SIDEBAR_APP_URL__: sidebarAppUrl,
+  };
+  const template = readFileSync(src, { encoding: 'utf8' });
+  const bootScript = template.replaceAll(
+    /"(__[A-Z_0-9]+__)"|'(__[A-Z_0-9]+__)'/g,
+    (match, doubleQuoted, singleQuoted) => {
+      const name = doubleQuoted || singleQuoted;
+      if (!Object.hasOwn(replacements, name)) {
+        throw new Error(`Unknown placeholder "${name}" in boot template`);
+      }
+      return `"${replacements[name]}"`;
+    },
+  );
+  writeFileSync(dest, bootScript);
+}


### PR DESCRIPTION
Previously the boot script generated the root URLs for assets using:

```
processUrlTemplate(config.assetRoot || 'https://cdn.hypothes.is/...')
```

Where the "cdn.hypothes.is" URL is used in the embed and `config.assetRoot` is set in the extension, so our CDN URL is not used there. The presence of the CDN URL in the extension caused Chrome Web Store reviewers to think the extension was loading remote code, even though it isn't.

To resolve this, the boot script build is being changed to generate two separate files, `build/boot-template.js` and `build/boot.js`. The template will contain code like `processUrlTemplate(config.assetRoot || '__ASSET_ROOT_')` and `build/boot.js` is a "rendered" version of the template with variables replaced by CDN URLs. In the extension we will replace `boot.js` with a different rendered version of the template, containing extension-specific URLs. This way the CDN URL will not appear in the extension's scripts.

The `assetRoot` and related config keys are still supported because they are used when Hypothesis injects itself into a same-origin iframe that has an `enable-annotation` attribute. Except for that, we could remove them entirely.