### PR TITLE
Remove annotation-metadata isPublic helper in favor of permissions isPrivate

### DIFF
--- a/src/sidebar/helpers/annotation-metadata.ts
+++ b/src/sidebar/helpers/annotation-metadata.ts
@@ -148,26 +148,6 @@ export function isNew(annotation: APIAnnotationData): boolean {
 }
 
 /**
- * Return `true` if the given annotation is public, `false` otherwise.
- */
-export function isPublic(annotation: Annotation): boolean {
-  let isPublic = false;
-
-  if (!annotation.permissions) {
-    return isPublic;
-  }
-
-  annotation.permissions.read.forEach(perm => {
-    const readPermArr = perm.split(':');
-    if (readPermArr.length === 2 && readPermArr[0] === 'group') {
-      isPublic = true;
-    }
-  });
-
-  return isPublic;
-}
-
-/**
  * Return `true` if `annotation` has a selector.
  *
  * An annotation which has a selector refers to a specific part of a document,

--- a/src/sidebar/helpers/permissions.ts
+++ b/src/sidebar/helpers/permissions.ts
@@ -81,9 +81,7 @@ export function defaultPermissions(
  * group.
  */
 export function isShared(perms: Permissions): boolean {
-  return perms.read.some(principal => {
-    return principal.indexOf('group:') === 0;
-  });
+  return perms.read.some(principal => principal.startsWith('group:'));
 }
 
 /**

--- a/src/sidebar/helpers/test/annotation-metadata-test.js
+++ b/src/sidebar/helpers/test/annotation-metadata-test.js
@@ -557,34 +557,6 @@ describe('sidebar/helpers/annotation-metadata', () => {
     });
   });
 
-  describe('isPublic', () => {
-    it('returns true if an annotation is shared within a group', () => {
-      assert.isTrue(annotationMetadata.isPublic(fixtures.publicAnnotation()));
-    });
-
-    [
-      {
-        read: ['acct:someemail@localhost'],
-      },
-      {
-        read: ['something invalid'],
-      },
-    ].forEach(testCase => {
-      it('returns false if an annotation is not publicly readable', () => {
-        const annotation = Object.assign(fixtures.defaultAnnotation(), {
-          permissions: testCase,
-        });
-        assert.isFalse(annotationMetadata.isPublic(annotation));
-      });
-    });
-
-    it('returns false if an annotation is missing permissions', () => {
-      const annot = fixtures.defaultAnnotation();
-      delete annot.permissions;
-      assert.isFalse(annotationMetadata.isPublic(annot));
-    });
-  });
-
   describe('isOrphan', () => {
     it('returns true if an annotation failed to anchor', () => {
       const annotation = Object.assign(fixtures.defaultAnnotation(), {

--- a/src/sidebar/services/annotations.ts
+++ b/src/sidebar/services/annotations.ts
@@ -12,6 +12,7 @@ import type { UserItem } from '../helpers/mention-suggestions';
 import { wrapDisplayNameMentions, wrapMentions } from '../helpers/mentions';
 import {
   defaultPermissions,
+  isPrivate,
   privatePermissions,
   sharedPermissions,
 } from '../helpers/permissions';
@@ -181,7 +182,7 @@ export class AnnotationsService {
       this._store.createDraft(annotation, {
         tags: annotation.tags,
         text: annotation.text,
-        isPrivate: !metadata.isPublic(annotation),
+        isPrivate: isPrivate(annotation.permissions),
         description: annotation.target[0]?.description,
       });
     }
@@ -252,7 +253,7 @@ export class AnnotationsService {
   reply(annotation: SavedAnnotation, userid: string) {
     const replyAnnotation = {
       group: annotation.group,
-      permissions: metadata.isPublic(annotation)
+      permissions: !isPrivate(annotation.permissions)
         ? sharedPermissions(userid, annotation.group)
         : privatePermissions(userid),
       references: (annotation.references || []).concat(annotation.id),

--- a/src/sidebar/services/frame-sync.ts
+++ b/src/sidebar/services/frame-sync.ts
@@ -23,11 +23,12 @@ import type {
   SidebarToGuestCalls,
   GuestToSidebarCalls,
 } from '../../types/port-rpc-calls';
-import { isReply, isPublic } from '../helpers/annotation-metadata';
+import { isReply } from '../helpers/annotation-metadata';
 import {
   annotationMatchesSegment,
   segmentMatchesFocusFilters,
 } from '../helpers/annotation-segment';
+import { isPrivate } from '../helpers/permissions';
 import type { SidebarStore } from '../store';
 import type { Frame } from '../store/modules/frames';
 import { watch } from '../util/watch';
@@ -239,7 +240,7 @@ export class FrameSyncService {
           return;
         }
 
-        if (isPublic(annot)) {
+        if (!isPrivate(annot.permissions)) {
           ++publicAnns;
         }
 

--- a/src/sidebar/services/test/annotations-test.js
+++ b/src/sidebar/services/test/annotations-test.js
@@ -13,6 +13,7 @@ describe('AnnotationsService', () => {
   let fakeDefaultPermissions;
   let fakePrivatePermissions;
   let fakeSharedPermissions;
+  let fakeIsPrivate;
 
   let svc;
 
@@ -55,8 +56,9 @@ describe('AnnotationsService', () => {
       isHighlight: sinon.stub(),
       isSaved: sinon.stub(),
       isPageNote: sinon.stub(),
-      isPublic: sinon.stub(),
     };
+
+    fakeIsPrivate = sinon.stub();
 
     fakeSettings = {};
 
@@ -90,6 +92,7 @@ describe('AnnotationsService', () => {
         defaultPermissions: fakeDefaultPermissions,
         privatePermissions: fakePrivatePermissions,
         sharedPermissions: fakeSharedPermissions,
+        isPrivate: fakeIsPrivate,
       },
     });
 
@@ -415,7 +418,7 @@ describe('AnnotationsService', () => {
     });
 
     it('uses public permissions if annotation is public', () => {
-      fakeMetadata.isPublic.returns(true);
+      fakeIsPrivate.returns(false);
       fakeSharedPermissions.returns('public');
 
       const annotation = filledAnnotation();
@@ -427,7 +430,7 @@ describe('AnnotationsService', () => {
     });
 
     it('uses private permissions if annotation is private', () => {
-      fakeMetadata.isPublic.returns(false);
+      fakeIsPrivate.returns(true);
       fakePrivatePermissions.returns('private');
 
       const annotation = filledAnnotation();

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -311,12 +311,14 @@ describe('FrameSyncService', () => {
       const mainFrameAnn = {
         id: 'abc',
         uri: 'https://example.com',
+        permissions: { read: [] },
       };
 
       // Annotation whose URI exactly matches the iframe.
       const iframeAnn = {
         id: 'def',
         uri: 'https://example.com/iframe',
+        permissions: { read: [] },
       };
 
       // Annotation whose URI doesn't match either frame exactly.
@@ -326,6 +328,7 @@ describe('FrameSyncService', () => {
       const unknownFrameAnn = {
         id: 'ghi',
         uri: 'https://example.org',
+        permissions: { read: [] },
       };
 
       // Connect two guests, one representing the main frame and one representing
@@ -365,6 +368,7 @@ describe('FrameSyncService', () => {
       const annotation = {
         id: 'abc',
         uri: 'urn:book-id:1234',
+        permissions: { read: [] },
       };
 
       // Connect a single guest which is not the main/host frame. This simulates
@@ -403,6 +407,7 @@ describe('FrameSyncService', () => {
             ],
           },
         ],
+        permissions: { read: [] },
       };
 
       const chapter2ann = {
@@ -418,6 +423,7 @@ describe('FrameSyncService', () => {
             ],
           },
         ],
+        permissions: { read: [] },
       };
 
       let clock;
@@ -552,7 +558,7 @@ describe('FrameSyncService', () => {
       emitGuestEvent('documentInfoChanged', fixtures.htmlDocumentInfo);
 
       const annot = annotationFixtures.defaultAnnotation();
-      delete annot.permissions;
+      annot.permissions.read = [];
 
       fakeStore.setState({
         annotations: [annot],


### PR DESCRIPTION
While extracting all components and logic involved in rendering annotation cards, I noticed we have some places where checking if an annotation is public was done via `annotation-metadata`'s `isPublic`, while in other places we were using `permissions`' `isPrivate` instead.

I checked the code, and they were mostly equivalent, with the only exception that `isPublic` also checks if the `permissions` object is set, which according with our type definition, is not an option.

This PR removes the `isPublic` function, and changes all places where it was called to now call `!isPrivate(...)` instead.