### PR TITLE
Fix share action being shown incorrectly in LMS app

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationActionBar.tsx
+++ b/src/sidebar/components/Annotation/AnnotationActionBar.tsx
@@ -12,6 +12,7 @@ import type { SavedAnnotation } from '../../../types/api';
 import type { SidebarSettings } from '../../../types/config';
 import { serviceConfig } from '../../config/service-config';
 import { annotationRole } from '../../helpers/annotation-metadata';
+import { sharingEnabled } from '../../helpers/annotation-sharing';
 import { isPrivate, permits } from '../../helpers/permissions';
 import { withServices } from '../../service-context';
 import type { AnnotationsService } from '../../services/annotations';
@@ -109,6 +110,8 @@ function AnnotationActionBar({
     onReply();
   };
 
+  const showShareAction = sharingEnabled(settings);
+
   return (
     <div className="flex text-[16px]" data-testid="annotation-action-bar">
       {showEditAction && (
@@ -118,7 +121,7 @@ function AnnotationActionBar({
         <IconButton icon={TrashIcon} title="Delete" onClick={onDelete} />
       )}
       <IconButton icon={ReplyIcon} title="Reply" onClick={onReplyClick} />
-      <AnnotationShareControl annotation={annotation} />
+      {showShareAction && <AnnotationShareControl annotation={annotation} />}
       {showFlagAction && !annotation.flagged && (
         <IconButton
           icon={FlagIcon}

--- a/src/sidebar/components/Annotation/test/AnnotationActionBar-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationActionBar-test.js
@@ -21,6 +21,7 @@ describe('AnnotationActionBar', () => {
   let fakePermits;
   let fakeSettings;
   // Fake dependencies
+  let fakeSharingEnabled;
   let fakeStore;
 
   function createComponent(props = {}) {
@@ -76,6 +77,8 @@ describe('AnnotationActionBar', () => {
     fakePermits = sinon.stub().returns(true);
     fakeSettings = {};
 
+    fakeSharingEnabled = sinon.stub().returns(true);
+
     fakeStore = {
       createDraft: sinon.stub(),
       isLoggedIn: sinon.stub(),
@@ -88,6 +91,9 @@ describe('AnnotationActionBar', () => {
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       '@hypothesis/frontend-shared': { confirm: fakeConfirm },
+      '../../helpers/annotation-sharing': {
+        sharingEnabled: fakeSharingEnabled,
+      },
       '../../helpers/permissions': { permits: fakePermits },
       '../../store': { useSidebarStore: () => fakeStore },
     });
@@ -240,12 +246,17 @@ describe('AnnotationActionBar', () => {
   });
 
   describe('share action button', () => {
-    it('forwards annotation to AnnotationShareControl', () => {
+    it('shows share action button if annotation is shareable', () => {
       const wrapper = createComponent();
-      assert.equal(
-        wrapper.find('AnnotationShareControl').prop('annotation'),
-        fakeAnnotation,
-      );
+
+      assert.isTrue(wrapper.find('AnnotationShareControl').exists());
+    });
+
+    it('does not show share action button if sharing is not enabled', () => {
+      fakeSharingEnabled.returns(false);
+      const wrapper = createComponent();
+
+      assert.isFalse(wrapper.find('AnnotationShareControl').exists());
     });
   });
 

--- a/src/sidebar/helpers/annotation-sharing.ts
+++ b/src/sidebar/helpers/annotation-sharing.ts
@@ -1,3 +1,6 @@
+import type { SidebarSettings } from '../../types/config';
+import { serviceConfig } from '../config/service-config';
+
 /**
  * Generate a URI for sharing: a bouncer link built to share annotations in
  * a specific group (groupID) on a specific document (documentURI). If the
@@ -22,4 +25,16 @@ export function pageSharingLink(
  */
 export function isShareableURI(uri: string): boolean {
   return /^http(s?):/i.test(uri);
+}
+
+/**
+ * Return true if annotation sharing is globally enabled in the client's
+ * configuration.
+ *
+ * Sharing is enabled by default but can be disabled when a third party
+ * authority is being used.
+ */
+export function sharingEnabled(settings: SidebarSettings): boolean {
+  const service = serviceConfig(settings);
+  return service?.enableShareLinks !== false;
 }

--- a/src/sidebar/helpers/test/annotation-sharing-test.js
+++ b/src/sidebar/helpers/test/annotation-sharing-test.js
@@ -1,6 +1,22 @@
 import * as sharingUtil from '../annotation-sharing';
 
 describe('sidebar/helpers/annotation-sharing', () => {
+  let fakeServiceConfig;
+  let fakeServiceSettings;
+
+  beforeEach(() => {
+    fakeServiceSettings = {};
+    fakeServiceConfig = sinon.stub().returns(fakeServiceSettings);
+
+    sharingUtil.$imports.$mock({
+      '../config/service-config': { serviceConfig: fakeServiceConfig },
+    });
+  });
+
+  afterEach(() => {
+    sharingUtil.$imports.$restore();
+  });
+
   describe('pageSharingLink', () => {
     it('generates a bouncer link based on the document URI and group id', () => {
       assert.equal(
@@ -43,6 +59,28 @@ describe('sidebar/helpers/annotation-sharing', () => {
       it('returns false for any URL not beginning with http or https', () => {
         assert.isFalse(sharingUtil.isShareableURI(invalidURI));
       });
+    });
+  });
+
+  describe('sharingEnabled', () => {
+    it('returns true if no service settings present', () => {
+      fakeServiceConfig.returns(null);
+      assert.isTrue(sharingUtil.sharingEnabled({}));
+    });
+
+    it('returns true if service settings do not have a `enableShareLinks` prop', () => {
+      // service config is an empty object
+      assert.isTrue(sharingUtil.sharingEnabled({}));
+    });
+
+    it('returns true if service settings `enableShareLinks` is non-boolean', () => {
+      fakeServiceConfig.returns({ enableShareLinks: 'foo' });
+      assert.isTrue(sharingUtil.sharingEnabled({}));
+    });
+
+    it('returns false if service settings really sets it to `false`', () => {
+      fakeServiceConfig.returns({ enableShareLinks: false });
+      assert.isFalse(sharingUtil.sharingEnabled({}));
     });
   });
 });


### PR DESCRIPTION
This is a partial revert of https://github.com/hypothesis/client/pull/7186. Prior to that PR the annotation share control was hidden in two cases:

 1. Sharing is globally disabled for the client. This is true in the LMS.
 2. The annotation does not have a share URL

Case (2) is handled by the `AnnotationShareControl` component in the @hypothesis/annotation-ui package, but the checks for case (1) were removed and that still needs to be handled in the Hypothesis client.

Fixes https://github.com/hypothesis/support/issues/199