### PR TITLE
Show thumbnail description as visible text

### DIFF
--- a/src/sidebar/components/Annotation/Annotation.tsx
+++ b/src/sidebar/components/Annotation/Annotation.tsx
@@ -132,6 +132,8 @@ function Annotation({
           tag={annotation.$tag}
           textInImage={targetShape.text}
           description={targetDescription}
+          // Don't show the description when it is also visible in an input field.
+          showDescription={!isEditing}
         />
       )}
       {annotationQuote && (

--- a/src/sidebar/components/Annotation/AnnotationThumbnail.tsx
+++ b/src/sidebar/components/Annotation/AnnotationThumbnail.tsx
@@ -1,8 +1,9 @@
-import { IconButton, InfoIcon, Popover } from '@hypothesis/frontend-shared';
-import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { StyledText } from '@hypothesis/annotation-ui';
+import { useEffect, useMemo, useState, useId } from 'preact/hooks';
 
 import { withServices } from '../../service-context';
 import type { ThumbnailService, Thumbnail } from '../../services/thumbnail';
+import Excerpt from '../Excerpt';
 
 export type AnnotationThumbnailProps = {
   tag: string;
@@ -15,8 +16,17 @@ export type AnnotationThumbnailProps = {
    */
   textInImage?: string;
 
-  /** Description of the thumbnail. */
+  /**
+   * Description of the thumbnail, used as alt text.
+   */
   description?: string;
+
+  /**
+   * Whether to show the description as visible text.
+   *
+   * Defaults to true. When false the description is still used as alt text.
+   */
+  showDescription?: boolean;
 };
 
 function AnnotationThumbnail({
@@ -24,6 +34,7 @@ function AnnotationThumbnail({
   textInImage,
   tag,
   thumbnailService,
+  showDescription = true,
 }: AnnotationThumbnailProps) {
   // If a cached thumbnail is available then render it immediately, otherwise
   // we'll request one be generated.
@@ -31,8 +42,6 @@ function AnnotationThumbnail({
     thumbnailService.get(tag),
   );
   const [error, setError] = useState<string>();
-  const [popoverOpen, setPopoverOpen] = useState(false);
-  const descriptionButtonRef = useRef();
 
   const devicePixelRatio = useMemo(() => window.devicePixelRatio, []);
   const maxWidth = 196;
@@ -48,77 +57,59 @@ function AnnotationThumbnail({
 
   let altText;
   if (description) {
-    altText = `Thumbnail. ${description}`;
+    altText = description;
   } else if (textInImage) {
-    altText = `Thumbnail. Contains text: ${textInImage}`;
-  } else {
-    altText = 'Thumbnail';
+    altText = textInImage;
   }
 
   const scaledWidth = thumbnail ? thumbnail.width / devicePixelRatio : 0;
   const scaledHeight = thumbnail ? thumbnail.height / devicePixelRatio : 0;
 
+  const altId = useId();
+
   return (
-    <div
-      className="flex flex-row justify-center relative"
-      data-testid="thumbnail-container"
-    >
-      {thumbnail && (
-        <img
-          src={thumbnail.url}
-          alt={altText}
-          className="border rounded-md"
-          style={{
-            width: `${scaledWidth}px`,
-            height: `${scaledHeight}px`,
-          }}
-        />
-      )}
-      {thumbnail && description && (
-        <>
-          <IconButton
-            classes="absolute text-[white] text-[16px]"
-            variant="custom"
-            icon={InfoIcon}
-            title="Image description"
-            onClick={() => setPopoverOpen(true)}
-            expanded={popoverOpen}
-            elementRef={descriptionButtonRef}
+    <>
+      <div
+        className="flex flex-row justify-center relative"
+        data-testid="thumbnail-container"
+      >
+        {thumbnail && (
+          <img
+            src={thumbnail.url}
+            alt={altText}
+            className="border rounded-md"
             style={{
-              // Position info button towards top-right corner of thumbnail.
-              //
-              // Conceptually we center the button on the top-right corner of
-              // the thumbnail, then offset it by 16px to bring it inside the
-              // thumbnail. The button size changes on touch displays, but the
-              // icon size is fixed.
-              left: `calc(50% + ${scaledWidth}px / 2 - 16px)`,
-              top: '16px',
-              transform: 'translateX(-50%) translateY(-50%)',
-              // Add a drop shadow to make the white icon visible on thumbnails
-              // that have a light background.
-              filter: 'drop-shadow(grey 1px 1px 1px)',
+              width: `${scaledWidth}px`,
+              height: `${scaledHeight}px`,
             }}
           />
-          <Popover
-            open={popoverOpen}
-            align="right"
-            anchorElementRef={descriptionButtonRef}
-            onClose={() => setPopoverOpen(false)}
-            classes="p-2"
+        )}
+        {!thumbnail && !error && (
+          // TODO - Adjust size here so it matches the thumbnail after it has
+          // finished loading.
+          <span data-testid="placeholder">Loading thumbnail...</span>
+        )}
+        {!thumbnail && error && (
+          <span data-testid="error">Unable to render thumbnail: {error}</span>
+        )}
+      </div>
+
+      {thumbnail && altText && showDescription && (
+        <Excerpt
+          // Two lines of text
+          collapsedHeight={35}
+          inlineControls={true}
+        >
+          <StyledText
+            // Hide this text from screen readers because it duplicates the thumbnail's
+            // `alt` attribute, and we don't want them to read the text twice.
+            aria-hidden="true"
           >
-            {description}
-          </Popover>
-        </>
+            <blockquote id={altId}>{altText}</blockquote>
+          </StyledText>
+        </Excerpt>
       )}
-      {!thumbnail && !error && (
-        // TODO - Adjust size here so it matches the thumbnail after it has
-        // finished loading.
-        <span data-testid="placeholder">Loading thumbnail...</span>
-      )}
-      {!thumbnail && error && (
-        <span data-testid="error">Unable to render thumbnail: {error}</span>
-      )}
-    </div>
+    </>
   );
 }
 

--- a/src/sidebar/components/Annotation/test/Annotation-test.js
+++ b/src/sidebar/components/Annotation/test/Annotation-test.js
@@ -167,6 +167,30 @@ describe('Annotation', () => {
       assert.equal(thumbnail.prop('tag'), annotation.$tag);
       assert.equal(thumbnail.prop('description'), 'This is a thing');
       assert.equal(thumbnail.prop('textInImage'), 'Some text');
+      assert.equal(thumbnail.prop('showDescription'), true);
+    });
+
+    it('hides thumbnail description when editing', () => {
+      setEditingMode(true);
+      const annotation = fixtures.defaultAnnotation();
+      annotation.target[0].description = 'This is a thing';
+      annotation.target[0].selector = [
+        {
+          type: 'ShapeSelector',
+          shape: {
+            type: 'rect',
+            left: 0,
+            top: 10,
+            right: 10,
+            bottom: 0,
+          },
+          text: 'Some text',
+        },
+      ];
+      const wrapper = createComponent({ annotation });
+      const thumbnail = wrapper.find('AnnotationThumbnail');
+      assert.isTrue(thumbnail.exists());
+      assert.isFalse(thumbnail.prop('showDescription'));
     });
   });
 


### PR DESCRIPTION
Update the display of the thumbnail description to match Figma mocks [^1] by
showing the thumbnail description as visible text. To avoid showing the
description twice, hide it when editing the annotation and also hide the
visible description from screen readers, since it duplicate's the image's `alt`
attribute.

The "Thumbnail" prefix was removed from the alt text because it looks odd in
visible text. Also it is recommended that alt text not start with phrases like
"Image of ...".

Co-Authored-By: Claude <noreply@anthropic.com>

[^1]: https://www.figma.com/design/uMbwJESeY0KozS6CY1yzuk/Hypothesis---Image-Annotation?node-id=697-442&p=f&t=NcJnlvRivFGzF7Ik-0