### PR TITLE
Render ThreadList as role=list and every thread as a role=listitem

### DIFF
--- a/src/sidebar/components/ThreadList.tsx
+++ b/src/sidebar/components/ThreadList.tsx
@@ -139,17 +139,21 @@ export default function ThreadList({ threads }: ThreadListProps) {
 
   const topLevelThreads = threads;
 
-  const { offscreenLowerHeight, offscreenUpperHeight, visibleThreads } =
-    useMemo(
-      () =>
-        calculateVisibleThreads(
-          topLevelThreads,
-          threadHeights,
-          scrollPosition,
-          scrollContainerHeight,
-        ),
-      [topLevelThreads, threadHeights, scrollPosition, scrollContainerHeight],
-    );
+  const {
+    offscreenLowerHeight,
+    offscreenUpperHeight,
+    visibleThreads,
+    offscreenThreadsAbove,
+  } = useMemo(
+    () =>
+      calculateVisibleThreads(
+        topLevelThreads,
+        threadHeights,
+        scrollPosition,
+        scrollContainerHeight,
+      ),
+    [topLevelThreads, threadHeights, scrollPosition, scrollContainerHeight],
+  );
 
   // Compute the heading to display above each thread. Headings are only shown
   // in some document types (eg. VitalSource books).
@@ -297,10 +301,16 @@ export default function ThreadList({ threads }: ThreadListProps) {
   }, [visibleThreads]);
 
   return (
-    <div>
+    // We use role="list"/role="listitem" rather than unstyled ul/li because
+    // some screen readers do not treat them as lists if they don't explicitly
+    // have bullets
+    <div role="list">
       <div style={{ height: offscreenUpperHeight }} />
-      {visibleThreads.map(child => (
+      {visibleThreads.map((child, index) => (
         <div
+          role="listitem"
+          aria-setsize={threads.length}
+          aria-posinset={offscreenThreadsAbove + index + 1}
           className={classnames(
             // The goal is to space out each annotation card vertically. Typically
             // this is better handled by applying vertical spacing to the parent

--- a/src/sidebar/components/test/ThreadList-test.js
+++ b/src/sidebar/components/test/ThreadList-test.js
@@ -82,6 +82,7 @@ describe('ThreadList', () => {
         visibleThreads: fakeTopThread.children,
         offscreenUpperHeight: 400,
         offscreenLowerHeight: 600,
+        offscreenThreadsAbove: 0,
       })),
       THREAD_DIMENSION_DEFAULTS: {
         defaultHeight: 200,
@@ -363,6 +364,19 @@ describe('ThreadList', () => {
     const wrapper = createComponent();
     const cards = wrapper.find('ThreadCard');
     assert.equal(cards.length, fakeTopThread.children.length);
+  });
+
+  it('calculates aria list attributes', () => {
+    const wrapper = createComponent();
+    const items = wrapper.find('[role="listitem"]');
+
+    assert.lengthOf(items, 4);
+    items.forEach((item, index) => {
+      // All items should have `aria-setsize` with the total amount of threads
+      // (visible and hidden)
+      assert.equal('4', item.prop('aria-setsize'));
+      assert.equal(`${index + 1}`, item.prop('aria-posinset'));
+    });
   });
 
   describe('chapter headings', () => {

--- a/src/sidebar/helpers/test/visible-threads-test.js
+++ b/src/sidebar/helpers/test/visible-threads-test.js
@@ -61,6 +61,7 @@ describe('sidebar/helpers/visible-threads', () => {
       // (4 additional threads): thus, the first 5 threads should be considered
       // "visible."
       assert.deepEqual(visibleIds, ['t1', 't2', 't3', 't4', 't5']);
+      assert.equal(calculated.offscreenThreadsAbove, 0);
       // The space offscreen below should be the remaining 5 threads at their
       // estimated 200px heights:
       assert.equal(calculated.offscreenLowerHeight, 1000);
@@ -90,6 +91,7 @@ describe('sidebar/helpers/visible-threads', () => {
       ]);
       // That first thread's space...
       assert.equal(calculated.offscreenUpperHeight, 200);
+      assert.equal(calculated.offscreenThreadsAbove, 1);
       // The rest are rendered within viewport + lower margin, so:
       assert.equal(calculated.offscreenLowerHeight, 0);
     });
@@ -119,6 +121,7 @@ describe('sidebar/helpers/visible-threads', () => {
             't9',
             't10',
           ],
+          expectedOffscreenThreadsAbove: 0,
           offscreenUpperHeight: 0,
           offscreenLowerHeight: 0,
         },
@@ -126,6 +129,7 @@ describe('sidebar/helpers/visible-threads', () => {
           scrollPos: 0,
           windowHeight: 100,
           expectedVisibleThreadIds: ['t1'],
+          expectedOffscreenThreadsAbove: 0,
           offscreenUpperHeight: 0,
           offscreenLowerHeight: 900,
         },
@@ -133,6 +137,7 @@ describe('sidebar/helpers/visible-threads', () => {
           scrollPos: 101,
           windowHeight: 199,
           expectedVisibleThreadIds: ['t2', 't3'],
+          expectedOffscreenThreadsAbove: 1,
           offscreenUpperHeight: 100,
           offscreenLowerHeight: 700,
         },
@@ -155,6 +160,10 @@ describe('sidebar/helpers/visible-threads', () => {
           assert.equal(
             calculated.offscreenLowerHeight,
             testCase.offscreenLowerHeight,
+          );
+          assert.equal(
+            calculated.offscreenThreadsAbove,
+            testCase.expectedOffscreenThreadsAbove,
           );
         });
       });

--- a/src/sidebar/helpers/visible-threads.ts
+++ b/src/sidebar/helpers/visible-threads.ts
@@ -11,10 +11,13 @@ export const THREAD_DIMENSION_DEFAULTS = {
   marginBelow: 800,
 };
 
-type VisibleThreads = {
+export type VisibleThreads = {
   visibleThreads: Thread[];
   offscreenUpperHeight: number;
   offscreenLowerHeight: number;
+
+  /** Number of offscreen threads above the first visible one */
+  offscreenThreadsAbove: number;
 };
 
 /**
@@ -42,6 +45,7 @@ export function calculateVisibleThreads(
   // Estimated height, in px, of the thread cards above and below the viewport
   let offscreenUpperHeight = 0;
   let offscreenLowerHeight = 0;
+  let offscreenThreadsAbove = 0;
 
   threads.forEach(thread => {
     const threadHeight = threadHeights.get(thread.id) || defaultHeight;
@@ -53,6 +57,7 @@ export function calculateVisibleThreads(
 
     if (threadIsAboveViewport) {
       offscreenUpperHeight += threadHeight;
+      offscreenThreadsAbove += 1;
     } else if (threadIsVisible) {
       visibleThreads.push(thread);
     } else {
@@ -66,5 +71,6 @@ export function calculateVisibleThreads(
     visibleThreads,
     offscreenUpperHeight,
     offscreenLowerHeight,
+    offscreenThreadsAbove,
   };
 }


### PR DESCRIPTION
Relates to https://github.com/hypothesis/client/issues/6185

This PR refactors the `ThreadList` component to render a `[role="list"]` container wrapping a `[role="listitem"]` element for every thread.

With this change, when an annotation is focused, screen readers announce we are inside a list with a size equivalent to the amount of threads. No visual changes should have been introduced.


https://github.com/user-attachments/assets/5f57ce4a-cd42-4387-bffe-5227166ff776

