### PR TITLE
Allow moderating annotations via ModerationStatusSelect

### DIFF
--- a/src/sidebar/components/moderation/ModerationControl.tsx
+++ b/src/sidebar/components/moderation/ModerationControl.tsx
@@ -1,22 +1,60 @@
+import type { ModerationStatus } from '@hypothesis/annotation-ui';
 import { ModerationStatusSelect } from '@hypothesis/annotation-ui';
+import { useCallback, useState } from 'preact/hooks';
 
-import type { Annotation } from '../../../types/api';
+import type { SavedAnnotation } from '../../../types/api';
+import { withServices } from '../../service-context';
+import type { AnnotationsService } from '../../services/annotations';
+import type { ToastMessengerService } from '../../services/toast-messenger';
+import { FetchError } from '../../util/fetch';
 import ModerationStatusBadge from './ModerationStatusBadge';
 
 export type ModerationControlProps = {
-  annotation: Annotation;
+  annotation: SavedAnnotation;
   groupIsPreModerated: boolean;
   /** Classes to apply to the ModerationStatusBadge in case it's rendered */
   badgeClasses?: string | string[];
+
+  // Injected
+  annotationsService: AnnotationsService;
+  toastMessenger: ToastMessengerService;
 };
 
-export default function ModerationControl({
+function ModerationControl({
   annotation,
   groupIsPreModerated,
   badgeClasses,
+  annotationsService,
+  toastMessenger,
 }: ModerationControlProps) {
   const canModerate = annotation.actions?.includes('moderate');
   const moderationStatus = annotation?.moderation_status ?? 'APPROVED';
+  const [changingStatus, setChangingStatus] = useState(false);
+  const changeModerationStatus = useCallback(
+    async (newStatus: ModerationStatus) => {
+      setChangingStatus(true);
+      try {
+        await annotationsService.moderate(annotation, newStatus);
+      } catch (e) {
+        const isConflictError =
+          e instanceof FetchError && e.response?.status === 409;
+
+        if (isConflictError) {
+          toastMessenger.notice(
+            'The annotation has been updated since this page was loaded',
+            { autoDismiss: false },
+          );
+        } else {
+          toastMessenger.error(
+            'An error occurred updating the moderation status',
+          );
+        }
+      } finally {
+        setChangingStatus(false);
+      }
+    },
+    [annotation, annotationsService, toastMessenger],
+  );
 
   // We don't want to show any moderation control for approved annotations in
   // non-pre-moderated groups, to avoid cluttering the UI, since most,
@@ -28,12 +66,17 @@ export default function ModerationControl({
   return canModerate ? (
     <ModerationStatusSelect
       mode="select"
-      selected={moderationStatus}
-      /* TODO Implement logic to change the status */
-      onChange={/* istanbul ignore next */ () => {}}
       alignListbox="left"
+      selected={moderationStatus}
+      onChange={changeModerationStatus}
+      disabled={changingStatus}
     />
   ) : (
     <ModerationStatusBadge status={moderationStatus} classes={badgeClasses} />
   );
 }
+
+export default withServices(ModerationControl, [
+  'annotationsService',
+  'toastMessenger',
+]);

--- a/src/sidebar/services/annotations.ts
+++ b/src/sidebar/services/annotations.ts
@@ -1,3 +1,5 @@
+import type { ModerationStatus } from '@hypothesis/annotation-ui';
+
 import { generateHexString } from '../../shared/random';
 import type { AnnotationData } from '../../types/annotator';
 import type {
@@ -314,6 +316,25 @@ export class AnnotationsService {
 
     // Add (or, in effect, update) the annotation to the store's collection
     this._store.addAnnotations([savedAnnotation]);
+    return savedAnnotation;
+  }
+
+  /**
+   * Change an annotation's moderation status, then update the annotation in
+   * the store
+   */
+  async moderate(
+    annotation: SavedAnnotation,
+    newStatus: ModerationStatus,
+  ): Promise<Annotation> {
+    const savedAnnotation = await this._api.annotation.moderate(
+      { id: annotation.id },
+      { moderation_status: newStatus, annotation_updated: annotation.updated },
+    );
+
+    // Add (or, in effect, update) the annotation to the store's collection
+    this._store.addAnnotations([savedAnnotation]);
+
     return savedAnnotation;
   }
 }

--- a/src/sidebar/services/api.ts
+++ b/src/sidebar/services/api.ts
@@ -5,6 +5,7 @@ import type {
   RouteMetadata,
   Profile,
   GroupMembers,
+  AnnotationModeration,
 } from '../../types/api';
 import { stripInternalProperties } from '../helpers/strip-internal-properties';
 import type { SidebarStore } from '../store';
@@ -214,6 +215,7 @@ export class APIService {
     flag: APICall<IDParam>;
     hide: APICall<IDParam>;
     unhide: APICall<IDParam>;
+    moderate: APICall<IDParam, AnnotationModeration, Annotation>;
   };
   group: {
     member: {
@@ -291,6 +293,11 @@ export class APIService {
       flag: apiCall('annotation.flag') as APICall<IDParam>,
       hide: apiCall('annotation.hide') as APICall<IDParam>,
       unhide: apiCall('annotation.unhide') as APICall<IDParam>,
+      moderate: apiCall('annotation.moderate') as APICall<
+        IDParam,
+        AnnotationModeration,
+        Annotation
+      >,
     };
     this.group = {
       member: {

--- a/src/sidebar/services/test/annotations-test.js
+++ b/src/sidebar/services/test/annotations-test.js
@@ -44,6 +44,7 @@ describe('AnnotationsService', () => {
         delete: sinon.stub().resolves(),
         flag: sinon.stub().resolves(),
         update: sinon.stub().resolves(fixtures.defaultAnnotation()),
+        moderate: sinon.stub().resolves(fixtures.defaultAnnotation()),
       },
     };
 
@@ -661,6 +662,31 @@ describe('AnnotationsService', () => {
           assert.notCalled(fakeStore.addAnnotations);
         });
       });
+    });
+  });
+
+  describe('moderate', () => {
+    it('calls the `moderate` API service', async () => {
+      const annotation = fixtures.defaultAnnotation();
+      await svc.moderate(annotation, 'APPROVED');
+
+      assert.calledWith(
+        fakeApi.annotation.moderate,
+        { id: annotation.id },
+        {
+          moderation_status: 'APPROVED',
+          annotation_updated: annotation.updated,
+        },
+      );
+    });
+
+    it('updates annotation in store', async () => {
+      const annotation = fixtures.defaultAnnotation();
+      await svc.moderate(annotation, 'APPROVED');
+
+      const savedAnnotation =
+        await fakeApi.annotation.moderate.lastCall.returnValue;
+      assert.calledWith(fakeStore.addAnnotations, [savedAnnotation]);
     });
   });
 });

--- a/src/sidebar/services/test/api-index.json
+++ b/src/sidebar/services/test/api-index.json
@@ -90,6 +90,11 @@
         "url": "https://example.com/api/annotations/:id",
         "method": "DELETE",
         "desc": "Delete an annotation"
+      },
+      "moderate": {
+        "url": "https://example.com/api/annotations/:id/moderation",
+        "method": "PATCH",
+        "desc": "Moderate an annotation"
       }
     },
     "analytics": {

--- a/src/sidebar/services/test/api-test.js
+++ b/src/sidebar/services/test/api-test.js
@@ -119,6 +119,11 @@ describe('APIService', () => {
     return api.annotation.unhide({ id: 'an-id' });
   });
 
+  it('moderates an annotation', () => {
+    expectCall('patch', 'annotations/an-id/moderation');
+    return api.annotation.moderate({ id: 'an-id' }, 'DENIED');
+  });
+
   it('removes current user from a group', () => {
     expectCall('delete', 'groups/an-id/members/me', 204);
     return api.group.member.delete({ pubid: 'an-id', userid: 'me' });

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -479,3 +479,17 @@ export type SearchResponse = {
   /** Undocumented property that is populated if `_separate_replies` query param was specified. */
   replies?: Annotation[];
 };
+
+/**
+ * Body of request to moderate an annotation via `/api/annotation/{id}/moderation`
+ */
+export type AnnotationModeration = {
+  moderation_status: ModerationStatus;
+
+  /**
+   * The annotation's current updated time, used to know if the annotation has
+   * changed since it was first loaded, which would cause a conflict error to be
+   * returned by the backend.
+   */
+  annotation_updated: ISODateTime;
+};


### PR DESCRIPTION
Part of  #7050

Allow moderation status to be changed by group moderators when selecting a different status from the status select.

[Grabación de pantalla desde 2025-08-04 12-42-15.webm](https://github.com/user-attachments/assets/d6c02d20-c7db-4a36-9fed-f91760360774)

Conflict error:

[Grabación de pantalla desde 2025-08-04 15-54-01.webm](https://github.com/user-attachments/assets/f840950e-f7c8-4f42-8073-ccebe98b1b8c)

> [!NOTE]
> This PR does not cover updating the annotation data as we do in h, I'll do that in a follow-up PR.
> The message is still rendered as a notice though, to avoid unnecessary future changes.

Other unknown errors:

[Grabación de pantalla desde 2025-08-04 15-55-29.webm](https://github.com/user-attachments/assets/dcd0751c-c305-4d06-b13a-27216ffd1069)

### Considerations

The status is not changed in the UI until the request succeeds, but the select is disabled in the meantime, to avoid accidental changes in parallel.

I did not add any loading state, assuming the action shouldn't usually take a lot of time, to avoid a lot of flickering in the UI. However, we could consider doing an optimistic update that is changed back only in case of error.

### TODO

- [x] Add tests
- [x] Handle errors
- [x] Check if we need to report the moderation activity (see https://github.com/hypothesis/client/pull/7236#discussion_r2251119925)