### PR TITLE
Revert addition of annotation-ui lib in annotator tailwind config

### DIFF
--- a/tailwind-annotator.config.js
+++ b/tailwind-annotator.config.js
@@ -5,7 +5,6 @@ export default {
   content: [
     './src/annotator/components/**/*.{js,ts,tsx}',
     './src/shared/components/**/*.{js,ts,tsx}',
-    './node_modules/@hypothesis/annotation-ui/lib/**/*.{js,ts,tsx}',
     './node_modules/@hypothesis/frontend-shared/lib/**/*.{js,ts,tsx}',
     // This module references `sidebar-frame` and related classes
     './src/annotator/sidebar.{js,ts,tsx}',


### PR DESCRIPTION
This reverts one of the changes introduced in https://github.com/hypothesis/client/pull/7152, specifically the scanning of the annotation-ui library for tailwind classes when generating the annotator styles.

This is not needed, as the annotation-ui lib is only used for the sidebar.