### PR TITLE
Truncate too long focused group names

### DIFF
--- a/src/sidebar/components/GroupList/GroupList.tsx
+++ b/src/sidebar/components/GroupList/GroupList.tsx
@@ -101,7 +101,7 @@ function GroupList({ settings }: GroupListProps) {
               alt={altName}
             />
           )}
-          {focusedGroup.name}
+          <span className="truncate">{focusedGroup.name}</span>
         </span>
       </span>
     );


### PR DESCRIPTION
Part of https://github.com/hypothesis/product-backlog/issues/1660

Since the horizontal space available in the sidebar is limited, this PR ensures the name of the focused group is truncated with an ellipsis if it cannot fit the space left by the toolbar.

The entire group name can still be seen when hovering over it.