### PR TITLE
Support searching target descriptions

### DIFF
--- a/src/sidebar/helpers/filter-annotations.ts
+++ b/src/sidebar/helpers/filter-annotations.ts
@@ -6,7 +6,12 @@ import {
 import type { Annotation } from '../../types/api';
 import { pageLabelInRange } from '../util/page-range';
 import * as unicodeUtils from '../util/unicode';
-import { cfi as getCFI, quote, pageLabel } from './annotation-metadata';
+import {
+  cfi as getCFI,
+  description,
+  quote,
+  pageLabel,
+} from './annotation-metadata';
 import type { Facet } from './query-parser';
 
 type Filter = {
@@ -111,7 +116,12 @@ function stringFieldMatcher(
  * Map of field name (from a parsed query) to matcher for that field.
  */
 const fieldMatchers: Record<string, Matcher | Matcher<number>> = {
-  quote: stringFieldMatcher(ann => [quote(ann) ?? '']),
+  quote: stringFieldMatcher(ann => {
+    // The quote field matches "the textual version of what was annotated". This
+    // can mean the text (for text annotations) or a text representation of the
+    // selection.
+    return [quote(ann) ?? description(ann) ?? ''];
+  }),
 
   cfi: {
     fieldValues: ann => [getCFI(ann)?.trim() ?? ''],

--- a/src/sidebar/helpers/test/filter-annotations-test.js
+++ b/src/sidebar/helpers/test/filter-annotations-test.js
@@ -310,6 +310,43 @@ describe('sidebar/helpers/filter-annotations', () => {
     });
   });
 
+  describe('"quote" field', () => {
+    const emptyAnnotation = { id: 42, target: [{}] };
+
+    it('matches target text quote', () => {
+      const annotation = {
+        id: 1,
+        target: [
+          {
+            selector: [
+              {
+                type: 'TextQuoteSelector',
+                exact: 'foobar',
+              },
+            ],
+          },
+        ],
+      };
+      const filters = { quote: { terms: ['foo'], operator: 'or' } };
+      const result = filterAnnotations([annotation, emptyAnnotation], filters);
+      assert.deepEqual(result, [annotation]);
+    });
+
+    it('matches target description', () => {
+      const annotation = {
+        id: 1,
+        target: [
+          {
+            description: 'a widget',
+          },
+        ],
+      };
+      const filters = { quote: { terms: ['widget'], operator: 'or' } };
+      const result = filterAnnotations([annotation, emptyAnnotation], filters);
+      assert.deepEqual(result, [annotation]);
+    });
+  });
+
   it('ignores filters with no terms in the query', () => {
     const annotation = {
       id: 1,


### PR DESCRIPTION
Generalize the "quote" field in searches to refer to "the textual description of what was annotated" and make it search the target description as well as the text quote.

This allows users to search for annotations using the descriptions of thumbnails.

**Testing:**

1. Add a pin or rect annotation and enter a description for the thumbnail
2. Click "search" in the top bar and enter a keyword from the description
3. Press Enter. The annotation from step (1) should match.