### PR TITLE
Darken annotation replies collapse button

### DIFF
--- a/src/sidebar/components/Thread.tsx
+++ b/src/sidebar/components/Thread.tsx
@@ -58,7 +58,7 @@ function ThreadCollapseControl({
             // thread/annotation's header. Override large touch targets for
             // touch interfaces; we need to conserve space here
             '-mt-1 touch:min-w-[auto] touch:min-h-[auto] p-[6.5px]',
-            'text-grey-5 hover:text-grey-7',
+            'text-grey-6 hover:text-grey-8',
           )}
           data-testid="toggle-button"
           expanded={!threadIsCollapsed}


### PR DESCRIPTION
Closes https://github.com/hypothesis/product-backlog/issues/1659

Move annotation reply collapse/expand chevron to our next shade of grey (`#737373`) so that it has a contrast higher than 3:1 with the white background, since according to https://www.w3.org/TR/WCAG21/#non-text-contrast, that's the minimum contrast non-text controls should have.

Current color (`#9c9c9c`) has a contrast of 2.75:1.

Before:
<img width="243" height="111" alt="image" src="https://github.com/user-attachments/assets/ff07d2b7-3f2c-4a83-8bbd-1df06eaedb95" />

After:
<img width="243" height="111" alt="image" src="https://github.com/user-attachments/assets/5f4c75c1-7d91-487f-849c-7ed2da5f9be2" />
