### PR TITLE
Do mention matching via substring check instead of RegExp

### DIFF
--- a/src/sidebar/helpers/mention-suggestions.ts
+++ b/src/sidebar/helpers/mention-suggestions.ts
@@ -114,7 +114,9 @@ export function usersMatchingMention(
           ? `${u.username} ${displayName}`
           : displayName;
 
-      return contentToMatch.match(new RegExp(mentionToMatch, 'i'));
+      return contentToMatch
+        .toLowerCase()
+        .includes(mentionToMatch.toLowerCase());
     })
     .slice(0, maxUsers);
 }

--- a/src/sidebar/helpers/test/mention-suggestions-test.js
+++ b/src/sidebar/helpers/test/mention-suggestions-test.js
@@ -454,6 +454,23 @@ describe('usersMatchingMention', () => {
         },
       ],
     },
+
+    // Matching even if the mention candidate includes an invalid RegExp
+    {
+      usersForMentions: {
+        status: 'loaded',
+        users: [
+          {
+            userid: 'acct:one@example.com',
+            username: 'one',
+            displayName: 'johndoe',
+          },
+        ],
+      },
+      mention: '\\',
+      options: { mentionMode: 'username' },
+      expectedSuggestions: [],
+    },
   ].forEach(({ usersForMentions, mention, options, expectedSuggestions }) => {
     it('suggests expected users for mention', () => {
       assert.deepEqual(


### PR DESCRIPTION
This PR changes how we match potential mentions in a list of users.

Previously, we would do it via `displayNameOrUsername.match(new RegExp(mentionToMatch, 'i'))`, allowing the matching to be case-insensitive.

The problem with this approach is that `mentionToMatch` is extracted from a value the user inputs, which can end up being an invalid regular expression if it includes escaping characters and such.

This PR makes the logic a bit more verbose, but also more straightforward, by checking if the lowercase version of `mentionToMatch` is included in the lowercase version of `displayNameOrUsername`.

Another option would have been to escape regular expressions from `mentionToMatch`, but I think it's less obvious.

> [!NOTE]
> This PR has been motivated by an [error reported to Sentry](https://hypothesis.sentry.io/issues/6529235849/?project=69811&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=3)