### PR TITLE
Increase the height of the login popup window

### DIFF
--- a/src/sidebar/util/oauth-client.ts
+++ b/src/sidebar/util/oauth-client.ts
@@ -220,14 +220,16 @@ export class OAuthClient {
     authURL.searchParams.set('response_type', 'code');
     authURL.searchParams.set('state', state);
 
+    // The sizes are chosen to be sufficient for our own login and sign-up UI,
+    // as well as the social login flows (Google etc.) that the user may be
+    // redirected through.
+    //
     // In Chrome & Firefox the sizes passed to `window.open` are used for the
     // viewport size. In Safari the size is used for the window size including
     // title bar etc. There is enough vertical space at the bottom to allow for
-    // this.
-    //
-    // See https://bugs.webkit.org/show_bug.cgi?id=143678
+    // this. See https://bugs.webkit.org/show_bug.cgi?id=143678.
     const width = 475;
-    const height = 430;
+    const height = 630;
     const left = $window.screen.width / 2 - width / 2;
     const top = $window.screen.height / 2 - height / 2;
 

--- a/src/sidebar/util/test/oauth-client-test.js
+++ b/src/sidebar/util/test/oauth-client-test.js
@@ -217,7 +217,7 @@ describe('sidebar/util/oauth-client', () => {
         fakeWindow.open,
         expectedAuthURL,
         'Log in to Hypothesis',
-        'left=274.5,top=169,width=475,height=430',
+        'left=274.5,top=69,width=475,height=630',
       );
 
       fakeWindow.sendMessage({


### PR DESCRIPTION
Increase the height of the login popup window to accomodate the UIs of the different social login providers (Google, Facebook, ORCID) that the user may directed through. This also creates room to show social login options on the initial form.

For a short period of time the window will seem redundantly tall, until we enable social login in production. We could alleviate that by vertically centering the contents in h if social login is disabled.

See https://hypothes-is.slack.com/archives/C4K6M7P5E/p1754045015491359?thread_ts=1754040814.938669&cid=C4K6M7P5E for notes and screenshots.