### PR TITLE
Remove usage of `Metadata.prototype.has` PDF.js API

### DIFF
--- a/src/annotator/integrations/pdf-metadata.ts
+++ b/src/annotator/integrations/pdf-metadata.ts
@@ -166,9 +166,12 @@ export class PDFMetadata {
     // is preferred if available.
     //
     // This logic is similar to how PDF.js sets `document.title`.
+
+    const dcTitle = metadata?.get('dc:title');
+
     let title;
-    if (metadata?.has('dc:title') && metadata.get('dc:title') !== 'Untitled') {
-      title = metadata.get('dc:title');
+    if (dcTitle && dcTitle !== 'Untitled') {
+      title = dcTitle;
     } else if (documentInfo?.Title) {
       title = documentInfo.Title;
     } else if (contentDispositionFilename) {

--- a/src/annotator/integrations/test/pdf-metadata-test.js
+++ b/src/annotator/integrations/test/pdf-metadata-test.js
@@ -19,10 +19,6 @@ class FakeMetadata {
   get(key) {
     return this._metadata[key];
   }
-
-  has(key) {
-    return Object.hasOwn(this._metadata, key);
-  }
 }
 
 /**

--- a/src/types/pdfjs.ts
+++ b/src/types/pdfjs.ts
@@ -18,8 +18,7 @@
  * See `Metadata` class from `display/metadata.js` in PDF.js.
  */
 export type Metadata = {
-  get(name: string): string;
-  has(name: string): boolean;
+  get(name: string): string | null;
 };
 
 /**


### PR DESCRIPTION
This API has been removed upstream in https://github.com/mozilla/pdf.js/commit/2c593b06e4ef22b9039f2270f5e829dca61e745a.

The affects PDF.js v5.2.133 and later.

Fixes https://github.com/hypothesis/support/issues/201