### PR TITLE
Make Sign up button open authorization popup window

### DIFF
--- a/src/sidebar/components/HypothesisApp.tsx
+++ b/src/sidebar/components/HypothesisApp.tsx
@@ -66,15 +66,9 @@ function HypothesisApp({
 
   const isThirdParty = isThirdPartyService(settings);
 
-  const login = async () => {
-    if (serviceConfig(settings)) {
-      // Let the host page handle the login request
-      frameSync.notifyHost('loginRequested');
-      return;
-    }
-
+  const loginOrSignUp = async (action: 'login' | 'signup') => {
     try {
-      await auth.login();
+      await auth.login({ action });
 
       store.closeSidebarPanel('loginPrompt');
       store.clearGroups();
@@ -84,13 +78,22 @@ function HypothesisApp({
     }
   };
 
-  const signUp = () => {
+  const login = async () => {
+    if (serviceConfig(settings)) {
+      // Let the host page handle the login request
+      frameSync.notifyHost('loginRequested');
+      return;
+    }
+    await loginOrSignUp('login');
+  };
+
+  const signUp = async () => {
     if (serviceConfig(settings)) {
       // Let the host page handle the signup request
       frameSync.notifyHost('signupRequested');
       return;
     }
-    window.open(store.getLink('signup'));
+    await loginOrSignUp('signup');
   };
 
   const promptToLogout = async () => {

--- a/src/sidebar/services/auth.ts
+++ b/src/sidebar/services/auth.ts
@@ -23,6 +23,17 @@ const isTokenInfo = (token: unknown): token is TokenInfo =>
   'expiresAt' in token &&
   typeof token.expiresAt === 'number';
 
+export type LoginOptions = {
+  /**
+   * A hint passed to the server for whether the user clicked a "Sign up" or
+   * "Log in" action.
+   *
+   * This is used to determine which form to show in the authorization popup if
+   * the user is not logged in.
+   */
+  action?: 'login' | 'signup';
+};
+
 export type Events = {
   oauthTokensChanged(): void;
 };
@@ -298,7 +309,7 @@ export class AuthService extends EventEmitter<Events> {
    * Store the resulting authorization code to exchange for an access token in
    * the next API call ( {@see getAccessToken} )
    */
-  async login() {
+  async login({ action = 'login' }: LoginOptions = {}) {
     // Any async steps before the call to `client.authorize` must complete
     // in less than ~1 second, otherwise the browser's popup blocker may block
     // the popup.
@@ -307,7 +318,7 @@ export class AuthService extends EventEmitter<Events> {
     // This should already have happened by the time this function is called
     // however, so it will just be returning a cached value.
     const client = await this._oauthClient();
-    const authCode = await client.authorize(this._window);
+    const authCode = await client.authorize(this._window, action);
 
     // Save the auth code. It will be exchanged for an access token when the
     // next API request is made.

--- a/src/sidebar/services/test/auth-test.js
+++ b/src/sidebar/services/test/auth-test.js
@@ -529,9 +529,11 @@ describe('AuthService', () => {
       fakeSettings.services = [];
     });
 
-    it('calls OAuthClient#authorize', async () => {
-      await auth.login();
-      assert.calledWith(fakeClient.authorize, fakeWindow);
+    ['login', 'signup'].forEach(action => {
+      it('calls OAuthClient#authorize', async () => {
+        await auth.login({ action });
+        assert.calledWith(fakeClient.authorize, fakeWindow);
+      });
     });
 
     it('resolves when auth completes successfully', () => {

--- a/src/sidebar/util/oauth-client.ts
+++ b/src/sidebar/util/oauth-client.ts
@@ -179,7 +179,10 @@ export class OAuthClient {
    * @param $window - Window which will receive the auth response.
    * @return - Authorization code which can be passed to {@link exchangeAuthCode}.
    */
-  authorize($window: Window): Promise<string> {
+  authorize(
+    $window: Window,
+    action: 'login' | 'signup' = 'login',
+  ): Promise<string> {
     // Random state string used to check that auth messages came from the popup
     // window that we opened.
     //
@@ -219,6 +222,7 @@ export class OAuthClient {
     authURL.searchParams.set('response_mode', 'web_message');
     authURL.searchParams.set('response_type', 'code');
     authURL.searchParams.set('state', state);
+    authURL.searchParams.set('action', action);
 
     // The sizes are chosen to be sufficient for our own login and sign-up UI,
     // as well as the social login flows (Google etc.) that the user may be


### PR DESCRIPTION
Make the "Sign up" button in the client open the authorization popup window with an `action=signup` parameter to hint to h that the user clicked "Sign up" rather than "Log in".

This supports a flow where the user can sign up for Hypothesis via a social login and be immediately logged in.

**Testing:**

See https://github.com/hypothesis/h/pull/9817.