### PR TITLE
Fix regression on excerpt link style

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationQuote.tsx
+++ b/src/sidebar/components/Annotation/AnnotationQuote.tsx
@@ -1,9 +1,10 @@
-import { Excerpt, StyledText } from '@hypothesis/annotation-ui';
+import { StyledText } from '@hypothesis/annotation-ui';
 import classnames from 'classnames';
 
 import type { SidebarSettings } from '../../../types/config';
 import { applyTheme } from '../../helpers/theme';
 import { withServices } from '../../service-context';
+import InlineControlExcerpt from '../InlineControlExcerpt';
 
 type AnnotationQuoteProps = {
   quote: string;
@@ -22,7 +23,7 @@ function AnnotationQuote({
   settings,
 }: AnnotationQuoteProps) {
   return (
-    <Excerpt collapsedHeight={35} inlineControls={true} overflowThreshold={20}>
+    <InlineControlExcerpt collapsedHeight={35} overflowThreshold={20}>
       <StyledText classes={classnames({ 'p-redacted-text': isOrphan })}>
         <blockquote
           className={classnames('hover:border-l-blue-quote', {
@@ -33,7 +34,7 @@ function AnnotationQuote({
           {quote}
         </blockquote>
       </StyledText>
-    </Excerpt>
+    </InlineControlExcerpt>
   );
 }
 

--- a/src/sidebar/components/Annotation/AnnotationThumbnail.tsx
+++ b/src/sidebar/components/Annotation/AnnotationThumbnail.tsx
@@ -1,8 +1,9 @@
-import { Excerpt, StyledText } from '@hypothesis/annotation-ui';
+import { StyledText } from '@hypothesis/annotation-ui';
 import { useEffect, useMemo, useState, useId } from 'preact/hooks';
 
 import { withServices } from '../../service-context';
 import type { ThumbnailService, Thumbnail } from '../../services/thumbnail';
+import InlineControlExcerpt from '../InlineControlExcerpt';
 
 export type AnnotationThumbnailProps = {
   tag: string;
@@ -94,10 +95,9 @@ function AnnotationThumbnail({
       </div>
 
       {thumbnail && altText && showDescription && (
-        <Excerpt
+        <InlineControlExcerpt
           // Two lines of text
           collapsedHeight={35}
-          inlineControls={true}
         >
           <StyledText
             // Hide this text from screen readers because it duplicates the thumbnail's
@@ -106,7 +106,7 @@ function AnnotationThumbnail({
           >
             <blockquote id={altId}>{altText}</blockquote>
           </StyledText>
-        </Excerpt>
+        </InlineControlExcerpt>
       )}
     </>
   );

--- a/src/sidebar/components/Annotation/test/AnnotationThumbnail-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationThumbnail-test.js
@@ -78,7 +78,7 @@ describe('AnnotationThumbnail', () => {
     fakeThumbnailService.get.returns(fakeThumbnail);
     const wrapper = createComponent({ description, showDescription: true });
 
-    const excerpt = wrapper.find('Excerpt');
+    const excerpt = wrapper.find('InlineControlExcerpt');
     assert.isTrue(excerpt.exists());
     assert.include(excerpt.text(), description);
   });
@@ -88,7 +88,7 @@ describe('AnnotationThumbnail', () => {
     fakeThumbnailService.get.returns(fakeThumbnail);
     const wrapper = createComponent({ description, showDescription: false });
 
-    const excerpt = wrapper.find('Excerpt');
+    const excerpt = wrapper.find('InlineControlExcerpt');
     assert.isFalse(excerpt.exists());
   });
 
@@ -96,7 +96,7 @@ describe('AnnotationThumbnail', () => {
     fakeThumbnailService.get.returns(fakeThumbnail);
     const wrapper = createComponent({ showDescription: true });
 
-    const excerpt = wrapper.find('Excerpt');
+    const excerpt = wrapper.find('InlineControlExcerpt');
     assert.isFalse(excerpt.exists());
   });
 

--- a/src/sidebar/components/InlineControlExcerpt.tsx
+++ b/src/sidebar/components/InlineControlExcerpt.tsx
@@ -1,0 +1,32 @@
+import type { ExcerptProps } from '@hypothesis/annotation-ui';
+import { Excerpt } from '@hypothesis/annotation-ui';
+
+import { applyTheme } from '../helpers/theme';
+import { withServices } from '../service-context';
+
+export type InlineControlExcerptProps = Omit<
+  ExcerptProps,
+  'inlineControls' | 'inlineControlsLinkStyle'
+> & {
+  // Injected
+  settings: object;
+};
+
+/**
+ * An `Excerpt` which implicitly has `inlineControls` set to `true` and the
+ * inline control styles set based on currently configured theme
+ */
+function InlineControlExcerpt({
+  settings,
+  ...props
+}: InlineControlExcerptProps) {
+  return (
+    <Excerpt
+      {...props}
+      inlineControls
+      inlineControlsLinkStyle={applyTheme(['selectionFontFamily'], settings)}
+    />
+  );
+}
+
+export default withServices(InlineControlExcerpt, ['settings']);

--- a/src/sidebar/components/test/InlineControlExcerpt-test.js
+++ b/src/sidebar/components/test/InlineControlExcerpt-test.js
@@ -1,0 +1,31 @@
+import { mount } from '@hypothesis/frontend-testing';
+import sinon from 'sinon';
+
+import InlineControlExcerpt, { $imports } from '../InlineControlExcerpt';
+
+describe('InlineControlExcerpt', () => {
+  let fakeApplyTheme;
+
+  beforeEach(() => {
+    fakeApplyTheme = sinon.stub().returns({});
+
+    $imports.$mock({
+      '../helpers/theme': {
+        applyTheme: fakeApplyTheme,
+      },
+    });
+  });
+
+  afterEach(() => {
+    $imports.$restore();
+  });
+
+  it('applies theme to wrapped Excerpt', () => {
+    const wrapper = mount(<InlineControlExcerpt settings={{}} />);
+    const excerpt = wrapper.find('Excerpt');
+
+    assert.isTrue(excerpt.prop('inlineControls'));
+    assert.isDefined(excerpt.prop('inlineControlsLinkStyle'));
+    assert.calledWith(fakeApplyTheme, ['selectionFontFamily'], {});
+  });
+});


### PR DESCRIPTION
This PR fixes a regression introduced when the `Excerpt` component [was extracted](https://github.com/hypothesis/client/pull/7249).

Previously, the `Excerpt` component defined here had implicit styles for the inline control based on the configured theme. See https://github.com/hypothesis/client/pull/7249/files#diff-397c0b6f13cbc0dade57917126bc15d42c7a8d87921e48df8a2dd1240e1ef0e6L212

When the `Excerpt` was extracted, that logic was removed and instead, a new prop was exposed so that consumers could pass those styles on demand.

However, in https://github.com/hypothesis/client/pull/7249, I forgot to pass those theme-based styles.

This PR gets that logic back, by creating an `InlintControlExcerpt` component wrapping `Excerpt` and implicitly setting `inlineControls={true}` and the  `inlineControlsLinkStyle` based on the theme settings.