### PR TITLE
Reload annotation when conflict occurs during moderation

### DIFF
--- a/src/sidebar/services/annotations.ts
+++ b/src/sidebar/services/annotations.ts
@@ -337,4 +337,16 @@ export class AnnotationsService {
 
     return savedAnnotation;
   }
+
+  /**
+   * Fetch an annotation from the API and add or update it in the store
+   */
+  async loadAnnotation(id: string): Promise<Annotation> {
+    const annotation = await this._api.annotation.read({ id });
+
+    // Add or update the annotation in the store's collection
+    this._store.addAnnotations([annotation]);
+
+    return annotation;
+  }
 }

--- a/src/sidebar/services/api.ts
+++ b/src/sidebar/services/api.ts
@@ -208,6 +208,7 @@ export class APIService {
 
   search: APICall<Record<string, unknown>, void, AnnotationSearchResult>;
   annotation: {
+    read: APICall<IDParam, void, Annotation>;
     create: APICall<Record<string, unknown>, Partial<Annotation>, Annotation>;
     delete: APICall<IDParam>;
     get: APICall<IDParam, void, Annotation>;
@@ -278,6 +279,7 @@ export class APIService {
       AnnotationSearchResult
     >;
     this.annotation = {
+      read: apiCall('annotation.read') as APICall<IDParam, void, Annotation>,
       create: apiCall('annotation.create') as APICall<
         Record<string, unknown>,
         Partial<Annotation>,

--- a/src/sidebar/services/test/annotations-test.js
+++ b/src/sidebar/services/test/annotations-test.js
@@ -40,6 +40,7 @@ describe('AnnotationsService', () => {
     };
     fakeApi = {
       annotation: {
+        read: sinon.stub().resolves(fixtures.defaultAnnotation()),
         create: sinon.stub().resolves(fixtures.defaultAnnotation()),
         delete: sinon.stub().resolves(),
         flag: sinon.stub().resolves(),
@@ -686,6 +687,24 @@ describe('AnnotationsService', () => {
 
       const savedAnnotation =
         await fakeApi.annotation.moderate.lastCall.returnValue;
+      assert.calledWith(fakeStore.addAnnotations, [savedAnnotation]);
+    });
+  });
+
+  describe('loadAnnotation', () => {
+    it('calls the `read` API service', async () => {
+      const annotation = fixtures.defaultAnnotation();
+      await svc.loadAnnotation(annotation.id);
+
+      assert.calledWith(fakeApi.annotation.read, { id: annotation.id });
+    });
+
+    it('updates annotation in store', async () => {
+      const annotation = fixtures.defaultAnnotation();
+      await svc.loadAnnotation(annotation.id);
+
+      const savedAnnotation =
+        await fakeApi.annotation.read.lastCall.returnValue;
       assert.calledWith(fakeStore.addAnnotations, [savedAnnotation]);
     });
   });

--- a/src/sidebar/services/test/api-test.js
+++ b/src/sidebar/services/test/api-test.js
@@ -85,6 +85,11 @@ describe('APIService', () => {
     fetchMock.restore();
   });
 
+  it('reads an annotation', () => {
+    expectCall('get', 'annotations/an-id');
+    return api.annotation.read({ id: 'an-id' });
+  });
+
   it('saves a new annotation', () => {
     // nb. The Hypothesis API returns 200 here not 201 as one might expect.
     expectCall('post', 'annotations', 200, { id: 'new-id' });


### PR DESCRIPTION
Depends on https://github.com/hypothesis/client/pull/7236
Closes https://github.com/hypothesis/client/issues/7050

When the server returns a conflict while trying to moderate an annotation, try to reload that annotation so that user can retry again based on the most recent content.

The logic is very similar to how it works in h moderation queue, where we capture errors when trying to moderate the annotation and do one of these things:

1. If the error is unknown, we display a generic error in an error toast message.
2. If the error is a conflict, we try to reload the annotation, and
    1. If reloading the annotation succeeds, we update it in the UI, and display a notice toast message indicating there was a conflict, but the ifno is now up to date and the user can retry.
    2. If it fails, we display an error toast message just indicating there was a conflict.

### Testing

1. Open http://localhost:3000 as a moderator in two different browsers.
4. Open a pre-moderated group, and make sure at least one annotation is created for the user.
5. Edit the annotation in one browser, then try to moderate it from the other one.
6. You should see the annotation being updated, and a toast message indicating the status could not be changed but the annotation has been updated.