### PR TITLE
Enable users to enter description of selection for image annotations

### DIFF
--- a/src/sidebar/components/Annotation/Annotation.tsx
+++ b/src/sidebar/components/Annotation/Annotation.tsx
@@ -7,6 +7,7 @@ import {
   annotationRole,
   isOrphan,
   isSaved,
+  description,
   quote,
   shape,
 } from '../../helpers/annotation-metadata';
@@ -78,6 +79,8 @@ function Annotation({
   const store = useSidebarStore();
 
   const annotationQuote = quote(annotation);
+  const targetDescription = description(annotation);
+
   const draft = store.getDraft(annotation);
   const userid = store.profile().userid;
 
@@ -128,6 +131,7 @@ function Annotation({
         <AnnotationThumbnail
           tag={annotation.$tag}
           textInImage={targetShape.text}
+          description={targetDescription}
         />
       )}
       {annotationQuote && (

--- a/src/sidebar/components/Annotation/AnnotationActionBar.tsx
+++ b/src/sidebar/components/Annotation/AnnotationActionBar.tsx
@@ -98,6 +98,7 @@ function AnnotationActionBar({
       tags: annotation.tags,
       text: annotation.text,
       isPrivate: isPrivate(annotation.permissions),
+      description: annotation.target[0]?.description,
     });
   };
 

--- a/src/sidebar/components/Annotation/AnnotationThumbnail.tsx
+++ b/src/sidebar/components/Annotation/AnnotationThumbnail.tsx
@@ -58,9 +58,13 @@ export type AnnotationThumbnailProps = {
    * This is used when generating alt text for the thumbnail.
    */
   textInImage?: string;
+
+  /** Description of the thumbnail. */
+  description?: string;
 };
 
 function AnnotationThumbnail({
+  description,
   textInImage,
   tag,
   thumbnailService,
@@ -85,7 +89,9 @@ function AnnotationThumbnail({
   }, [error, devicePixelRatio, tag, thumbnail, thumbnailService]);
 
   let altText;
-  if (textInImage) {
+  if (description) {
+    altText = `Thumbnail. ${description}`;
+  } else if (textInImage) {
     altText = `Thumbnail. Contains text: ${textInImage}`;
   } else {
     altText = 'Thumbnail';

--- a/src/sidebar/components/Annotation/test/Annotation-test.js
+++ b/src/sidebar/components/Annotation/test/Annotation-test.js
@@ -147,6 +147,7 @@ describe('Annotation', () => {
 
     it('renders a thumbnail if annotation has a shape selector', () => {
       const annotation = fixtures.defaultAnnotation();
+      annotation.target[0].description = 'This is a thing';
       annotation.target[0].selector = [
         {
           type: 'ShapeSelector',
@@ -164,6 +165,7 @@ describe('Annotation', () => {
       const thumbnail = wrapper.find('AnnotationThumbnail');
       assert.isTrue(thumbnail.exists());
       assert.equal(thumbnail.prop('tag'), annotation.$tag);
+      assert.equal(thumbnail.prop('description'), 'This is a thing');
       assert.equal(thumbnail.prop('textInImage'), 'Some text');
     });
   });

--- a/src/sidebar/components/Annotation/test/AnnotationActionBar-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationActionBar-test.js
@@ -114,6 +114,8 @@ describe('AnnotationActionBar', () => {
     });
 
     it('creates a new draft when `Edit` button clicked', () => {
+      fakeAnnotation.target[0].description = 'Image description';
+
       allowOnly('update');
       const button = getButton(createComponent(), 'EditIcon');
 
@@ -125,6 +127,7 @@ describe('AnnotationActionBar', () => {
       assert.include(call.args[1], {
         isPrivate: false,
         text: fakeAnnotation.text,
+        description: 'Image description',
       });
       assert.isArray(call.args[1].tags);
     });

--- a/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
@@ -187,6 +187,38 @@ describe('AnnotationEditor', () => {
     });
   });
 
+  describe('editing target descriptions', () => {
+    const getDescription = wrapper =>
+      wrapper.find('input[data-testid="description"]');
+
+    beforeEach(() => {
+      fakeStore.isFeatureEnabled.withArgs('image_descriptions').returns(true);
+    });
+
+    it('does not show description input if annotation has no shape selector', () => {
+      const wrapper = createComponent();
+      assert.isFalse(getDescription(wrapper).exists());
+    });
+
+    it('updates draft when description is edited', () => {
+      const annotation = Object.assign(fixtures.defaultAnnotation(), {
+        target: [
+          {
+            selector: [{ type: 'ShapeSelector' }],
+          },
+        ],
+      });
+      const wrapper = createComponent({ annotation });
+      const input = wrapper.find('input[data-testid="description"]');
+      input.getDOMNode().value = 'new-description';
+      input.simulate('input');
+
+      const draftCall = fakeStore.createDraft.getCall(0);
+
+      assert.deepEqual(draftCall.args[1].description, 'new-description');
+    });
+  });
+
   describe('saving the annotation', () => {
     it('saves the annotation when save callback invoked', async () => {
       const annotation = fixtures.defaultAnnotation();

--- a/src/sidebar/components/Annotation/test/AnnotationThumbnail-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationThumbnail-test.js
@@ -39,18 +39,25 @@ describe('AnnotationThumbnail', () => {
   });
 
   [
+    // No alt text
     {
-      textInImage: undefined,
       expectedAlt: 'Thumbnail',
     },
+    // Text extracted from image
     {
       textInImage: 'Foo bar',
       expectedAlt: 'Thumbnail. Contains text: Foo bar',
     },
-  ].forEach(({ textInImage, expectedAlt }) => {
+    // Explicitly provided description
+    {
+      description: 'Foo bar',
+      textInImage: 'Some text',
+      expectedAlt: 'Thumbnail. Foo bar',
+    },
+  ].forEach(({ textInImage, description, expectedAlt }) => {
     it('sets alt text for thumbnail', () => {
       fakeThumbnailService.get.returns(fakeThumbnail);
-      const wrapper = createComponent({ textInImage });
+      const wrapper = createComponent({ description, textInImage });
       const image = wrapper.find('canvas');
       assert.equal(image.prop('aria-label'), expectedAlt);
     });

--- a/src/sidebar/helpers/annotation-metadata.ts
+++ b/src/sidebar/helpers/annotation-metadata.ts
@@ -394,6 +394,11 @@ export function quote(annotation: APIAnnotationData): string | null {
   return quoteSel ? quoteSel.exact : null;
 }
 
+/** Return the description of the annotation's selection. */
+export function description(annotation: APIAnnotationData): string | undefined {
+  return annotation.target[0]?.description;
+}
+
 /**
  * Return the shape of an annotation's target, if there is one.
  *

--- a/src/sidebar/helpers/test/annotation-metadata-test.js
+++ b/src/sidebar/helpers/test/annotation-metadata-test.js
@@ -2,6 +2,7 @@ import * as fixtures from '../../test/annotation-fixtures';
 import * as annotationMetadata from '../annotation-metadata';
 import {
   cfi,
+  description,
   documentMetadata,
   domainAndTitle,
   isSaved,
@@ -749,6 +750,22 @@ describe('sidebar/helpers/annotation-metadata', () => {
         const annShape = shape(annotation);
         assert.deepEqual(annShape, expected);
       });
+    });
+  });
+
+  describe('description', () => {
+    it('returns target description', () => {
+      const annotation = { target: [] };
+      assert.isUndefined(description(annotation));
+
+      const annotation2 = {
+        target: [
+          {
+            description: 'Two roads diverge in a wood',
+          },
+        ],
+      };
+      assert.equal(description(annotation2), 'Two roads diverge in a wood');
     });
   });
 

--- a/src/sidebar/services/annotations.ts
+++ b/src/sidebar/services/annotations.ts
@@ -90,6 +90,13 @@ export class AnnotationsService {
       ? privatePermissions(annotation.user)
       : sharedPermissions(annotation.user, annotation.group);
 
+    const target = annotation.target;
+    if (target[0] && target[0].description !== draft.description) {
+      const newTarget = structuredClone(target);
+      newTarget[0].description = draft.description;
+      changes.target = newTarget;
+    }
+
     // Integrate changes from draft into object to be persisted
     return { ...annotation, ...changes };
   }
@@ -175,6 +182,7 @@ export class AnnotationsService {
         tags: annotation.tags,
         text: annotation.text,
         isPrivate: !metadata.isPublic(annotation),
+        description: annotation.target[0]?.description,
       });
     }
 

--- a/src/sidebar/store/modules/drafts.ts
+++ b/src/sidebar/store/modules/drafts.ts
@@ -19,6 +19,9 @@ type DraftChanges = {
   isPrivate: boolean;
   tags: string[];
   text: string;
+
+  /** Description of what was selected, for image annotations. */
+  description?: string;
 };
 
 /**
@@ -32,12 +35,14 @@ export class Draft {
   isPrivate: boolean;
   tags: string[];
   text: string;
+  description?: string;
 
   constructor(annotation: AnnotationID, changes: DraftChanges) {
     this.annotation = { id: annotation.id, $tag: annotation.$tag };
     this.isPrivate = changes.isPrivate;
     this.tags = changes.tags;
     this.text = changes.text;
+    this.description = changes.description;
   }
   /**
    * Returns true if this draft matches a given annotation.
@@ -55,7 +60,7 @@ export class Draft {
    * any user input.
    */
   isEmpty() {
-    return !this.text && this.tags.length === 0;
+    return !this.text && this.tags.length === 0 && !this.description;
   }
 }
 

--- a/src/sidebar/store/modules/test/drafts-test.js
+++ b/src/sidebar/store/modules/test/drafts-test.js
@@ -44,19 +44,31 @@ describe('store/modules/drafts', () => {
         annotation: {
           ...fixtures.annotation,
         },
+        description: undefined,
         ...fixtures.draftWithText,
       });
     });
+
     describe('#isEmpty', () => {
       it('returns false if draft has tags or text', () => {
         const draft = new Draft(fixtures.annotation, fixtures.draftWithText);
         assert.isFalse(draft.isEmpty());
       });
+
+      it('returns false if draft has a description', () => {
+        const draft = new Draft(fixtures.annotation, {
+          ...fixtures.emptyDraft,
+          description: 'foo',
+        });
+        assert.isFalse(draft.isEmpty());
+      });
+
       it('returns true if draft has no tags or text', () => {
         const draft = new Draft(fixtures.annotation, fixtures.emptyDraft);
         assert.isTrue(draft.isEmpty());
       });
     });
+
     describe('#match', () => {
       it('matches an annotation with the same tag or id', () => {
         const draft = new Draft(fixtures.annotation, fixtures.draftWithText);

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -239,6 +239,8 @@ export type Target = {
   source: string;
   /** Region of the document */
   selector?: Selector[];
+  /** Text description of the selection, for when the selection itself is not text. */
+  description?: string;
 };
 
 export type UserInfo = {


### PR DESCRIPTION
For rect and pin annotations, add an input field on the annotation card which allows the user to enter a description of the selected region. When a description is present, it is used as the alt text for the thumbnail.

The input field currently looks like this:

<img width="425" alt="Description field" src="https://github.com/user-attachments/assets/685772a6-479a-42f3-b726-4e0597d89ba0" />

**Testing:**

1. Enable the `image_descriptions` feature in h
2. Create a new rect or pin annotation
3. The annotation card should display a new field for the description
4. When the annotation is saved, the description should be used in the alt-text (title, label) for the image