### PR TITLE
Update non-selectable-text warning banner message

### DIFF
--- a/src/annotator/components/WarningBanner.tsx
+++ b/src/annotator/components/WarningBanner.tsx
@@ -3,7 +3,8 @@ import classnames from 'classnames';
 
 /**
  * A banner shown at the top of the PDF viewer if the PDF cannot be annotated
- * by Hypothesis.
+ * via text annotations due to lack of selectable text.
+ * Other types of annotations (like image annotations) may still work.
  */
 export default function WarningBanner() {
   return (
@@ -18,15 +19,18 @@ export default function WarningBanner() {
           <CautionIcon className="text-annotator-xl" />
         </div>
         <div>
-          <strong>This PDF does not contain selectable text:</strong>{' '}
+          <strong>
+            Text annotation tools are unavailable because this PDF does not
+            contain selectable text.
+          </strong>{' '}
           <Link
             target="_blank"
             href="https://web.hypothes.is/help/how-to-ocr-optimize-pdfs/"
             underline="always"
           >
-            Learn how to fix this
-          </Link>{' '}
-          in order to annotate with Hypothesis.
+            Learn more here
+          </Link>
+          .
         </div>
       </div>
     </div>

--- a/src/annotator/integrations/test/pdf-test.js
+++ b/src/annotator/integrations/test/pdf-test.js
@@ -366,7 +366,7 @@ describe('annotator/integrations/pdf', () => {
       assert.isNotNull(banner);
       assert.include(
         banner.shadowRoot.textContent,
-        'This PDF does not contain selectable text',
+        'Text annotation tools are unavailable because this PDF does not contain selectable text',
       );
     });
 


### PR DESCRIPTION
Closes https://github.com/hypothesis/product-backlog/issues/1665

Update warning message displayed in PDFs without selectable text, indicating only text annotations are disabled, but implying other annotation methods (like image annotations) should still work.