### PR TITLE
Handle Unicode normalization differences in `translateOffsets`

### DIFF
--- a/src/annotator/anchoring/pdf.ts
+++ b/src/annotator/anchoring/pdf.ts
@@ -330,13 +330,19 @@ async function anchorByPosition(
       start,
       end,
       isNotSpace,
+      // Apply normalization since the extracted text and text layer may have
+      // different normalization, depending on the PDF.js version.
+      { normalize: true },
     );
 
     const textLayerQuote = stripSpaces(
       textLayerStr.slice(textLayerStart, textLayerEnd),
     );
     const pageTextQuote = stripSpaces(pageText.slice(start, end));
-    if (textLayerQuote !== pageTextQuote) {
+
+    // Compare NFKD normalized-strings here to match how `translateOffsets`
+    // works.
+    if (textLayerQuote.normalize('NFKD') !== pageTextQuote.normalize('NFKD')) {
       warnOnce(
         'Text layer text does not match page text. Highlights will be mis-aligned.',
       );
@@ -446,6 +452,9 @@ async function anchorQuote(
           expectedOffsetInPage,
           expectedOffsetInPage,
           isNotSpace,
+          // We don't need to normalize here since both input strings are
+          // derived from the same input.
+          { normalize: false },
         );
       } else {
         strippedHint = 0; // Prefer matches closer to start of page.

--- a/src/annotator/util/normalize.ts
+++ b/src/annotator/util/normalize.ts
@@ -36,6 +36,107 @@ function countChars(
   return count;
 }
 
+type NormalizeResult = {
+  input: string;
+
+  /** Normalized output string. */
+  output: string;
+
+  /**
+   * Offsets which map from positions in {@link output} to positions in
+   * {@link input}.
+   *
+   * This will be undefined if the input and output strings are identical.
+   */
+  reverseOffsets?: number[];
+
+  /**
+   * Offsets which map from positions in {@link input} to positions in
+   * {@link output}.
+   *
+   * This will be undefined if the input and output strings are identical.
+   */
+  offsets?: number[];
+};
+
+/** Specifies which offsets to record in {@link normalizeWithOffsets}. */
+type NormalizeOptions = {
+  offsets?: boolean;
+  reverseOffsets?: boolean;
+};
+
+// Map of Unicode code point to length of NFKD-decomposed representation in
+// UTF-16 characters.
+const nfkdLengthCache = new Map<number, number>();
+
+/**
+ * Apply Unicode normalization to an input string, tracking the mapping between
+ * offsets in the output string and offsets in the input string.
+ */
+function normalizeWithOffsets(
+  input: string,
+  opts: NormalizeOptions,
+): NormalizeResult {
+  // Generate the normalized output string in one step. This is more efficient
+  // that incrementally appending to the output string. Plus we can bail early
+  // if no normalization is required.
+  const output = input.normalize('NFKD');
+  if (output === input) {
+    return { input, output };
+  }
+
+  const reverseOffsets = [];
+  const offsets = [];
+  let inOffset = 0;
+  let outOffset = 0;
+
+  for (const ch of input) {
+    // We use a decomposition normalization here so that we can process each
+    // Unicode character (note: not UTF-16 character) of the input separately.
+    const codePoint = ch.codePointAt(0)!;
+    let decomposedLen = nfkdLengthCache.get(codePoint);
+    if (decomposedLen === undefined) {
+      decomposedLen = ch.normalize('NFKD').length;
+      nfkdLengthCache.set(codePoint, decomposedLen);
+    }
+
+    if (opts.offsets) {
+      for (let i = 0; i < ch.length; i++) {
+        offsets.push(outOffset);
+      }
+      outOffset += decomposedLen;
+    }
+
+    if (opts.reverseOffsets) {
+      for (let i = 0; i < decomposedLen; i++) {
+        reverseOffsets.push(inOffset);
+      }
+      inOffset += ch.length;
+    }
+  }
+
+  // Add offset for end of string.
+  if (opts.offsets) {
+    offsets.push(output.length);
+  }
+  if (opts.reverseOffsets) {
+    reverseOffsets.push(inOffset);
+  }
+
+  return { input, output, reverseOffsets, offsets };
+}
+
+export type TranslateOffsetOptions = {
+  /**
+   * Whether to apply Unicode normalization to the input and output before
+   * translating offsets.
+   *
+   * Disabling normalization avoids unnecessary work if the input and output
+   * are known to already be normalized in the same way.
+   */
+  normalize?: boolean;
+};
+
 /**
  * Translate a (start, end) pair of offsets for an "input" string into
  * corresponding offsets in an "output" string.
@@ -52,6 +153,11 @@ function countChars(
  * correspond to the input offsets, the largest start offset and smallest end
  * offset are chosen. In other words, leading and trailing ignored characters
  * are trimmed from the output.
+ *
+ * This function can optionally apply Unicode normalization to its inputs. This
+ * allows for relating positions between input strings with different
+ * representations of the same character. For example `input` may contain "fi"
+ * as two separate characters and `output` may contain a combined "ﬁ" ligature.
  *
  * @example
  *   // The input offsets (1, 3) select the substring "bc" in the "input" argument.
@@ -70,24 +176,55 @@ export function translateOffsets(
   start: number,
   end: number,
   filter: (ch: string) => boolean,
+  options: TranslateOffsetOptions = {},
 ): [number, number] {
-  const beforeStartCount = countChars(input, filter, 0, start);
-  const startToEndCount = countChars(input, filter, start, end);
+  start = Math.max(0, Math.min(start, input.length));
+  end = Math.max(start, Math.min(end, input.length));
+
+  const normInput: NormalizeResult = options.normalize
+    ? normalizeWithOffsets(input, { offsets: true })
+    : { input, output: input };
+  const normOutput = options.normalize
+    ? normalizeWithOffsets(output, { reverseOffsets: true })
+    : { input, output };
+
+  const normStart = normInput.offsets?.[start] ?? start;
+  const normEnd = normInput.offsets?.[end] ?? end;
+
+  const beforeStartCount = countChars(normInput.output, filter, 0, normStart);
+  const startToEndCount = countChars(
+    normInput.output,
+    filter,
+    normStart,
+    normEnd,
+  );
 
   // Find the smallest offset in `output` with same number of non-ignored characters
   // before it as before `start` in the input. This offset might correspond to
   // an ignored character.
-  let outputStart = advance(output, beforeStartCount, filter);
+  let outputStart = advance(normOutput.output, beforeStartCount, filter);
 
   // Increment this offset until it points to a non-ignored character. This
   // "trims" leading ignored characters from the result.
-  while (outputStart < output.length && !filter(output[outputStart])) {
+  while (
+    outputStart < normOutput.output.length &&
+    !filter(normOutput.output[outputStart])
+  ) {
     ++outputStart;
   }
 
   // Find smallest offset in `output` with same number of non-ignored characters
   // before it as before `end` in the input.
-  const outputEnd = advance(output, startToEndCount, filter, outputStart);
+  const outputEnd = advance(
+    normOutput.output,
+    startToEndCount,
+    filter,
+    outputStart,
+  );
 
-  return [outputStart, outputEnd];
+  const unnormOutputStart =
+    normOutput.reverseOffsets?.[outputStart] ?? outputStart;
+  const unnormOutputEnd = normOutput.reverseOffsets?.[outputEnd] ?? outputEnd;
+
+  return [unnormOutputStart, unnormOutputEnd];
 }

--- a/src/annotator/util/test/normalize-test.js
+++ b/src/annotator/util/test/normalize-test.js
@@ -25,28 +25,47 @@ describe('annotator/util/normalize', () => {
         inMatch: 'bar',
         outMatch: 'b  ar',
       },
-    ].forEach(({ inStr, outStr, inMatch, outMatch }, index) => {
-      it(`returns translated offsets (${index})`, () => {
-        const start = inStr.indexOf(inMatch);
-        assert.notEqual(start, -1, 'Input substring not found');
-        const end = start + inMatch.length;
+      // Strings where positions need to be adjusted between the input and
+      // output to account for differences in Unicode normalization.
+      {
+        inStr: 'a field of gold', // "fi" as latin chars
+        outStr: 'a ﬁeld of gold', // "fi" as a ligature
+        inMatch: 'gold',
+        outMatch: 'gold',
+        normalize: true,
+      },
+      {
+        inStr: 'a ﬁeld of gold', // "fi" as a ligature
+        outStr: 'a field of gold', // "fi" as latin chars
+        inMatch: 'gold',
+        outMatch: 'gold',
+        normalize: true,
+      },
+    ].forEach(
+      ({ inStr, outStr, inMatch, outMatch, normalize = false }, index) => {
+        it(`returns translated offsets (${index})`, () => {
+          const start = inStr.indexOf(inMatch);
+          assert.notEqual(start, -1, 'Input substring not found');
+          const end = start + inMatch.length;
 
-        const expectedStart = outStr.indexOf(outMatch);
-        assert.notEqual(expectedStart, -1, 'Output substring not found');
-        const expectedEnd = expectedStart + outMatch.length;
+          const expectedStart = outStr.indexOf(outMatch);
+          assert.notEqual(expectedStart, -1, 'Output substring not found');
+          const expectedEnd = expectedStart + outMatch.length;
 
-        const [outStart, outEnd] = translateOffsets(
-          inStr,
-          outStr,
-          start,
-          end,
-          isNotSpace,
-        );
+          const [outStart, outEnd] = translateOffsets(
+            inStr,
+            outStr,
+            start,
+            end,
+            isNotSpace,
+            { normalize },
+          );
 
-        assert.equal(outStart, expectedStart, 'Incorrect start offset');
-        assert.equal(outEnd, expectedEnd, 'Incorrect end offset');
-      });
-    });
+          assert.equal(outStart, expectedStart, 'Incorrect start offset');
+          assert.equal(outEnd, expectedEnd, 'Incorrect end offset');
+        });
+      },
+    );
 
     it('returns offsets at end of string if input contains only ignored chars', () => {
       const inStr = '     ';


### PR DESCRIPTION
_This is an alternative to https://github.com/hypothesis/client/pull/7096 which solves the problem in a different way. The upside is that it doesn't modify the text layer at all, and thus avoids potential issues with the text layer becoming misaligned with the canvas underneath. It is also more general, so we may be able to use it for other integrations in future._

---

Handle Unicode normalization differences in `translateOffsets`

In current versions of PDF.js, text extracted from the PDF via the PDF.js APIs
is normalized using a subset of NFKC normalization, as was the case for older
versions of PDF.js, whereas text in the text layer is not. This causes
misalignments if we try to use anchor positions in extracted text to create DOM
ranges that reference positions in the text layer.

We had a `translateOffsets` function which handled this problem for whitespace,
extend it to also handle Unicode normalization. The translation works by
normalizing both input strings before computing the alignment between a range in
the input string and a range in the output string. Once the alignment is
computed the positions are mapped back into positions in the un-normalized
string.

This implementation does some simple caching of the mappings between code points
and decomposed string length (in UTF-16) units. Higher-level caching could be
added in future to avoid re-normalizing the same text layer content more than
once.

See https://github.com/hypothesis/client/issues/6784#issuecomment-2624697567.

---

**Testing:**

1. Go to https://mozilla.github.io/pdf.js/web/viewer.html
2. Activate the production extension and annotate the text "efﬁcient way of incrementally compiling" in the Abstract. Observe that the highlight shifts from what you selected after you click "Annotate"
3. Reload the page and do the same with the dev bookmarklet. Observe that the highlight shifts only to a much smaller degree. The remaining shift is due to the text layer not being perfectly aligned with the visual text on that line, and when you annotate we clip the selection to start and end at the nearest non-whitespace characters.

----

**TODO:**

- [x] Avoid normalization in calls to `translateOffsets` that don't need it
- [x] Measure overhead of normalization and add caching if needed