### PR TITLE
Send current_moderation_status when moderating annotations

### DIFF
--- a/src/sidebar/services/annotations.ts
+++ b/src/sidebar/services/annotations.ts
@@ -329,7 +329,11 @@ export class AnnotationsService {
   ): Promise<Annotation> {
     const savedAnnotation = await this._api.annotation.moderate(
       { id: annotation.id },
-      { moderation_status: newStatus, annotation_updated: annotation.updated },
+      {
+        moderation_status: newStatus,
+        current_moderation_status: annotation.moderation_status,
+        annotation_updated: annotation.updated,
+      },
     );
 
     // Add (or, in effect, update) the annotation to the store's collection

--- a/src/sidebar/services/test/annotations-test.js
+++ b/src/sidebar/services/test/annotations-test.js
@@ -668,7 +668,10 @@ describe('AnnotationsService', () => {
 
   describe('moderate', () => {
     it('calls the `moderate` API service', async () => {
-      const annotation = fixtures.defaultAnnotation();
+      const annotation = {
+        ...fixtures.defaultAnnotation(),
+        moderation_status: 'PENDING',
+      };
       await svc.moderate(annotation, 'APPROVED');
 
       assert.calledWith(
@@ -676,6 +679,7 @@ describe('AnnotationsService', () => {
         { id: annotation.id },
         {
           moderation_status: 'APPROVED',
+          current_moderation_status: annotation.moderation_status,
           annotation_updated: annotation.updated,
         },
       );

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -487,9 +487,16 @@ export type AnnotationModeration = {
   moderation_status: ModerationStatus;
 
   /**
-   * The annotation's current updated time, used to know if the annotation has
-   * changed since it was first loaded, which would cause a conflict error to be
-   * returned by the backend.
+   * The annotation's current moderation status, used to check if the annotation
+   * has been moderated since it was loaded. If it has, the server will return a
+   * 409 Conflict response.
+   */
+  current_moderation_status?: ModerationStatus;
+
+  /**
+   * The annotation's current updated time, used to check if the annotation has
+   * changed since it was loaded. If it has, the server will return a 409
+   * Conflict response.
    */
   annotation_updated: ISODateTime;
 };


### PR DESCRIPTION
Part of https://github.com/hypothesis/h/issues/9743

This is the same that has been implemented in https://github.com/hypothesis/h/pull/9801, but for the client.

### Testing

Follow the test steps described in https://github.com/hypothesis/h/pull/9801, but opening the client in two browsers, instead of the moderation queue.