### PR TITLE
Normalize flag-related UI for new moderation system

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationBody.tsx
+++ b/src/sidebar/components/Annotation/AnnotationBody.tsx
@@ -6,7 +6,6 @@ import { useMemo, useState } from 'preact/hooks';
 import type { Annotation } from '../../../types/api';
 import type { SidebarSettings } from '../../../types/config';
 import { isThirdPartyUser } from '../../helpers/account-id';
-import { isHidden } from '../../helpers/annotation-metadata';
 import type { MentionMode } from '../../helpers/mentions';
 import { applyTheme } from '../../helpers/theme';
 import { withServices } from '../../service-context';
@@ -106,9 +105,6 @@ function AnnotationBody({ annotation, settings }: AnnotationBodyProps) {
         >
           <MarkdownView
             markdown={text}
-            classes={classnames({
-              'p-redacted-text': isHidden(annotation),
-            })}
             style={textStyle}
             mentions={annotation.mentions}
             mentionsEnabled={mentionsEnabled}

--- a/src/sidebar/components/FlagBanner.tsx
+++ b/src/sidebar/components/FlagBanner.tsx
@@ -1,63 +1,21 @@
-import { Button, FlagIcon, HideIcon } from '@hypothesis/frontend-shared';
+import { FlagIcon, HideIcon } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 
 import type { Annotation } from '../../types/api';
 import * as annotationMetadata from '../helpers/annotation-metadata';
-import { withServices } from '../service-context';
-import type { APIService } from '../services/api';
-import type { ToastMessengerService } from '../services/toast-messenger';
-import { useSidebarStore } from '../store';
 
 export type FlagBannerProps = {
   annotation: Annotation;
-
-  // injected
-  api: APIService;
-  toastMessenger: ToastMessengerService;
 };
 
 /**
- * Banner allows moderators to hide/unhide the flagged annotation from other
- * users.
+ * Banner allows moderators to know if an annotation is flagged
  */
-function FlagBanner({ annotation, api, toastMessenger }: FlagBannerProps) {
-  const store = useSidebarStore();
+export default function FlagBanner({ annotation }: FlagBannerProps) {
   const flagCount = annotationMetadata.flagCount(annotation);
+  const isFlagged = !!flagCount;
 
-  const isHiddenOrFlagged =
-    flagCount !== null && (flagCount > 0 || annotation.hidden);
-
-  /**
-   * Hide an annotation from non-moderator users.
-   */
-  const hideAnnotation = () => {
-    const id = annotation.id!;
-    api.annotation
-      .hide({ id })
-      .then(() => {
-        store.hideAnnotation(id);
-      })
-      .catch(() => {
-        toastMessenger.error('Failed to hide annotation');
-      });
-  };
-
-  /**
-   * Un-hide an annotation from non-moderator users.
-   */
-  const unhideAnnotation = () => {
-    const id = annotation.id!;
-    api.annotation
-      .unhide({ id })
-      .then(() => {
-        store.unhideAnnotation(id);
-      })
-      .catch(() => {
-        toastMessenger.error('Failed to unhide annotation');
-      });
-  };
-
-  if (!isHiddenOrFlagged) {
+  if (!isFlagged) {
     return null;
   }
 
@@ -100,28 +58,6 @@ function FlagBanner({ annotation, api, toastMessenger }: FlagBannerProps) {
         )}
         {annotation.hidden && <span>Hidden from users</span>}
       </div>
-      <div className="self-center pr-2">
-        <Button
-          classes={classnames(
-            'px-1.5 py-1',
-            'bg-slate-1 text-grey-7 bg-grey-2',
-            'enabled:hover:text-grey-9 enabled:hover:bg-grey-3 disabled:text-grey-5',
-            'aria-pressed:bg-grey-3 aria-expanded:bg-grey-3',
-          )}
-          onClick={annotation.hidden ? unhideAnnotation : hideAnnotation}
-          title={
-            annotation.hidden
-              ? 'Make this annotation visible to everyone'
-              : 'Hide this annotation from non-moderators'
-          }
-          size="custom"
-          variant="custom"
-        >
-          {annotation.hidden ? 'Unhide' : 'Hide'}
-        </Button>
-      </div>
     </div>
   );
 }
-
-export default withServices(FlagBanner, ['api', 'toastMessenger']);

--- a/src/sidebar/components/moderation/ModerationControl.tsx
+++ b/src/sidebar/components/moderation/ModerationControl.tsx
@@ -3,6 +3,7 @@ import { ModerationStatusSelect } from '@hypothesis/annotation-ui';
 import { useCallback, useState } from 'preact/hooks';
 
 import type { SavedAnnotation } from '../../../types/api';
+import { flagCount } from '../../helpers/annotation-metadata';
 import { withServices } from '../../service-context';
 import type { AnnotationsService } from '../../services/annotations';
 import type { ToastMessengerService } from '../../services/toast-messenger';
@@ -73,10 +74,18 @@ function ModerationControl({
     [annotation, annotationsService, handleChangeStatusError],
   );
 
+  const isAnnotationFlagged = !!flagCount(annotation);
+
   // We don't want to show any moderation control for approved annotations in
   // non-pre-moderated groups, to avoid cluttering the UI, since most,
   // annotations will have `APPROVED` status.
-  if (!groupIsPreModerated && moderationStatus === 'APPROVED') {
+  // Flagged annotations should always show the control to allow
+  // hiding/unhiding on the spot.
+  if (
+    !groupIsPreModerated &&
+    moderationStatus === 'APPROVED' &&
+    !isAnnotationFlagged
+  ) {
     return null;
   }
 

--- a/src/sidebar/components/moderation/test/ModerationControl-test.js
+++ b/src/sidebar/components/moderation/test/ModerationControl-test.js
@@ -56,6 +56,21 @@ describe('ModerationControl', () => {
     assert.isFalse(wrapper.exists('ModerationStatusBadge'));
   });
 
+  it('renders ModerationStatusSelect for APPROVED annotations in non-pre-moderated groups, if annotation is flagged', () => {
+    const wrapper = createComponent({
+      annotation: {
+        ...defaultAnnotation(),
+        actions: ['moderate'],
+        moderation_status: 'APPROVED',
+        moderation: { flagCount: 10 },
+      },
+      groupIsPreModerated: false,
+    });
+
+    assert.isTrue(wrapper.exists('ModerationStatusSelect'));
+    assert.isFalse(wrapper.exists('ModerationStatusBadge'));
+  });
+
   it('renders ModerationStatusBadge when annotation cannot be moderated', () => {
     const wrapper = createComponent({
       annotation: defaultAnnotation(),

--- a/src/sidebar/helpers/annotation-metadata.ts
+++ b/src/sidebar/helpers/annotation-metadata.ts
@@ -66,13 +66,6 @@ export function isWaitingToAnchor(annotation: Annotation): boolean {
 }
 
 /**
- * Has this annotation hidden by moderators?
- */
-export function isHidden(annotation: Annotation): boolean {
-  return !!annotation.hidden;
-}
-
-/**
  * Is this annotation a highlight?
  *
  * Highlights are generally identifiable by having no text content AND no tags,
@@ -240,10 +233,7 @@ function distanceFromTopOfView(selector: ShapeSelector): number | undefined {
  * by other users. If moderation metadata is not present, returns `null`.
  */
 export function flagCount(annotation: Annotation): number | null {
-  if (!annotation.moderation) {
-    return null;
-  }
-  return annotation.moderation.flagCount;
+  return annotation.moderation?.flagCount ?? null;
 }
 
 /**

--- a/src/sidebar/helpers/test/annotation-metadata-test.js
+++ b/src/sidebar/helpers/test/annotation-metadata-test.js
@@ -189,24 +189,6 @@ describe('sidebar/helpers/annotation-metadata', () => {
     });
   });
 
-  describe('isHidden', () => {
-    it('returns `true` if annotation has been hidden', () => {
-      const annotation = fixtures.moderatedAnnotation({ hidden: true });
-      assert.isTrue(annotationMetadata.isHidden(annotation));
-    });
-
-    [
-      fixtures.newEmptyAnnotation(),
-      fixtures.newReply(),
-      fixtures.newHighlight(),
-      fixtures.oldAnnotation(),
-    ].forEach(nonHiddenAnnotation => {
-      it('returns `false` if annotation is not hidden', () => {
-        assert.isFalse(annotationMetadata.isHidden(nonHiddenAnnotation));
-      });
-    });
-  });
-
   describe('isHighlight', () => {
     [
       {

--- a/src/sidebar/store/modules/annotations.ts
+++ b/src/sidebar/store/modules/annotations.ts
@@ -202,16 +202,6 @@ const reducers = {
     return { hovered: toTrueMap(action.tags) };
   },
 
-  HIDE_ANNOTATION(state: State, action: { id: string }): Partial<State> {
-    const anns = state.annotations.map(ann => {
-      if (ann.id !== action.id) {
-        return ann;
-      }
-      return { ...ann, hidden: true };
-    });
-    return { annotations: anns };
-  },
-
   HIGHLIGHT_ANNOTATIONS(
     state: State,
     action: Pick<State, 'highlighted'>,
@@ -229,16 +219,6 @@ const reducers = {
     return {
       annotations: [...action.remainingAnnotations],
     };
-  },
-
-  UNHIDE_ANNOTATION(state: State, action: { id: string }): Partial<State> {
-    const anns = state.annotations.map(ann => {
-      if (ann.id !== action.id) {
-        return ann;
-      }
-      return Object.assign({}, ann, { hidden: false });
-    });
-    return { annotations: anns };
   },
 
   UPDATE_ANCHOR_STATUS(
@@ -373,16 +353,6 @@ function hoverAnnotations(tags: string[]) {
 }
 
 /**
- * Update the local hidden state of an annotation.
- *
- * This updates an annotation to reflect the fact that it has been hidden from
- * non-moderators.
- */
-function hideAnnotation(id: string) {
-  return makeAction(reducers, 'HIDE_ANNOTATION', { id });
-}
-
-/**
  * Highlight annotations with the given `ids`.
  *
  * This is used to add a visual indicator to specific annotation cards, like a
@@ -416,16 +386,6 @@ export function removeAnnotations(annotations: AnnotationStub[]) {
       }),
     );
   };
-}
-
-/**
- * Update the local hidden state of an annotation.
- *
- * This updates an annotation to reflect the fact that it has been made visible
- * to non-moderators.
- */
-function unhideAnnotation(id: string) {
-  return makeAction(reducers, 'UNHIDE_ANNOTATION', { id });
 }
 
 /**
@@ -633,10 +593,8 @@ export const annotationsModule = createStoreModule(initialState, {
     addAnnotations,
     clearAnnotations,
     hoverAnnotations,
-    hideAnnotation,
     highlightAnnotations,
     removeAnnotations,
-    unhideAnnotation,
     updateAnchorStatus,
     updateFlagStatus,
   },

--- a/src/sidebar/store/modules/test/annotations-test.js
+++ b/src/sidebar/store/modules/test/annotations-test.js
@@ -417,32 +417,6 @@ describe('sidebar/store/modules/annotations', () => {
     });
   });
 
-  describe('#hideAnnotation', () => {
-    it('sets the `hidden` state to `true`', () => {
-      const store = createTestStore();
-      const ann = fixtures.moderatedAnnotation({ hidden: false });
-
-      store.addAnnotations([ann]);
-      store.hideAnnotation(ann.id);
-
-      const storeAnn = store.findAnnotationByID(ann.id);
-      assert.equal(storeAnn.hidden, true);
-    });
-  });
-
-  describe('#unhideAnnotation', () => {
-    it('sets the `hidden` state to `false`', () => {
-      const store = createTestStore();
-      const ann = fixtures.moderatedAnnotation({ hidden: true });
-
-      store.addAnnotations([ann]);
-      store.unhideAnnotation(ann.id);
-
-      const storeAnn = store.findAnnotationByID(ann.id);
-      assert.equal(storeAnn.hidden, false);
-    });
-  });
-
   describe('#removeAnnotations', () => {
     it('removes the annotation', () => {
       const store = createTestStore();


### PR DESCRIPTION
Depends on https://github.com/hypothesis/client/pull/7246
Closes #7247 

As described in #7247, this PR applies the next changes to flag-related pieces of UI:

- [x] Display the flag banner (formerly known as moderation banner) only if the annotation has been flagged, regardless of its ''hidden'' property, to prevent the banner from showing for every single pending annotation in pre-moderated groups.
- [x] Remove the "hide"/"unhide" button from the flag banner, as those implicitly mark annotations as `SPAM` or `APPROVED` respectively. We want user to now use the moderation select for this task.
- [x] Always display the moderation select in flagged annotations, even for non-pre-moderated groups, so that admins can hide them right away.
- [x] Remove the strikethrough style in hidden annotations, as that affects any non-approved annotation now.

### TODO

- [x] Adjust tests