### PR TITLE
Use text-base font size for share link input on all devices

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationShareControl.tsx
+++ b/src/sidebar/components/Annotation/AnnotationShareControl.tsx
@@ -157,13 +157,7 @@ function AnnotationShareControl({
             <h2 className="text-brand text-md font-medium">
               Share this annotation
             </h2>
-            <div
-              className={classnames(
-                // Slightly larger font size for touch devices to correspond with
-                // larger button and input sizes
-                'flex w-full text-xs touch:text-base',
-              )}
-            >
+            <div className="flex w-full text-base">
               <InputGroup>
                 <Input
                   aria-label="Use this URL to share this annotation"


### PR DESCRIPTION
Using the `text-base` font size for the share link input makes the content more readable and aligns the font size with other input fields in the UI.

Before:

<img width="384" alt="Smaller text" src="https://github.com/user-attachments/assets/6c7925e7-e40d-42b6-a6ae-edf7f2bcebec" />

After:

<img width="419" alt="Bigger text" src="https://github.com/user-attachments/assets/3feb6f75-062f-41ea-9660-c0011693ea3b" />
