### PR TITLE
Send notification to LMS frontend when there are unsaved changes

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationEditor.tsx
+++ b/src/sidebar/components/Annotation/AnnotationEditor.tsx
@@ -44,8 +44,8 @@ type AnnotationEditorProps = {
   annotationsService: AnnotationsService;
   groups: GroupsService;
   settings: SidebarSettings;
-  toastMessenger: ToastMessengerService;
   tags: TagsService;
+  toastMessenger: ToastMessengerService;
 };
 
 /**
@@ -53,8 +53,8 @@ type AnnotationEditorProps = {
  */
 function AnnotationEditor({
   annotation,
-  draft,
   annotationsService,
+  draft,
   groups: groupsService,
   settings,
   tags: tagsService,

--- a/src/sidebar/services/annotation-activity.ts
+++ b/src/sidebar/services/annotation-activity.ts
@@ -4,7 +4,11 @@ import { isShared } from '../helpers/permissions';
 import * as postMessageJsonRpc from '../util/postmessage-json-rpc';
 
 /**
- * Send messages to configured ancestor frame on annotation activity
+ * Service for sending messages to the embedder frame.
+ *
+ * This is primarily used in the Hypothesis LMS app, where the client sends
+ * the LMS frontend notifications about annotation activity happening in the
+ * client.
  */
 // @inject
 export class AnnotationActivityService {
@@ -43,12 +47,40 @@ export class AnnotationActivityService {
     };
 
     if (this._reportConfig.events.includes(eventType)) {
-      postMessageJsonRpc.notify(
-        this._rpc.targetFrame,
-        this._rpc.origin,
-        this._reportConfig.method,
-        [eventType, data],
-      );
+      this.notify(this._reportConfig.method, [eventType, data]);
     }
+  }
+
+  /**
+   * Notify the embedder frame that the client has, or does not have,
+   * unsaved changes to annotations.
+   */
+  notifyUnsavedChanges(unsaved: boolean) {
+    // Note: Unlike activity reporting, the method name here is not configurable.
+    //
+    // The reason for having a configurable method name for activity reporting
+    // was because messages are sent via `window.postMessage` which is a shared
+    // channel that might be used for other purposes, hence configurable method
+    // names were added to avoid conflicts. The main consumer of this feature
+    // though is the Hypothesis LMS app, where we control all the JS code that
+    // runs. This method takes a simpler approach of using a fixed name and
+    // assuming it won't cause problems for the embedder frame.
+    //
+    // A better solution to this problem would be to use a dedicated
+    // `MessagePort` for communication.
+    this.notify('reportUnsavedChanges', [{ unsaved }]);
+  }
+
+  /** Send a JSON-RPC message to the embedder frame. */
+  private notify(method: string, args: unknown[]) {
+    if (!this._rpc) {
+      return;
+    }
+    postMessageJsonRpc.notify(
+      this._rpc.targetFrame,
+      this._rpc.origin,
+      method,
+      args,
+    );
   }
 }

--- a/src/sidebar/services/test/annotation-activity-test.js
+++ b/src/sidebar/services/test/annotation-activity-test.js
@@ -156,4 +156,29 @@ describe('AnnotationActivityService', () => {
       });
     });
   });
+
+  describe('#notifyUnsavedChanges', () => {
+    [true, false].forEach(unsaved => {
+      it('sends reportUnsavedChanges notification with unsaved state', () => {
+        const svc = new AnnotationActivityService(fakeSettings);
+
+        svc.notifyUnsavedChanges(unsaved);
+
+        assert.calledOnce(fakePostMessageJsonRpc.notify);
+        assert.calledWith(
+          fakePostMessageJsonRpc.notify,
+          window,
+          'https://www.example.com',
+          'reportUnsavedChanges',
+          [{ unsaved }],
+        );
+      });
+    });
+
+    it('does not send notification if RPC is not configured', () => {
+      const svc = new AnnotationActivityService({});
+      svc.notifyUnsavedChanges(true);
+      assert.notCalled(fakePostMessageJsonRpc.notify);
+    });
+  });
 });


### PR DESCRIPTION
We want to prevent accidentally losing unsaved changes by closing the tab. In Chrome and Firefox we do this using `beforeunload` in the client. In desktop Safari this does not work if the `beforeunload` handler is set in a cross-origin iframe. To work around this, have the client send a message to the LMS frontend which can install/remove a `beforeunload` handler in the top-level frame instead. In mobile Safari this change doesn't help because `beforeunload` is ignored there entirely.

See https://github.com/hypothesis/support/issues/59#issuecomment-3068704178

**TODO:**

- [x] Handle the possibility of having multiple drafts
- [x] Ensure notification is sent when editor is unmounted

**Testing:**

See https://github.com/hypothesis/lms/pull/7178.