### PR TITLE
Rename AnnotationThumbnailDescription => ThumbnailDescriptionInput

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationEditor.tsx
+++ b/src/sidebar/components/Annotation/AnnotationEditor.tsx
@@ -32,7 +32,7 @@ import TagEditor from '../TagEditor';
 import { useUnsavedChanges } from '../hooks/unsaved-changes';
 import AnnotationLicense from './AnnotationLicense';
 import AnnotationPublishControl from './AnnotationPublishControl';
-import AnnotationThumbnailDescription from './AnnotationThumbnailDescription';
+import ThumbnailDescriptionInput from './ThumbnailDescriptionInput';
 
 type AnnotationEditorProps = {
   /** The annotation under edit */
@@ -287,7 +287,7 @@ function AnnotationEditor({
       onKeyDown={onKeyDown}
     >
       {showDescription && (
-        <AnnotationThumbnailDescription
+        <ThumbnailDescriptionInput
           description={description ?? ''}
           onEdit={onEditDescription}
         />

--- a/src/sidebar/components/Annotation/ThumbnailDescriptionInput.tsx
+++ b/src/sidebar/components/Annotation/ThumbnailDescriptionInput.tsx
@@ -8,15 +8,15 @@ import {
 import classnames from 'classnames';
 import { useState, useRef } from 'preact/hooks';
 
-export type AnnotationThumbnailDescriptionProps = {
+export type ThumbnailDescriptionInputProps = {
   description: string;
   onEdit: (description: string) => void;
 };
 
-export default function AnnotationThumbnailDescription({
+export default function ThumbnailDescriptionInput({
   description,
   onEdit,
-}: AnnotationThumbnailDescriptionProps) {
+}: ThumbnailDescriptionInputProps) {
   const [popoverOpen, setPopoverOpen] = useState(false);
   const iconRef = useRef<HTMLButtonElement | null>(null);
 

--- a/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
@@ -188,8 +188,7 @@ describe('AnnotationEditor', () => {
   });
 
   describe('editing target descriptions', () => {
-    const getDescription = wrapper =>
-      wrapper.find('AnnotationThumbnailDescription');
+    const getDescription = wrapper => wrapper.find('ThumbnailDescriptionInput');
 
     beforeEach(() => {
       fakeStore.isFeatureEnabled.withArgs('image_descriptions').returns(true);
@@ -209,7 +208,7 @@ describe('AnnotationEditor', () => {
         ],
       });
       const wrapper = createComponent({ annotation });
-      wrapper.find('AnnotationThumbnailDescription').prop('onEdit')(
+      wrapper.find('ThumbnailDescriptionInput').prop('onEdit')(
         'new-description',
       );
 

--- a/src/sidebar/components/Annotation/test/ThumbnailDescriptionInput-test.js
+++ b/src/sidebar/components/Annotation/test/ThumbnailDescriptionInput-test.js
@@ -1,11 +1,11 @@
 import { mount } from '@hypothesis/frontend-testing';
 
-import AnnotationThumbnailDescription from '../AnnotationThumbnailDescription';
+import ThumbnailDescriptionInput from '../ThumbnailDescriptionInput';
 
-describe('AnnotationThumbnailDescription', () => {
+describe('ThumbnailDescriptionInput', () => {
   it('displays current description', () => {
     const wrapper = mount(
-      <AnnotationThumbnailDescription description="foo bar" />,
+      <ThumbnailDescriptionInput description="foo bar" />,
       // Needed for popover to work
       { connected: true },
     );
@@ -15,7 +15,7 @@ describe('AnnotationThumbnailDescription', () => {
   it('invokes `onEdit` when description is changed', () => {
     const onEdit = sinon.stub();
     const wrapper = mount(
-      <AnnotationThumbnailDescription description="foo bar" onEdit={onEdit} />,
+      <ThumbnailDescriptionInput description="foo bar" onEdit={onEdit} />,
       { connected: true },
     );
     const input = wrapper.find('input');
@@ -27,10 +27,9 @@ describe('AnnotationThumbnailDescription', () => {
   });
 
   it('displays alt-text info popover when info button is clicked', () => {
-    const wrapper = mount(
-      <AnnotationThumbnailDescription description="foo bar" />,
-      { connected: true },
-    );
+    const wrapper = mount(<ThumbnailDescriptionInput description="foo bar" />, {
+      connected: true,
+    });
     assert.isFalse(wrapper.find('Popover').prop('open'));
 
     wrapper.find('button').simulate('click');


### PR DESCRIPTION
Make it clear that this component is for editing the description, not displaying it when an annotation is not being edited.