### PR TITLE
Display a moderation status badge in your own annotations

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@babel/preset-env": "^7.1.6",
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.16.7",
-    "@hypothesis/annotation-ui": "^0.4.1",
+    "@hypothesis/annotation-ui": "^0.5.0",
     "@hypothesis/frontend-build": "^4.0.0",
     "@hypothesis/frontend-shared": "^9.6.1",
     "@hypothesis/frontend-testing": "^1.7.1",

--- a/src/sidebar/components/Annotation/Annotation.tsx
+++ b/src/sidebar/components/Annotation/Annotation.tsx
@@ -15,6 +15,7 @@ import { annotationDisplayName } from '../../helpers/annotation-user';
 import { withServices } from '../../service-context';
 import type { AnnotationsService } from '../../services/annotations';
 import { useSidebarStore } from '../../store';
+import ModerationStatusBadge from '../moderation/ModerationStatusBadge';
 import AnnotationActionBar from './AnnotationActionBar';
 import AnnotationBody from './AnnotationBody';
 import AnnotationEditor from './AnnotationEditor';
@@ -95,6 +96,10 @@ function Annotation({
   const defaultAuthority = store.defaultAuthority();
   const displayNamesEnabled = store.isFeatureEnabled('client_display_names');
 
+  // We want to show moderation controls only if current user is the author.
+  const moderationStatus =
+    annotation.user === userid ? annotation?.moderation_status : undefined;
+
   const onReply = () => {
     if (isSaved(annotation) && userid) {
       annotationsService.reply(annotation, userid);
@@ -151,14 +156,22 @@ function Annotation({
       {isEditing && <AnnotationEditor annotation={annotation} draft={draft} />}
 
       {!isCollapsedReply && (
-        <footer className="flex items-center">
-          {onToggleReplies && (
-            <AnnotationReplyToggle
-              onToggleReplies={onToggleReplies}
-              replyCount={replyCount}
-              threadIsCollapsed={threadIsCollapsed}
-            />
-          )}
+        <footer className="flex items-start">
+          <div className="flex flex-col items-start gap-y-1">
+            {showActions && moderationStatus && (
+              <ModerationStatusBadge
+                status={moderationStatus}
+                classes="mt-0.5"
+              />
+            )}
+            {onToggleReplies && (
+              <AnnotationReplyToggle
+                onToggleReplies={onToggleReplies}
+                replyCount={replyCount}
+                threadIsCollapsed={threadIsCollapsed}
+              />
+            )}
+          </div>
           {isSaving && <SavingMessage />}
           {showActions && (
             <CardActions classes="grow">

--- a/src/sidebar/components/Annotation/test/Annotation-test.js
+++ b/src/sidebar/components/Annotation/test/Annotation-test.js
@@ -299,6 +299,71 @@ describe('Annotation', () => {
     });
   });
 
+  [
+    {
+      author: 'acct:foo@bar.com',
+      showActions: true,
+      moderationStatus: 'PENDING',
+      shouldRenderBadge: true,
+    },
+    {
+      author: 'acct:foo@bar.com',
+      showActions: true,
+      moderationStatus: undefined,
+      shouldRenderBadge: false,
+    },
+    {
+      author: 'acct:foo@bar.com',
+      showActions: false,
+      moderationStatus: 'PENDING',
+      shouldRenderBadge: false,
+    },
+    {
+      author: 'acct:foo@bar.com',
+      showActions: false,
+      moderationStatus: undefined,
+      shouldRenderBadge: false,
+    },
+    {
+      author: 'acct:bar@bar.com',
+      showActions: true,
+      moderationStatus: 'PENDING',
+      shouldRenderBadge: false,
+    },
+    {
+      author: 'acct:bar@bar.com',
+      showActions: true,
+      moderationStatus: undefined,
+      shouldRenderBadge: false,
+    },
+    {
+      author: 'acct:bar@bar.com',
+      showActions: false,
+      moderationStatus: 'PENDING',
+      shouldRenderBadge: false,
+    },
+    {
+      author: 'acct:bar@bar.com',
+      showActions: false,
+      moderationStatus: undefined,
+      shouldRenderBadge: false,
+    },
+  ].forEach(({ author, showActions, moderationStatus, shouldRenderBadge }) => {
+    it('renders ModerationStatusBadge when current user is the annotation author', () => {
+      fakeStore.isSavingAnnotation.returns(!showActions);
+
+      const wrapper = createComponent({
+        annotation: {
+          ...fixtures.defaultAnnotation(),
+          user: author,
+          moderation_status: moderationStatus,
+        },
+      });
+
+      assert.equal(wrapper.exists('ModerationStatusBadge'), shouldRenderBadge);
+    });
+  });
+
   it(
     'should pass a11y checks',
     checkAccessibility([

--- a/src/sidebar/components/ThreadCard.tsx
+++ b/src/sidebar/components/ThreadCard.tsx
@@ -39,6 +39,11 @@ function ThreadCard({ frameSync, thread }: ThreadCardProps) {
     [frameSync],
   );
 
+  const currentUserId = store.profile().userid;
+  const annotationIsDeclined =
+    thread.annotation?.moderation_status === 'DENIED' &&
+    thread.annotation.user === currentUserId;
+
   /**
    * Is the target's event an <a> or <button> element, or does it have
    * either as an ancestor?
@@ -69,7 +74,10 @@ function ThreadCard({ frameSync, thread }: ThreadCardProps) {
       active={isHovered}
       classes={classnames(
         'cursor-pointer focus-visible-ring theme-clean:border-none',
-        { 'border-brand': isHighlighted },
+        {
+          'border-brand': isHighlighted,
+          'border-red': !isHighlighted && annotationIsDeclined,
+        },
       )}
       data-testid="thread-card"
       elementRef={cardRef}

--- a/src/sidebar/components/moderation/ModerationStatusBadge.tsx
+++ b/src/sidebar/components/moderation/ModerationStatusBadge.tsx
@@ -1,0 +1,67 @@
+import type { ModerationStatus } from '@hypothesis/annotation-ui';
+import { moderationStatusInfo } from '@hypothesis/annotation-ui';
+import { Button, Popover } from '@hypothesis/frontend-shared';
+import classnames from 'classnames';
+import { useRef, useState } from 'preact/hooks';
+
+export type ModerationStatusBadgeProps = {
+  status: ModerationStatus;
+  classes?: string | string[];
+};
+
+/**
+ * Badge representation of a moderation status, with the corresponding color
+ * palette, icon and text
+ */
+export default function ModerationStatusBadge({
+  status,
+  classes,
+}: ModerationStatusBadgeProps) {
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const badgeRef = useRef<HTMLButtonElement | null>(null);
+
+  // We only support these two moderation statuses for now
+  if (!['PENDING', 'DENIED'].includes(status)) {
+    return null;
+  }
+
+  const { icon: Icon, label } = moderationStatusInfo[status]!;
+  let popoverMessage = '';
+  if (status === 'PENDING') {
+    popoverMessage =
+      'Not visible to other users yet. Waiting for a moderator to review it.';
+  } else if (status === 'DENIED') {
+    popoverMessage =
+      'Not visible to other users. Edit this annotation to resubmit it for moderator approval.';
+  }
+
+  return (
+    <div className="relative" data-testid="moderation-status-badge">
+      <Button
+        variant="custom"
+        elementRef={badgeRef}
+        classes={classnames(
+          'px-1.5 py-1 rounded flex items-center gap-1.5',
+          {
+            'bg-grey-2 text-black': status === 'PENDING',
+            'bg-red-light text-red-dark': status === 'DENIED',
+          },
+          classes,
+        )}
+        onClick={() => setPopoverOpen(true)}
+      >
+        <Icon className={classnames(status === 'PENDING' && 'text-grey-7')} />
+        {label}
+      </Button>
+      <Popover
+        open={popoverOpen}
+        onClose={() => setPopoverOpen(false)}
+        anchorElementRef={badgeRef}
+        placement="above"
+        classes="!bg-grey-9 !border-grey-9 text-white px-2.5 py-2"
+      >
+        {popoverMessage}
+      </Popover>
+    </div>
+  );
+}

--- a/src/sidebar/components/moderation/test/ModerationStatusBadge-test.js
+++ b/src/sidebar/components/moderation/test/ModerationStatusBadge-test.js
@@ -1,0 +1,48 @@
+import { mount } from '@hypothesis/frontend-testing';
+
+import ModerationStatusBadge from '../ModerationStatusBadge';
+
+describe('ModerationStatusBadge', () => {
+  function createComponent(moderationStatus) {
+    return mount(<ModerationStatusBadge status={moderationStatus} />, {
+      connected: true,
+    });
+  }
+
+  [
+    { moderationStatus: 'PENDING', shouldHaveContent: true },
+    { moderationStatus: 'APPROVED', shouldHaveContent: false },
+    { moderationStatus: 'SPAM', shouldHaveContent: false },
+    { moderationStatus: 'DENIED', shouldHaveContent: true },
+  ].forEach(({ moderationStatus, shouldHaveContent }) => {
+    it('renders nothing for APPROVED and SPAM statuses', () => {
+      const wrapper = createComponent(moderationStatus);
+      assert.equal(
+        wrapper.exists('[data-testid="moderation-status-badge"]'),
+        shouldHaveContent,
+      );
+    });
+  });
+
+  [
+    {
+      moderationStatus: 'PENDING',
+      expectedTooltip:
+        'Not visible to other users yet. Waiting for a moderator to review it.',
+    },
+    {
+      moderationStatus: 'DENIED',
+      expectedTooltip:
+        'Not visible to other users. Edit this annotation to resubmit it for moderator approval.',
+    },
+  ].forEach(({ moderationStatus, expectedTooltip }) => {
+    it('renders expected popover', () => {
+      const wrapper = createComponent(moderationStatus);
+
+      // Open popover
+      wrapper.find('button').simulate('click');
+
+      assert.equal(wrapper.find('Popover').text(), expectedTooltip);
+    });
+  });
+});

--- a/src/sidebar/components/test/ThreadCard-test.js
+++ b/src/sidebar/components/test/ThreadCard-test.js
@@ -3,6 +3,7 @@ import {
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
 import { mount } from '@hypothesis/frontend-testing';
+import sinon from 'sinon';
 
 import ThreadCard, { $imports } from '../ThreadCard';
 
@@ -33,6 +34,7 @@ describe('ThreadCard', () => {
       isAnnotationHovered: sinon.stub().returns(false),
       route: sinon.stub(),
       isAnnotationHighlighted: sinon.stub().returns(false),
+      profile: sinon.stub().returns({ userid: '123' }),
     };
 
     fakeThread = {
@@ -145,6 +147,25 @@ describe('ThreadCard', () => {
         wrapper.find('Card').prop('classes').includes('border-brand'),
         isHighlighted,
       );
+    });
+
+    [
+      { author: '456', moderationStatus: 'DENIED', shouldBeDenied: false },
+      { author: '123', moderationStatus: 'DENIED', shouldBeDenied: true },
+      { author: '456', moderationStatus: 'APPROVED', shouldBeDenied: false },
+      { author: '123', moderationStatus: 'APPROVED', shouldBeDenied: false },
+    ].forEach(({ author, moderationStatus, shouldBeDenied }) => {
+      it('marks thread as declined when moderation status is DENIED and is not highlighted', () => {
+        fakeStore.isAnnotationHighlighted.returns(isHighlighted);
+        fakeThread.annotation.user = author;
+        fakeThread.annotation.moderation_status = moderationStatus;
+
+        const wrapper = createComponent();
+        assert.equal(
+          wrapper.find('Card').prop('classes').includes('border-red'),
+          !isHighlighted && shouldBeDenied,
+        );
+      });
     });
   });
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,3 +1,5 @@
+import type { ModerationStatus } from '@hypothesis/annotation-ui';
+
 import type { ClientAnnotationData } from './shared';
 
 /**
@@ -312,6 +314,8 @@ export type APIAnnotationData = {
   moderation?: {
     flagCount: number;
   };
+
+  moderation_status?: ModerationStatus;
 
   links: {
     /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2535,16 +2535,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hypothesis/annotation-ui@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "@hypothesis/annotation-ui@npm:0.4.1"
+"@hypothesis/annotation-ui@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "@hypothesis/annotation-ui@npm:0.5.0"
   peerDependencies:
     "@hypothesis/frontend-shared": ^9.4.0
     dompurify: ^3.0.0
     escape-html: ^1.0.3
     katex: ^0.16.0
     showdown: ^2.0.0
-  checksum: 310aa6156cfa8d20f0368837dd4d155e6250a49a0bedb73f27acbcc9062362b373824becbac6df35ea341f2973c50426e1e1afa368666425ec2e603c2917f7ef
+  checksum: e35e8ddfa5e5393b6d4cd43614abfb7ca5cd12da498016fc17807cfeac701227d0f1c46b595e7700ae447673146847c9d91319d6aecb9b7b92c39554dc8eb01f
   languageName: node
   linkType: hard
 
@@ -8110,7 +8110,7 @@ __metadata:
     "@babel/preset-env": ^7.1.6
     "@babel/preset-react": ^7.0.0
     "@babel/preset-typescript": ^7.16.7
-    "@hypothesis/annotation-ui": ^0.4.1
+    "@hypothesis/annotation-ui": ^0.5.0
     "@hypothesis/frontend-build": ^4.0.0
     "@hypothesis/frontend-shared": ^9.6.1
     "@hypothesis/frontend-testing": ^1.7.1


### PR DESCRIPTION
Part of #7049 

This PR ensures that a moderation status badge is displayed in regular users own annotations, when they are still pending or have been denied by a moderator.

The badge is not displayed for approved annotations, as those are considered "normal" ones and that would introduce a lot of noise.

Pending annotations:
<img width="427" height="197" alt="image" src="https://github.com/user-attachments/assets/37b72721-1fd8-4466-b23a-67a85afa0593" />

Declined annotations:
<img width="427" height="197" alt="image" src="https://github.com/user-attachments/assets/9ca78e64-5261-4f9d-b23f-c50f7c42c104" />

Tooltips:

https://github.com/user-attachments/assets/32d6c600-8f6f-40a2-925e-8e3dead28372

### Considerations

#### Do not conditionally show moderation status badge

We discussed displaying moderation controls only in pre-moderated groups, to avoid extra UI noise in most of other groups. However, that will apply only to moderators, regular users will still see the badge in their denied annotations, even if the group is not pre-moderated.

In non pre-moderated groups, annotations go straight to approved, so the "pending" badge will not show in most of the annotations anyway, and when their annotation has been denied, it's still useful for them to see it.

#### Do not show a SPAM status badge

As per the [requirements document](https://docs.google.com/document/d/1NzArJi9K8tHmxmwCYe30_qs0LIboPh4dZMIZdA8ZJJQ/edit?pli=1&tab=t.0)

> do not indicate the Spam status on annotation cards in the client.
>
> We don't want to encourage spammers to keep peppering the group with new pending annotations in the hopes of sneaking one through.
>
> This means that Spam annotations, when shown to their authors, will have no label at all and will look the same as Approved annotations.

#### Show tooltips on click

The badge is rendered as a clickable button, which displays the moderation tooltip on click.

This follows a pattern we have been recently following, which allows for a more accessible experience than showing tooltips/popovers on hover, as that doesn't work in mobile devices.

### TODO

- [x] Add tests
- [x] Add popovers with extra info (on hover and on click)
- [x] ~Implement badge for spam status?~ No. See "Do not show a SPAM status badge" point above