### PR TITLE
Use `<img>` rather than `<canvas>` to render thumbnails

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationThumbnail.tsx
+++ b/src/sidebar/components/Annotation/AnnotationThumbnail.tsx
@@ -1,52 +1,7 @@
-import {
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'preact/hooks';
+import { useEffect, useMemo, useState } from 'preact/hooks';
 
 import { withServices } from '../../service-context';
-import type { ThumbnailService } from '../../services/thumbnail';
-
-type BitmapImageProps = {
-  alt: string;
-  bitmap: ImageBitmap;
-  classes?: string;
-  scale?: number;
-};
-
-/** An `<img>`-like component which renders an {@link ImageBitmap}. */
-function BitmapImage({ alt, bitmap, classes, scale = 1.0 }: BitmapImageProps) {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-
-  useLayoutEffect(() => {
-    const ctx = canvasRef.current!.getContext('2d')!;
-    ctx.drawImage(bitmap, 0, 0, bitmap.width, bitmap.height);
-  }, [bitmap]);
-
-  return (
-    <canvas
-      ref={canvasRef}
-      width={bitmap.width}
-      height={bitmap.height}
-      role="img"
-      // The `alt` attribute on an `<img>` maps to aria-label. We might want to
-      // split this into a separate concise label and longer description in
-      // future.
-      aria-label={alt}
-      // Set the title attribute to make it easy to inspect the alt text on
-      // desktop. Screen readers will only read `aria-label` since it has the
-      // same value.
-      title={alt}
-      className={classes}
-      style={{
-        width: `${bitmap.width / scale}px`,
-        height: `${bitmap.height / scale}px`,
-      }}
-    />
-  );
-}
+import type { ThumbnailService, Thumbnail } from '../../services/thumbnail';
 
 export type AnnotationThumbnailProps = {
   tag: string;
@@ -71,7 +26,7 @@ function AnnotationThumbnail({
 }: AnnotationThumbnailProps) {
   // If a cached thumbnail is available then render it immediately, otherwise
   // we'll request one be generated.
-  const [thumbnail, setThumbnail] = useState<ImageBitmap | null>(() =>
+  const [thumbnail, setThumbnail] = useState<Thumbnail | null>(() =>
     thumbnailService.get(tag),
   );
   const [error, setError] = useState<string>();
@@ -103,11 +58,15 @@ function AnnotationThumbnail({
       data-testid="thumbnail-container"
     >
       {thumbnail && (
-        <BitmapImage
+        <img
+          src={thumbnail.url}
           alt={altText}
-          bitmap={thumbnail}
-          classes="border rounded-md"
-          scale={devicePixelRatio}
+          title={altText}
+          className="border rounded-md"
+          style={{
+            width: `${thumbnail.width / devicePixelRatio}px`,
+            height: `${thumbnail.height / devicePixelRatio}px`,
+          }}
         />
       )}
       {!thumbnail && !error && (

--- a/src/sidebar/components/Annotation/test/AnnotationThumbnail-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationThumbnail-test.js
@@ -17,8 +17,7 @@ describe('AnnotationThumbnail', () => {
   };
 
   beforeEach(async () => {
-    const imageData = new ImageData(32, 32);
-    fakeThumbnail = await createImageBitmap(imageData);
+    fakeThumbnail = { url: 'blob:1234', width: 256, height: 256 };
     fakeThumbnailService = {
       get: sinon.stub().returns(null),
       fetch: sinon.stub().resolves(fakeThumbnail),
@@ -27,7 +26,7 @@ describe('AnnotationThumbnail', () => {
 
   it('renders a placeholder if thumbnail is not available', () => {
     const wrapper = createComponent();
-    assert.isFalse(wrapper.exists('BitmapImage'));
+    assert.isFalse(wrapper.exists('img'));
     assert.isTrue(wrapper.exists('[data-testid="placeholder"]'));
   });
 
@@ -35,7 +34,7 @@ describe('AnnotationThumbnail', () => {
     fakeThumbnailService.get.returns(fakeThumbnail);
     const wrapper = createComponent();
     assert.isFalse(wrapper.exists('[data-testid="placeholder"]'));
-    assert.isTrue(wrapper.exists('BitmapImage'));
+    assert.isTrue(wrapper.exists('img'));
   });
 
   [
@@ -58,16 +57,16 @@ describe('AnnotationThumbnail', () => {
     it('sets alt text for thumbnail', () => {
       fakeThumbnailService.get.returns(fakeThumbnail);
       const wrapper = createComponent({ description, textInImage });
-      const image = wrapper.find('canvas');
-      assert.equal(image.prop('aria-label'), expectedAlt);
+      const image = wrapper.find('img');
+      assert.equal(image.prop('alt'), expectedAlt);
     });
   });
 
   it('requests thumbnail and then renders it if not cached', async () => {
     const wrapper = createComponent();
     assert.calledOnce(fakeThumbnailService.fetch);
-    const thumbnail = await waitForElement(wrapper, 'BitmapImage');
-    assert.equal(thumbnail.prop('bitmap'), fakeThumbnail);
+    const thumbnail = await waitForElement(wrapper, 'img');
+    assert.equal(thumbnail.prop('src'), fakeThumbnail.url);
   });
 
   it('renders error indicator if thumbnail rendering failed', async () => {

--- a/src/sidebar/services/test/thumbnail-test.js
+++ b/src/sidebar/services/test/thumbnail-test.js
@@ -22,7 +22,7 @@ describe('ThumbnailService', () => {
     it('returns thumbnail if cached', async () => {
       const svc = createService();
       await svc.fetch('ann123');
-      assert.instanceOf(svc.get('ann123'), ImageBitmap);
+      assert.ok(svc.get('ann123'));
     });
 
     it('moves thumbnail to back of least-recently-used list', async () => {


### PR DESCRIPTION
The decision to use `<canvas>` elements rather than `<img>`s to render thumbnails was motivated by performance (avoids overhead of serializing the thumbnail as a PNG image) and avoiding the need to release thumbnail URLs when no longer used.

However this has a downside of losing various affordances that browsers provide for images such as being able to copy the image from the context menu or select text in them (in Safari). On reflection it seems a better choice to use an `<img>` and preserve these capabilities.

**Testing:**

Thumbnails should look the same as before, but you should now have access to whatever context menu options your browser supports for images. In certain browsers and platforms (eg. macOS Safari) you will also be able to copy OCR-ed text from the image.