### PR TITLE
Make thumbnail info icon visual position correct on touch devices

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationThumbnail.tsx
+++ b/src/sidebar/components/Annotation/AnnotationThumbnail.tsx
@@ -77,7 +77,7 @@ function AnnotationThumbnail({
       {thumbnail && description && (
         <>
           <IconButton
-            classes="absolute top-0 text-[white] text-[16px]"
+            classes="absolute text-[white] text-[16px]"
             variant="custom"
             icon={InfoIcon}
             title="Image description"
@@ -86,7 +86,14 @@ function AnnotationThumbnail({
             elementRef={descriptionButtonRef}
             style={{
               // Position info button towards top-right corner of thumbnail.
-              left: `calc(50% + ${scaledWidth}px / 2 - 32px)`,
+              //
+              // Conceptually we center the button on the top-right corner of
+              // the thumbnail, then offset it by 16px to bring it inside the
+              // thumbnail. The button size changes on touch displays, but the
+              // icon size is fixed.
+              left: `calc(50% + ${scaledWidth}px / 2 - 16px)`,
+              top: '16px',
+              transform: 'translateX(-50%) translateY(-50%)',
               // Add a drop shadow to make the white icon visible on thumbnails
               // that have a light background.
               filter: 'drop-shadow(grey 1px 1px 1px)',


### PR DESCRIPTION
The button size is larger on touch devices to increase the tap area size. Adjust the positioning so that the visual position of the icon is the same on touch/non-touch.

**Testing:**

In Chrome compare the position of the info icon on thumbnails with and without responsive design mode active. It should be the same in both cases, although the button is larger on mobile (44 vs 32px).