### PR TITLE
Fix adder Z-index not being set in some cases

### DIFF
--- a/src/annotator/adder.tsx
+++ b/src/annotator/adder.tsx
@@ -280,7 +280,12 @@ export class Adder implements Destroyable {
       ...document.elementsFromPoint(left + adderWidth, top + adderHeight),
     ]);
 
-    const elementZIndex = (el: Element) => +getComputedStyle(el).zIndex;
+    const elementZIndex = (el: Element) => {
+      // The `zIndex` property value is a string whose value can either be an
+      // integer or "auto".
+      const zIndex = parseInt(getComputedStyle(el).zIndex);
+      return Number.isInteger(zIndex) ? zIndex : 0;
+    };
 
     const zIndexes = [...elements].map(elementZIndex).filter(Number.isInteger);
 

--- a/src/annotator/test/adder-test.js
+++ b/src/annotator/test/adder-test.js
@@ -328,16 +328,27 @@ describe('Adder', () => {
       wrapper.unmount();
     });
 
-    it('returns a z-index greater than any highlights', () => {
-      const fakeHighlight = document.createElement('hypothesis-highlight');
-      fakeHighlight.style.zIndex = '20';
+    [
+      {
+        zIndex: '20',
+        adderZIndex: 21,
+      },
+      {
+        zIndex: 'auto',
+        adderZIndex: 1,
+      },
+    ].forEach(({ zIndex, adderZIndex }) => {
+      it('returns a z-index greater than any highlights', () => {
+        const fakeHighlight = document.createElement('hypothesis-highlight');
+        fakeHighlight.style.zIndex = zIndex;
 
-      try {
-        document.body.append(fakeHighlight);
-        assert.equal(getAdderZIndex(0, 0), 21);
-      } finally {
-        fakeHighlight.remove();
-      }
+        try {
+          document.body.append(fakeHighlight);
+          assert.equal(getAdderZIndex(0, 0), adderZIndex);
+        } finally {
+          fakeHighlight.remove();
+        }
+      });
     });
   });
 


### PR DESCRIPTION
Fix an issue where the `z-index` style property of the `<hypothesis-adder>` element was not set if any of the reference elements used to determine the value had a computed z-index of "auto".

If a reference element did have a computed z-index of "auto", then the `elementZIndex` function would attempt to convert this to a number using `+zIndex` which produced NaN. The NaN would be returned from `_findZIndex` and was then ignored when assigned to `element.style.zIndex`. The fix is to treat "auto" values as zero.

Related #support thread: https://hypothes-is.slack.com/archives/C2BLQDKHA/p1756497119701239