### PR TITLE
Rename ModerationBanner to FlagBanner

### DIFF
--- a/src/sidebar/components/FlagBanner.tsx
+++ b/src/sidebar/components/FlagBanner.tsx
@@ -8,7 +8,7 @@ import type { APIService } from '../services/api';
 import type { ToastMessengerService } from '../services/toast-messenger';
 import { useSidebarStore } from '../store';
 
-export type ModerationBannerProps = {
+export type FlagBannerProps = {
   annotation: Annotation;
 
   // injected
@@ -20,11 +20,7 @@ export type ModerationBannerProps = {
  * Banner allows moderators to hide/unhide the flagged annotation from other
  * users.
  */
-function ModerationBanner({
-  annotation,
-  api,
-  toastMessenger,
-}: ModerationBannerProps) {
+function FlagBanner({ annotation, api, toastMessenger }: FlagBannerProps) {
   const store = useSidebarStore();
   const flagCount = annotationMetadata.flagCount(annotation);
 
@@ -64,6 +60,7 @@ function ModerationBanner({
   if (!isHiddenOrFlagged) {
     return null;
   }
+
   return (
     <div
       className={classnames(
@@ -127,4 +124,4 @@ function ModerationBanner({
   );
 }
 
-export default withServices(ModerationBanner, ['api', 'toastMessenger']);
+export default withServices(FlagBanner, ['api', 'toastMessenger']);

--- a/src/sidebar/components/Thread.tsx
+++ b/src/sidebar/components/Thread.tsx
@@ -14,7 +14,7 @@ import { useSidebarStore } from '../store';
 import Annotation from './Annotation';
 import AnnotationHeader from './Annotation/AnnotationHeader';
 import EmptyAnnotation from './Annotation/EmptyAnnotation';
-import ModerationBanner from './ModerationBanner';
+import FlagBanner from './FlagBanner';
 
 type ThreadCollapseControlProps = {
   threadIsCollapsed: boolean;
@@ -128,7 +128,7 @@ function Thread({ thread, threadsService }: ThreadProps) {
         <>
           {thread.annotation ? (
             <>
-              <ModerationBanner annotation={thread.annotation} />
+              <FlagBanner annotation={thread.annotation} />
               <Annotation
                 annotation={thread.annotation}
                 isReply={isReply}

--- a/src/sidebar/components/test/FlagBanner-test.js
+++ b/src/sidebar/components/test/FlagBanner-test.js
@@ -6,17 +6,17 @@ import {
 import { mount } from '@hypothesis/frontend-testing';
 
 import * as fixtures from '../../test/annotation-fixtures';
-import ModerationBanner, { $imports } from '../ModerationBanner';
+import FlagBanner, { $imports } from '../FlagBanner';
 
 const moderatedAnnotation = fixtures.moderatedAnnotation;
 
-describe('ModerationBanner', () => {
+describe('FlagBanner', () => {
   let fakeApi;
   let fakeToastMessenger;
 
   function createComponent(props) {
     return mount(
-      <ModerationBanner
+      <FlagBanner
         api={fakeApi}
         toastMessenger={fakeToastMessenger}
         {...props}

--- a/src/sidebar/components/test/Thread-test.js
+++ b/src/sidebar/components/test/Thread-test.js
@@ -149,7 +149,7 @@ describe('Thread', () => {
       // is an `annotation` object
       const wrapper = createComponent();
 
-      assert.isTrue(wrapper.exists('ModerationBanner'));
+      assert.isTrue(wrapper.exists('FlagBanner'));
     });
 
     it('renders the annotation', () => {


### PR DESCRIPTION
Part of #7247 

Now that we are adding more advanced moderation capabilities to the app, everything around flagging annotations overlaps a bit and needs a bit of extra thinking.

In fact, hiding/unhiding flagged annotations was already refactored to use the new moderation system internally.

As a first step I'm renaming ModerationBanner, which is only used to indicate if an annotation is flagged and let moderators hide/unhide it, to FlagBanner, to make it more clear it does not allow all the options that current moderation system allows.

In follow-up PRs I will simplify this component, as some of the things it allows can now be done differently.