### PR TITLE
Display moderation selects in annotations to moderators

### DIFF
--- a/src/sidebar/components/Annotation/Annotation.tsx
+++ b/src/sidebar/components/Annotation/Annotation.tsx
@@ -15,7 +15,7 @@ import { annotationDisplayName } from '../../helpers/annotation-user';
 import { withServices } from '../../service-context';
 import type { AnnotationsService } from '../../services/annotations';
 import { useSidebarStore } from '../../store';
-import ModerationStatusBadge from '../moderation/ModerationStatusBadge';
+import ModerationControl from '../moderation/ModerationControl';
 import AnnotationActionBar from './AnnotationActionBar';
 import AnnotationBody from './AnnotationBody';
 import AnnotationEditor from './AnnotationEditor';
@@ -96,10 +96,6 @@ function Annotation({
   const defaultAuthority = store.defaultAuthority();
   const displayNamesEnabled = store.isFeatureEnabled('client_display_names');
 
-  // We want to show moderation controls only if current user is the author.
-  const moderationStatus =
-    annotation.user === userid ? annotation?.moderation_status : undefined;
-
   const onReply = () => {
     if (isSaved(annotation) && userid) {
       annotationsService.reply(annotation, userid);
@@ -158,10 +154,11 @@ function Annotation({
       {!isCollapsedReply && (
         <footer className="flex items-start">
           <div className="flex flex-col items-start gap-y-1">
-            {showActions && moderationStatus && (
-              <ModerationStatusBadge
-                status={moderationStatus}
-                classes="mt-0.5"
+            {showActions && (
+              <ModerationControl
+                annotation={annotation}
+                groupIsPreModerated={!!store.focusedGroup()?.pre_moderated}
+                badgeClasses="mt-0.5"
               />
             )}
             {onToggleReplies && (

--- a/src/sidebar/components/Annotation/test/Annotation-test.js
+++ b/src/sidebar/components/Annotation/test/Annotation-test.js
@@ -66,6 +66,7 @@ describe('Annotation', () => {
       profile: sinon.stub().returns({ userid: 'acct:foo@bar.com' }),
       setExpanded: sinon.stub(),
       isAnnotationHighlighted: sinon.stub().returns(false),
+      focusedGroup: sinon.stub(),
     };
 
     $imports.$mock(mockImportedComponents());
@@ -299,68 +300,15 @@ describe('Annotation', () => {
     });
   });
 
-  [
-    {
-      author: 'acct:foo@bar.com',
-      showActions: true,
-      moderationStatus: 'PENDING',
-      shouldRenderBadge: true,
-    },
-    {
-      author: 'acct:foo@bar.com',
-      showActions: true,
-      moderationStatus: undefined,
-      shouldRenderBadge: false,
-    },
-    {
-      author: 'acct:foo@bar.com',
-      showActions: false,
-      moderationStatus: 'PENDING',
-      shouldRenderBadge: false,
-    },
-    {
-      author: 'acct:foo@bar.com',
-      showActions: false,
-      moderationStatus: undefined,
-      shouldRenderBadge: false,
-    },
-    {
-      author: 'acct:bar@bar.com',
-      showActions: true,
-      moderationStatus: 'PENDING',
-      shouldRenderBadge: false,
-    },
-    {
-      author: 'acct:bar@bar.com',
-      showActions: true,
-      moderationStatus: undefined,
-      shouldRenderBadge: false,
-    },
-    {
-      author: 'acct:bar@bar.com',
-      showActions: false,
-      moderationStatus: 'PENDING',
-      shouldRenderBadge: false,
-    },
-    {
-      author: 'acct:bar@bar.com',
-      showActions: false,
-      moderationStatus: undefined,
-      shouldRenderBadge: false,
-    },
-  ].forEach(({ author, showActions, moderationStatus, shouldRenderBadge }) => {
-    it('renders ModerationStatusBadge when current user is the annotation author', () => {
+  [true, false].forEach(showActions => {
+    it('renders ModerationControl when actions are shown', () => {
       fakeStore.isSavingAnnotation.returns(!showActions);
 
       const wrapper = createComponent({
-        annotation: {
-          ...fixtures.defaultAnnotation(),
-          user: author,
-          moderation_status: moderationStatus,
-        },
+        annotation: fixtures.defaultAnnotation(),
       });
 
-      assert.equal(wrapper.exists('ModerationStatusBadge'), shouldRenderBadge);
+      assert.equal(wrapper.exists('ModerationControl'), showActions);
     });
   });
 

--- a/src/sidebar/components/moderation/ModerationControl.tsx
+++ b/src/sidebar/components/moderation/ModerationControl.tsx
@@ -1,0 +1,48 @@
+import { ModerationStatusSelect } from '@hypothesis/annotation-ui';
+
+import type { Annotation } from '../../../types/api';
+import ModerationStatusBadge from './ModerationStatusBadge';
+
+export type ModerationControlProps = {
+  annotation: Annotation;
+  groupIsPreModerated: boolean;
+  /** Classes to apply to the ModerationStatusBadge in case it's rendered */
+  badgeClasses?: string | string[];
+};
+
+/**
+ * Render the proper moderation control/s for provided annotation.
+ *
+ * - ModerationStatusSelect for moderators of pre-moderated groups.
+ * - ModerationStatusBadge for own annotations in any group
+ */
+export default function ModerationControl({
+  annotation,
+  groupIsPreModerated,
+  badgeClasses,
+}: ModerationControlProps) {
+  const canModerate = annotation.actions?.includes('moderate');
+
+  // We want to show moderation controls only if current user is a moderator or
+  // the annotation's author
+  const moderationStatus = annotation?.moderation_status ?? 'APPROVED';
+
+  if (!canModerate && moderationStatus === 'APPROVED') {
+    return null;
+  }
+
+  // We don't want to show moderation selects to moderators of non-pre-moderated
+  // groups, to avoid cluttering the UI with all the extra controls, since most
+  // annotations will have `APPROVED` status.
+  return canModerate && groupIsPreModerated ? (
+    <ModerationStatusSelect
+      mode="select"
+      selected={moderationStatus}
+      /* TODO Implement logic to change the status */
+      onChange={/* istanbul ignore next */ () => {}}
+      alignListbox="left"
+    />
+  ) : (
+    <ModerationStatusBadge status={moderationStatus} classes={badgeClasses} />
+  );
+}

--- a/src/sidebar/components/moderation/test/ModerationControl-test.js
+++ b/src/sidebar/components/moderation/test/ModerationControl-test.js
@@ -1,0 +1,68 @@
+import { mockImportedComponents, mount } from '@hypothesis/frontend-testing';
+
+import { defaultAnnotation } from '../../../test/annotation-fixtures';
+import ModerationControl, { $imports } from '../ModerationControl';
+
+describe('ModerationControl', () => {
+  beforeEach(() => {
+    $imports.$mock(mockImportedComponents());
+  });
+
+  function createComponent({ annotation, groupIsPreModerated = true }) {
+    return mount(
+      <ModerationControl
+        annotation={annotation}
+        groupIsPreModerated={groupIsPreModerated}
+      />,
+    );
+  }
+
+  context('when annotation cannot be moderated', () => {
+    const annotation = {
+      ...defaultAnnotation(),
+      moderation_status: 'PENDING',
+    };
+
+    it('does not render anything if status is APPROVED', () => {
+      const wrapper = createComponent({
+        annotation: {
+          ...annotation,
+          moderation_status: 'APPROVED',
+        },
+      });
+      assert.isEmpty(wrapper.text());
+    });
+
+    it('renders ModerationStatusBadge if status is not APPROVED', () => {
+      const wrapper = createComponent({ annotation });
+
+      assert.isTrue(wrapper.exists('ModerationStatusBadge'));
+      assert.isFalse(wrapper.exists('ModerationStatusSelect'));
+    });
+  });
+
+  context('when annotation can be moderated', () => {
+    const annotation = {
+      ...defaultAnnotation(),
+      moderation_status: 'PENDING',
+      actions: ['moderate'],
+    };
+
+    it('renders ModerationStatusBadge if group is not pre-moderated', () => {
+      const wrapper = createComponent({
+        annotation,
+        groupIsPreModerated: false,
+      });
+
+      assert.isTrue(wrapper.exists('ModerationStatusBadge'));
+      assert.isFalse(wrapper.exists('ModerationStatusSelect'));
+    });
+
+    it('renders ModerationStatusSelect if group is pre-moderated', () => {
+      const wrapper = createComponent({ annotation });
+
+      assert.isTrue(wrapper.exists('ModerationStatusSelect'));
+      assert.isFalse(wrapper.exists('ModerationStatusBadge'));
+    });
+  });
+});

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -343,6 +343,12 @@ export type APIAnnotationData = {
    * This prop will be present only if `at_mentions` is enabled.
    */
   mentions?: Mention[];
+
+  /**
+   * The list of actions current user can perform over this annotation.
+   * Possible values are: `moderate`.
+   */
+  actions?: Array<'moderate' | string>;
 };
 
 /**
@@ -393,6 +399,7 @@ export type Group = {
   links: {
     html?: string;
   };
+  pre_moderated: boolean;
 
   // Properties not present on API objects, but added in the client.
   logo: string;


### PR DESCRIPTION
Part of #7050
Depends on https://github.com/hypothesis/h/pull/9766

Display a moderation status select with the annotation's moderation status on every annotation, as long as focused group is pre-moderated, and current user is a moderator, admin or owner of that group.

<img width="466" height="819" alt="image" src="https://github.com/user-attachments/assets/30e2a7e1-18f9-4b6b-90e7-f80af17bb450" />

> [!NOTE]  
> This PR does not cover being able to change the moderation status. That will come in a follow-up PR.

### Considerations

- I did not check any feature flag in order to conditionally add this logic, as it already depends on the group being pre-moderated.
    Enabling pre-moderation in a group already depends on a feature flag, so I think that should be good enough.
- ~In order to know if current user is a moderator, we need to load the group's members first.~
    ~This causes some UI flickering, so we may wont to a) load members earlier, before annotations are rendered, for pre-moderated groups, or b) include current user's role in every group when the list of groups is loaded~
    We choose a different approach, where we expose the `actions` current user can perform on every annotation. We'll start using this to determine if a user can moderate the action or not, but could be used for other purposes too. See https://github.com/hypothesis/h/pull/9766

### Test steps

1. In your local h instance, checkout to https://github.com/hypothesis/h/pull/9766
2. In the client, check out to this branch.
3. Verify that, if you log-in the client and select a group for which current user is a moderator and the group is pre-moderated, you see moderation selects in every annotation.
4. If the user is an admin but the group is not pre-moderated, you see moderation badges in own pending and denied annotations.
5. If the user is not an admin, you see the same as in 4, both for pre-moderated and non-pre-moderated groups.

### TODO

- [x] `ModerationControl` exposes a `classess` prop, but this is only forwarded to `ModerationStatusBadge`. Think on a better solution.