### PR TITLE
Deduplicate annotations accessible description with creation date

### DIFF
--- a/src/sidebar/components/Annotation/Annotation.tsx
+++ b/src/sidebar/components/Annotation/Annotation.tsx
@@ -1,4 +1,8 @@
-import { CardActions, Spinner } from '@hypothesis/frontend-shared';
+import {
+  CardActions,
+  formatDateTime,
+  Spinner,
+} from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import { useMemo } from 'preact/hooks';
 
@@ -107,7 +111,10 @@ function Annotation({
       annotationDisplayName(annotation, defaultAuthority, displayNamesEnabled),
     [annotation, defaultAuthority, displayNamesEnabled],
   );
-
+  const formattedDate = useMemo(
+    () => formatDateTime(annotation.created),
+    [annotation.created],
+  );
   const annotationDescription = isSaved(annotation)
     ? annotationRole(annotation)
     : `New ${annotationRole(annotation).toLowerCase()}`;
@@ -120,7 +127,7 @@ function Annotation({
   return (
     <article
       className="space-y-4"
-      aria-label={`${annotationDescription} by ${authorName}${state}`}
+      aria-label={`${annotationDescription} by ${authorName} on ${formattedDate}${state}`}
     >
       <AnnotationHeader
         annotation={annotation}

--- a/src/sidebar/components/Annotation/test/Annotation-test.js
+++ b/src/sidebar/components/Annotation/test/Annotation-test.js
@@ -71,6 +71,7 @@ describe('Annotation', () => {
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
+      '@hypothesis/frontend-shared': { formatDateTime: date => date },
       '../../helpers/annotation-metadata': fakeMetadata,
       '../../helpers/annotation-user': fakeAnnotationUser,
       '../../store': { useSidebarStore: () => fakeStore },
@@ -83,20 +84,20 @@ describe('Annotation', () => {
 
   describe('annotation accessibility (ARIA) attributes', () => {
     it('should add a descriptive `aria-label` for an existing annotation', () => {
-      const wrapper = createComponent();
+      const annotation = fixtures.defaultAnnotation();
+      const wrapper = createComponent({ annotation });
 
       assert.equal(
-        wrapper.find('article').props()['aria-label'],
-        'Annotation by Richard Lionheart',
+        wrapper.find('article').prop('aria-label'),
+        `Annotation by Richard Lionheart on ${annotation.created}`,
       );
     });
 
     it('should add a descriptive `aria-label` for a new annotation', () => {
       const wrapper = createComponent({ annotation: fixtures.newAnnotation() });
 
-      assert.equal(
-        wrapper.find('article').props()['aria-label'],
-        'New annotation by Richard Lionheart',
+      assert.isTrue(
+        wrapper.find('article').prop('aria-label').startsWith('New annotation'),
       );
     });
 


### PR DESCRIPTION
Closes https://github.com/hypothesis/client/issues/6185

Extend every annotation's `aria-label` to include the date in which it was created, making sure annotations from the same user can be differentiated via assistive technologies.

### Considerations

I opted to include the date in a human-friendly format, not as an ISO time. However, our most used formatting utility does not include the seconds. That means annotations by the same author created in the same minute would still have a duplicated description.

We could address this by extending the utility so that it includes seconds, or just assume the likeliness of users creating more than one anno in the same minute is low, but IMHO, it's not low enough.

### Testing

1. Checkout this branch
2. Open a screen reader
3. Focus anything inside an annotation (the author name is the first focusable element)
4. Verify the screen reader announces the annotation description, including the human-friendly date at the end.