### PR TITLE
Replace AnnotationShareControl with annotation-ui one

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@babel/preset-env": "^7.1.6",
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.16.7",
-    "@hypothesis/annotation-ui": "^0.2.0",
+    "@hypothesis/annotation-ui": "^0.3.0",
     "@hypothesis/frontend-build": "^4.0.0",
     "@hypothesis/frontend-shared": "^9.5.1",
     "@hypothesis/frontend-testing": "^1.7.1",

--- a/src/sidebar/components/Annotation/AnnotationActionBar.tsx
+++ b/src/sidebar/components/Annotation/AnnotationActionBar.tsx
@@ -12,10 +12,6 @@ import type { SavedAnnotation } from '../../../types/api';
 import type { SidebarSettings } from '../../../types/config';
 import { serviceConfig } from '../../config/service-config';
 import { annotationRole } from '../../helpers/annotation-metadata';
-import {
-  sharingEnabled,
-  annotationSharingLink,
-} from '../../helpers/annotation-sharing';
 import { isPrivate, permits } from '../../helpers/permissions';
 import { withServices } from '../../service-context';
 import type { AnnotationsService } from '../../services/annotations';
@@ -72,9 +68,6 @@ function AnnotationActionBar({
     !!userProfile.userid &&
     userProfile.userid !== annotation.user;
 
-  const shareLink =
-    sharingEnabled(settings) && annotationSharingLink(annotation);
-
   const onDelete = async () => {
     const annType = annotationRole(annotation);
     if (
@@ -125,9 +118,7 @@ function AnnotationActionBar({
         <IconButton icon={TrashIcon} title="Delete" onClick={onDelete} />
       )}
       <IconButton icon={ReplyIcon} title="Reply" onClick={onReplyClick} />
-      {shareLink && (
-        <AnnotationShareControl annotation={annotation} shareUri={shareLink} />
-      )}
+      <AnnotationShareControl annotation={annotation} />
       {showFlagAction && !annotation.flagged && (
         <IconButton
           icon={FlagIcon}

--- a/src/sidebar/components/Annotation/AnnotationShareControl.tsx
+++ b/src/sidebar/components/Annotation/AnnotationShareControl.tsx
@@ -1,171 +1,46 @@
-import {
-  CopyIcon,
-  IconButton,
-  Input,
-  InputGroup,
-  Popover,
-  ShareIcon,
-} from '@hypothesis/frontend-shared';
-import classnames from 'classnames';
-import { useEffect, useRef, useState } from 'preact/hooks';
+import { AnnotationShareControl as BaseAnnotationShareControl } from '@hypothesis/annotation-ui';
+import { useCallback } from 'preact/hooks';
 
-import { isIOS } from '../../../shared/user-agent';
 import type { Annotation } from '../../../types/api';
-import { isShareableURI } from '../../helpers/annotation-sharing';
-import { isPrivate } from '../../helpers/permissions';
 import { withServices } from '../../service-context';
 import type { ToastMessengerService } from '../../services/toast-messenger';
 import { useSidebarStore } from '../../store';
-import { copyPlainText } from '../../util/copy-to-clipboard';
 
 export type AnnotationShareControlProps = {
-  /** The annotation in question */
   annotation: Annotation;
-
-  /** The URI to view the annotation on its own */
-  shareUri: string;
 
   // Injected
   toastMessenger: ToastMessengerService;
 };
 
-function selectionOverflowsInputElement() {
-  // On iOS the selection overflows the input element
-  // See: https://github.com/hypothesis/client/pull/2799
-  return isIOS();
-}
-
 /**
  * "Popup"-style component for sharing a single annotation.
- *
- * @param {AnnotationShareControlProps} props
  */
 function AnnotationShareControl({
   annotation,
   toastMessenger,
-  shareUri,
 }: AnnotationShareControlProps) {
   const store = useSidebarStore();
   const group = store.getGroup(annotation.group);
 
-  const annotationIsPrivate = isPrivate(annotation.permissions);
-  const inContextAvailable = isShareableURI(annotation.uri);
-  const inputRef = useRef<HTMLInputElement | null>(null);
-  const shareRef = useRef<HTMLDivElement | null>(null);
-
-  const [isOpen, setOpen] = useState(false);
-  const wasOpen = useRef(isOpen);
-
-  const toggleSharePanel = () => setOpen(!isOpen);
-  const closePanel = () => setOpen(false);
-
-  useEffect(() => {
-    if (wasOpen.current !== isOpen) {
-      wasOpen.current = isOpen;
-
-      if (isOpen && !selectionOverflowsInputElement()) {
-        // Panel was just opened: select and focus the share URI for convenience
-        inputRef.current?.focus();
-        inputRef.current?.select();
+  const copyShareLink = useCallback(
+    async (result: { ok: boolean }) => {
+      if (result.ok) {
+        toastMessenger.success('Copied share link to clipboard');
+      } else {
+        toastMessenger.error('Unable to copy link');
       }
-    }
-  }, [isOpen]);
-
-  if (!group) {
-    // This can happen if groups have just been unloaded but annotations have
-    // not yet been unloaded, e.g. on logout if a private group was focused
-    return null;
-  }
-
-  const copyShareLink = async () => {
-    try {
-      await copyPlainText(shareUri);
-      toastMessenger.success('Copied share link to clipboard');
-    } catch {
-      toastMessenger.error('Unable to copy link');
-    }
-  };
-
-  // Generate some descriptive text about who may see the annotation if they
-  // follow the share link.
-  // First: Based on the type of the group the annotation is in, who would
-  // be able to view it?
-  const groupSharingInfo =
-    group.type === 'private' ? (
-      <span>
-        Only members of the group <em>{group.name}</em> may view this
-        annotation.
-      </span>
-    ) : (
-      <span>Anyone using this link may view this annotation.</span>
-    );
-
-  // However, if the annotation is marked as "only me" (`annotationIsPrivate` is `true`),
-  // then group sharing settings are irrelevant—only the author may view the
-  // annotation.
-  const annotationSharingInfo = annotationIsPrivate ? (
-    <span>Only you may view this annotation.</span>
-  ) : (
-    groupSharingInfo
+    },
+    [toastMessenger],
   );
 
   return (
-    <div className="relative" ref={shareRef}>
-      <IconButton
-        icon={ShareIcon}
-        title="Share"
-        onClick={toggleSharePanel}
-        expanded={isOpen}
-      />
-      <Popover
-        open={isOpen}
-        onClose={closePanel}
-        anchorElementRef={shareRef}
-        align="right"
-        placement="above"
-        arrow
-        classes={classnames({
-          // Set explicit width for browsers not supporting native popover API
-          'w-max':
-            // eslint-disable-next-line no-prototype-builtins
-            !HTMLElement.prototype.hasOwnProperty('popover'),
-        })}
-      >
-        <div className="p-2 flex flex-col gap-y-2">
-          <h2 className="text-brand text-md font-medium">
-            Share this annotation
-          </h2>
-          <div className="flex w-full text-base">
-            <InputGroup>
-              <Input
-                aria-label="Use this URL to share this annotation"
-                type="text"
-                value={shareUri}
-                readOnly
-                elementRef={inputRef}
-              />
-              <IconButton
-                icon={CopyIcon}
-                title="Copy share link to clipboard"
-                onClick={copyShareLink}
-                variant="dark"
-              />
-            </InputGroup>
-          </div>
-          <div className="text-base font-normal" data-testid="share-details">
-            {inContextAvailable ? (
-              <>{annotationSharingInfo}</>
-            ) : (
-              <>
-                This annotation cannot be shared in its original context because
-                it was made on a document that is not available on the web. This
-                link shares the annotation by itself.
-              </>
-            )}
-          </div>
-        </div>
-      </Popover>
-    </div>
+    <BaseAnnotationShareControl
+      annotation={annotation}
+      group={group ?? null}
+      onCopy={copyShareLink}
+      data-testid="base-share-control"
+    />
   );
 }
 

--- a/src/sidebar/components/Annotation/test/AnnotationActionBar-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationActionBar-test.js
@@ -21,8 +21,6 @@ describe('AnnotationActionBar', () => {
   let fakePermits;
   let fakeSettings;
   // Fake dependencies
-  let fakeAnnotationSharingLink;
-  let fakeSharingEnabled;
   let fakeStore;
 
   function createComponent(props = {}) {
@@ -78,9 +76,6 @@ describe('AnnotationActionBar', () => {
     fakePermits = sinon.stub().returns(true);
     fakeSettings = {};
 
-    fakeSharingEnabled = sinon.stub().returns(true);
-    fakeAnnotationSharingLink = sinon.stub().returns('http://share.me');
-
     fakeStore = {
       createDraft: sinon.stub(),
       isLoggedIn: sinon.stub(),
@@ -93,10 +88,6 @@ describe('AnnotationActionBar', () => {
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       '@hypothesis/frontend-shared': { confirm: fakeConfirm },
-      '../../helpers/annotation-sharing': {
-        sharingEnabled: fakeSharingEnabled,
-        annotationSharingLink: fakeAnnotationSharingLink,
-      },
       '../../helpers/permissions': { permits: fakePermits },
       '../../store': { useSidebarStore: () => fakeStore },
     });
@@ -249,24 +240,12 @@ describe('AnnotationActionBar', () => {
   });
 
   describe('share action button', () => {
-    it('shows share action button if annotation is shareable', () => {
+    it('forwards annotation to AnnotationShareControl', () => {
       const wrapper = createComponent();
-
-      assert.isTrue(wrapper.find('AnnotationShareControl').exists());
-    });
-
-    it('does not show share action button if sharing is not enabled', () => {
-      fakeSharingEnabled.returns(false);
-      const wrapper = createComponent();
-
-      assert.isFalse(wrapper.find('AnnotationShareControl').exists());
-    });
-
-    it('does not show share action button if annotation lacks sharing URI', () => {
-      fakeAnnotationSharingLink.returns(undefined);
-      const wrapper = createComponent();
-
-      assert.isFalse(wrapper.find('AnnotationShareControl').exists());
+      assert.equal(
+        wrapper.find('AnnotationShareControl').prop('annotation'),
+        fakeAnnotation,
+      );
     });
   });
 

--- a/src/sidebar/components/Annotation/test/AnnotationShareControl-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationShareControl-test.js
@@ -1,66 +1,30 @@
-import {
-  checkAccessibility,
-  mockImportedComponents,
-} from '@hypothesis/frontend-testing';
+import { mockImportedComponents } from '@hypothesis/frontend-testing';
 import { mount } from '@hypothesis/frontend-testing';
-import { act } from 'preact/test-utils';
 
 import AnnotationShareControl, { $imports } from '../AnnotationShareControl';
 
 describe('AnnotationShareControl', () => {
   let fakeAnnotation;
-  let fakeCopyToClipboard;
   let fakeToastMessenger;
   let fakeGroup;
-  let fakeIsPrivate;
-  let fakeIsShareableURI;
-  let fakeShareUri;
-  let fakeIsIOS;
   let fakeStore;
-
-  const getIconButton = (wrapper, iconName) => {
-    return wrapper
-      .find('IconButton')
-      .filterWhere(n => n.find(iconName).exists());
-  };
 
   function createComponent(props = {}) {
     return mount(
       <AnnotationShareControl
         annotation={fakeAnnotation}
         toastMessenger={fakeToastMessenger}
-        shareUri={fakeShareUri}
         {...props}
       />,
       { connected: true },
     );
   }
 
-  function openElement(wrapper) {
-    act(() => {
-      wrapper.find('IconButton').props().onClick();
-    });
-    wrapper.update();
-  }
-
-  function isLinkInputFocused() {
-    return (
-      document.activeElement.getAttribute('aria-label') ===
-      'Use this URL to share this annotation'
-    );
-  }
-
   beforeEach(() => {
     fakeAnnotation = {
       group: 'fakegroup',
-      permissions: {},
-      user: 'acct:bar@foo.com',
-      uri: 'http://www.example.com',
     };
 
-    fakeCopyToClipboard = {
-      copyPlainText: sinon.stub(),
-    };
     fakeToastMessenger = {
       success: sinon.stub(),
       error: sinon.stub(),
@@ -69,10 +33,6 @@ describe('AnnotationShareControl', () => {
       name: 'My Group',
       type: 'private',
     };
-    fakeIsPrivate = sinon.stub().returns(false);
-    fakeIsShareableURI = sinon.stub().returns(true);
-    fakeShareUri = 'https://www.example.com';
-    fakeIsIOS = sinon.stub().returns(false);
 
     fakeStore = {
       getGroup: sinon.stub().returns(fakeGroup),
@@ -80,13 +40,10 @@ describe('AnnotationShareControl', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
-      '../../helpers/annotation-sharing': {
-        isShareableURI: fakeIsShareableURI,
-      },
-      '../../util/copy-to-clipboard': fakeCopyToClipboard,
-      '../../helpers/permissions': { isPrivate: fakeIsPrivate },
       '../../store': { useSidebarStore: () => fakeStore },
-      '../../../shared/user-agent': { isIOS: fakeIsIOS },
+      '@hypothesis/annotation-ui': {
+        AnnotationShareControl: () => null,
+      },
     });
   });
 
@@ -94,58 +51,22 @@ describe('AnnotationShareControl', () => {
     $imports.$restore();
   });
 
-  it('does not render component if annotation group is not available', () => {
-    fakeStore.getGroup.returns(undefined);
-    const wrapper = createComponent();
-    assert.equal(wrapper.html(), '');
-  });
+  const baseShareControl = wrapper =>
+    wrapper.find('[data-testid="base-share-control"]');
 
-  it('does not render content when not open', () => {
-    const wrapper = createComponent();
+  [fakeGroup, undefined].forEach(group => {
+    it('passes group from sidebar store to base share control', () => {
+      fakeStore.getGroup.returns(group);
+      const wrapper = createComponent();
 
-    // Component is not `open` initially
-    assert.isFalse(wrapper.find('Card').exists());
-  });
-
-  it('toggles the share control element when the button is clicked', () => {
-    const wrapper = createComponent();
-    const button = getIconButton(wrapper, 'ShareIcon');
-
-    act(() => {
-      button.props().onClick();
+      assert.equal(baseShareControl(wrapper).prop('group'), group ?? null);
     });
-    wrapper.update();
-
-    assert.isTrue(wrapper.find('Popover').prop('open'));
-  });
-
-  it('renders the share URI in a readonly input field', () => {
-    const wrapper = createComponent();
-    openElement(wrapper);
-
-    const inputEl = wrapper.find('input');
-    assert.equal(inputEl.prop('value'), fakeShareUri);
-    assert.isTrue(inputEl.prop('readOnly'));
   });
 
   describe('copying the share URI to the clipboard', () => {
-    it('copies the share link to the clipboard when the copy button is clicked', () => {
-      const wrapper = createComponent();
-      openElement(wrapper);
-
-      getIconButton(wrapper, 'CopyIcon').props().onClick();
-
-      assert.calledWith(
-        fakeCopyToClipboard.copyPlainText,
-        'https://www.example.com',
-      );
-    });
-
     it('confirms link copy when successful', async () => {
       const wrapper = createComponent();
-      openElement(wrapper);
-
-      await getIconButton(wrapper, 'CopyIcon').props().onClick();
+      baseShareControl(wrapper).props().onCopy({ ok: true });
 
       assert.calledWith(
         fakeToastMessenger.success,
@@ -154,94 +75,10 @@ describe('AnnotationShareControl', () => {
     });
 
     it('flashes an error if link copying unsuccessful', () => {
-      fakeCopyToClipboard.copyPlainText.throws();
       const wrapper = createComponent();
-      openElement(wrapper);
-
-      getIconButton(wrapper, 'CopyIcon').props().onClick();
+      baseShareControl(wrapper).props().onCopy({ ok: false });
 
       assert.calledWith(fakeToastMessenger.error, 'Unable to copy link');
     });
   });
-
-  [
-    {
-      groupType: 'private',
-      isPrivate: false,
-      expected: 'Only members of the group My Group may view this annotation.',
-    },
-    {
-      groupType: 'open',
-      isPrivate: false,
-      expected: 'Anyone using this link may view this annotation.',
-    },
-    {
-      groupType: 'private',
-      isPrivate: true,
-      expected: 'Only you may view this annotation.',
-    },
-    {
-      groupType: 'open',
-      isPrivate: true,
-      expected: 'Only you may view this annotation.',
-    },
-  ].forEach(testcase => {
-    it(`renders the correct sharing information for a ${testcase.groupType} group when annotation privacy is ${testcase.isPrivate}`, () => {
-      fakeIsPrivate.returns(testcase.isPrivate);
-      fakeGroup.type = testcase.groupType;
-      const wrapper = createComponent({ isPrivate: testcase.isPrivate });
-      openElement(wrapper);
-
-      const permissionsEl = wrapper.find('[data-testid="share-details"]');
-      assert.equal(permissionsEl.text(), testcase.expected);
-    });
-  });
-
-  it('renders an explanation if annotation cannot be shared in context', () => {
-    fakeIsShareableURI.returns(false);
-    const wrapper = createComponent();
-    openElement(wrapper);
-
-    const detailsEl = wrapper.find('[data-testid="share-details"]');
-    assert.include(
-      detailsEl.text(),
-      'This annotation cannot be shared in its original context',
-    );
-  });
-
-  it('focuses the share-URI input when opened on non-iOS', () => {
-    const wrapper = createComponent();
-    openElement(wrapper);
-    wrapper.update();
-
-    assert.isTrue(isLinkInputFocused());
-  });
-
-  it("doesn't focuses the share-URI input when opened on iOS", () => {
-    fakeIsIOS.returns(true);
-    const wrapper = createComponent();
-    openElement(wrapper);
-    wrapper.update();
-
-    assert.isFalse(isLinkInputFocused());
-  });
-
-  it(
-    'should pass a11y checks',
-    checkAccessibility(
-      {
-        name: 'when closed',
-        content: () => createComponent(),
-      },
-      {
-        name: 'when open',
-        content: () => {
-          const wrapper = createComponent();
-          openElement(wrapper);
-          wrapper.update();
-          return wrapper;
-        },
-      },
-    ),
-  );
 });

--- a/src/sidebar/helpers/annotation-sharing.ts
+++ b/src/sidebar/helpers/annotation-sharing.ts
@@ -1,28 +1,3 @@
-import type { Annotation } from '../../types/api';
-import type { SidebarSettings } from '../../types/config';
-import { serviceConfig } from '../config/service-config';
-
-/**
- * Retrieve an appropriate sharing link for this annotation.
- *
- * If the annotation is on a shareable document (i.e. its document is
- * web-accessible), prefer the `incontext` (bouncer) link, but fallback to the
- * `html` (single-annotation `h` web view) link if needed.
- *
- * If the annotation is not on a shareable document, don't use the `incontext`
- * link as that won't work; only use the single-annotation-view `html` link.
- *
- * Note that `html` links are not provided by the service for third-party
- * annotations.
- */
-export function annotationSharingLink(annotation: Annotation): string | null {
-  if (isShareableURI(annotation.uri)) {
-    return annotation.links?.incontext ?? annotation.links?.html ?? null;
-  } else {
-    return annotation.links?.html ?? null;
-  }
-}
-
 /**
  * Generate a URI for sharing: a bouncer link built to share annotations in
  * a specific group (groupID) on a specific document (documentURI). If the
@@ -47,13 +22,4 @@ export function pageSharingLink(
  */
 export function isShareableURI(uri: string): boolean {
   return /^http(s?):/i.test(uri);
-}
-
-/**
- * Is the sharing of annotations enabled? Check for any defined `serviceConfig`,
- * but default to `true` if none found.
- */
-export function sharingEnabled(settings: SidebarSettings): boolean {
-  const service = serviceConfig(settings);
-  return service?.enableShareLinks !== false;
 }

--- a/src/sidebar/helpers/test/annotation-sharing-test.js
+++ b/src/sidebar/helpers/test/annotation-sharing-test.js
@@ -1,88 +1,6 @@
 import * as sharingUtil from '../annotation-sharing';
 
 describe('sidebar/helpers/annotation-sharing', () => {
-  let fakeAnnotation;
-  let fakeServiceConfig;
-  let fakeServiceSettings;
-
-  beforeEach(() => {
-    fakeServiceSettings = {};
-    fakeServiceConfig = sinon.stub().returns(fakeServiceSettings);
-    fakeAnnotation = {
-      links: {
-        incontext: 'https://www.example.com',
-        html: 'https://www.example2.com',
-      },
-      uri: 'https://www.example3.com',
-    };
-
-    sharingUtil.$imports.$mock({
-      '../config/service-config': { serviceConfig: fakeServiceConfig },
-    });
-  });
-
-  afterEach(() => {
-    sharingUtil.$imports.$restore();
-  });
-
-  describe('annotationSharingLink', () => {
-    context('sharing an annotation whose document is on the web', () => {
-      it('returns `incontext` link if set on annotation', () => {
-        assert.equal(
-          sharingUtil.annotationSharingLink(fakeAnnotation),
-          'https://www.example.com',
-        );
-      });
-
-      it('returns `html` link if `incontext` link not set on annotation', () => {
-        delete fakeAnnotation.links.incontext;
-
-        assert.equal(
-          sharingUtil.annotationSharingLink(fakeAnnotation),
-          'https://www.example2.com',
-        );
-      });
-
-      it('returns null if links empty', () => {
-        delete fakeAnnotation.links.incontext;
-        delete fakeAnnotation.links.html;
-
-        assert.isNull(sharingUtil.annotationSharingLink(fakeAnnotation));
-      });
-
-      it('returns null if no links on annotation', () => {
-        delete fakeAnnotation.links;
-
-        assert.isNull(sharingUtil.annotationSharingLink(fakeAnnotation));
-      });
-    });
-
-    context('sharing an annotation whose document is not on the web', () => {
-      beforeEach(() => {
-        fakeAnnotation.uri = 'file://not-on-web';
-      });
-
-      it('returns `html` link if set on annotation', () => {
-        assert.equal(
-          sharingUtil.annotationSharingLink(fakeAnnotation),
-          'https://www.example2.com',
-        );
-      });
-
-      it('returns null if no `html` link', () => {
-        delete fakeAnnotation.links.html;
-
-        assert.isNull(sharingUtil.annotationSharingLink(fakeAnnotation));
-      });
-
-      it('returns null if no links on annotation', () => {
-        delete fakeAnnotation.links;
-
-        assert.isNull(sharingUtil.annotationSharingLink(fakeAnnotation));
-      });
-    });
-  });
-
   describe('pageSharingLink', () => {
     it('generates a bouncer link based on the document URI and group id', () => {
       assert.equal(
@@ -125,28 +43,6 @@ describe('sidebar/helpers/annotation-sharing', () => {
       it('returns false for any URL not beginning with http or https', () => {
         assert.isFalse(sharingUtil.isShareableURI(invalidURI));
       });
-    });
-  });
-
-  describe('sharingEnabled', () => {
-    it('returns true if no service settings present', () => {
-      fakeServiceConfig.returns(null);
-      assert.isTrue(sharingUtil.sharingEnabled({}));
-    });
-
-    it('returns true if service settings do not have a `enableShareLinks` prop', () => {
-      // service config is an empty object
-      assert.isTrue(sharingUtil.sharingEnabled({}));
-    });
-
-    it('returns true if service settings `enableShareLinks` is non-boolean', () => {
-      fakeServiceConfig.returns({ enableShareLinks: 'foo' });
-      assert.isTrue(sharingUtil.sharingEnabled({}));
-    });
-
-    it('returns false if service settings really sets it to nope', () => {
-      fakeServiceConfig.returns({ enableShareLinks: false });
-      assert.isFalse(sharingUtil.sharingEnabled({}));
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2453,16 +2453,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/annotation-ui@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "@hypothesis/annotation-ui@npm:0.2.0"
+"@hypothesis/annotation-ui@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@hypothesis/annotation-ui@npm:0.3.0"
   peerDependencies:
     "@hypothesis/frontend-shared": ^9.4.0
     dompurify: ^3.0.0
     escape-html: ^1.0.3
     katex: ^0.16.0
     showdown: ^2.0.0
-  checksum: b7418856c4af72c813a5d3a6ae0c4155b010c3b320606ed75369574222914a209de9f0ff6d1d2ff03cde9c79ad70348f49f3303c49a35637ac18eaa1a23e6b97
+  checksum: aa2bf243e0867905094984c3ec57c2261755180f7f94cf63a7202a21f25196191045cada4d0d82306561264d676642f39eecb14f73eae6be4e423a55a921da1f
   languageName: node
   linkType: hard
 
@@ -7933,7 +7933,7 @@ __metadata:
     "@babel/preset-env": ^7.1.6
     "@babel/preset-react": ^7.0.0
     "@babel/preset-typescript": ^7.16.7
-    "@hypothesis/annotation-ui": ^0.2.0
+    "@hypothesis/annotation-ui": ^0.3.0
     "@hypothesis/frontend-build": ^4.0.0
     "@hypothesis/frontend-shared": ^9.5.1
     "@hypothesis/frontend-testing": ^1.7.1


### PR DESCRIPTION
Reduce code duplication by using the `AnnotationShareControl` from https://github.com/hypothesis/annotation-ui/pull/30

The logic here still wraps the component so that it can transparently fetch the group from the sidebar store, and display copy-to-clipboard results via toast messages.

With these changes there should be no visual or behavioral differences.