### PR TITLE
Add annotation-ui to tailwind content config

### DIFF
--- a/tailwind-annotator.config.js
+++ b/tailwind-annotator.config.js
@@ -5,6 +5,7 @@ export default {
   content: [
     './src/annotator/components/**/*.{js,ts,tsx}',
     './src/shared/components/**/*.{js,ts,tsx}',
+    './node_modules/@hypothesis/annotation-ui/lib/**/*.{js,ts,tsx}',
     './node_modules/@hypothesis/frontend-shared/lib/**/*.{js,ts,tsx}',
     // This module references `sidebar-frame` and related classes
     './src/annotator/sidebar.{js,ts,tsx}',

--- a/tailwind-sidebar.config.js
+++ b/tailwind-sidebar.config.js
@@ -6,6 +6,7 @@ export default {
     './src/sidebar/components/**/*.{js,ts,tsx}',
     './src/shared/components/**/*.{js,ts,tsx}',
     './dev-server/ui-playground/components/**/*.{js,ts,tsx}',
+    './node_modules/@hypothesis/annotation-ui/lib/**/*.{js,ts,tsx}',
     './node_modules/@hypothesis/frontend-shared/lib/**/*.{js,ts,tsx}',
   ],
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,6 +9,7 @@ export default {
     './src/sidebar/components/**/*.{js,ts,tsx}',
     './src/annotator/components/**/*.{js,ts,tsx}',
     './dev-server/ui-playground/components/**/*.{js,ts,tsx}',
+    './node_modules/@hypothesis/annotation-ui/lib/**/*.{js,ts,tsx}',
     './node_modules/@hypothesis/frontend-shared/lib/**/*.{js,ts,tsx}',
     // This module references `sidebar-frame` and related classes
     './src/annotator/sidebar.{js,ts,tsx}',


### PR DESCRIPTION
Make sure the `@hypothesis/annotation-ui` library is scanned for tailwind classes.

This was overlooked in https://github.com/hypothesis/client/pull/7151, because most classes from the library worked since they were already used in other places of the project. 