### PR TITLE
Add focus-visible-ring to valid mention links

### DIFF
--- a/src/styles/sidebar/components/StyledText.scss
+++ b/src/styles/sidebar/components/StyledText.scss
@@ -107,7 +107,7 @@
 
     // Valid processed mention with link
     a[data-hyp-mention-type='link'] {
-      @apply text-brand font-bold underline;
+      @apply text-brand font-bold underline focus-visible-ring;
     }
 
     // Valid processed mention without link


### PR DESCRIPTION
This PR adds a standard focus ring to valid link mentions.

Before the changes:
![image](https://github.com/user-attachments/assets/02d95b6f-7891-40ad-b995-0967ea15ac53)

After the changes:
![Captura desde 2025-06-04 10-58-13](https://github.com/user-attachments/assets/bb69e885-96bd-42c4-8865-804c802d3d39)
