### PR TITLE
Simplify Menu DOM

### DIFF
--- a/src/sidebar/components/GroupList/GroupList.tsx
+++ b/src/sidebar/components/GroupList/GroupList.tsx
@@ -79,31 +79,27 @@ function GroupList({ settings }: GroupListProps) {
     // and pass an empty string.
     const altName = orgName(focusedGroup) ? orgName(focusedGroup) : '';
     label = (
-      <span
-        className={classnames(
-          // Add some vertical padding so that the dropdown has some space
-          'py-1',
+      <>
+        {icon && (
+          <img
+            className={classnames(
+              // Tiny adjustment to make H logo align better with group name
+              'relative top-[1px] w-4 h-4',
+            )}
+            src={icon}
+            alt={altName}
+          />
         )}
-      >
         <span
           className={classnames(
-            // Don't allow this label to shrink (wrap to next line)
-            'shrink-0 flex items-center gap-x-1 text-md text-color-text font-bold',
+            'text-md text-color-text font-bold',
+            // Add some vertical padding so that the dropdown has some space
+            'py-1',
           )}
         >
-          {icon && (
-            <img
-              className={classnames(
-                // Tiny adjustment to make H logo align better with group name
-                'relative top-[1px] w-4 h-4',
-              )}
-              src={icon}
-              alt={altName}
-            />
-          )}
           {focusedGroup.name}
         </span>
-      </span>
+      </>
     );
   } else {
     label = <span>…</span>;

--- a/src/sidebar/components/GroupList/test/GroupList-test.js
+++ b/src/sidebar/components/GroupList/test/GroupList-test.js
@@ -224,14 +224,18 @@ describe('GroupList', () => {
     fakeServiceConfig.returns({ icon: 'test-icon' });
     const wrapper = createGroupList();
     const label = wrapper.find('Menu').prop('label');
-    const img = mount(label).find('img');
+    const img = mount(<div>{label}</div>).find('img');
     assert.equal(img.prop('src'), 'test-icon');
   });
 
   it('does not render an icon if the the publisher-provided icon is missing', () => {
     const wrapper = createGroupList();
     const label = wrapper.find('Menu').prop('label');
-    assert.isFalse(mount(label).find('img').exists());
+    assert.isFalse(
+      mount(<div>{label}</div>)
+        .find('img')
+        .exists(),
+    );
   });
 
   /**

--- a/src/sidebar/components/Menu.tsx
+++ b/src/sidebar/components/Menu.tsx
@@ -187,8 +187,8 @@ export default function Menu({
         aria-expanded={isOpen ? 'true' : 'false'}
         aria-haspopup={true}
         className={classnames(
-          'focus-visible-ring',
-          'flex items-center justify-center rounded transition-colors',
+          'focus-visible-ring rounded transition-colors',
+          'flex items-center justify-center gap-x-1',
           {
             'text-grey-7 hover:text-grey-9': !isOpen,
             'text-brand': isOpen,
@@ -201,21 +201,16 @@ export default function Menu({
         aria-label={title}
         title={title}
       >
-        <span
-          // wrapper is needed to serve as the flex layout for the label and indicator content.
-          className="flex items-center gap-x-1"
-        >
-          {label}
-          {menuIndicator && (
-            <span
-              className={classnames({
-                'rotate-180 text-color-text': isOpen,
-              })}
-            >
-              <MenuExpandIcon className="w-2.5 h-2.5" />
-            </span>
-          )}
-        </span>
+        {label}
+        {menuIndicator && (
+          <span
+            className={classnames({
+              'rotate-180 text-color-text': isOpen,
+            })}
+          >
+            <MenuExpandIcon className="w-2.5 h-2.5" />
+          </span>
+        )}
       </button>
       {isOpen && (
         <div


### PR DESCRIPTION
This is an intermediary step part of https://github.com/hypothesis/product-backlog/issues/1660

This PR reduces the amount of nested DOM elements in `Menu` and `GroupList`, so that it is possible to make the group name truncate as much as the horizontal space allows, without affecting other elements.

This PR does not yet solve the issue in https://github.com/hypothesis/product-backlog/issues/1660, and should not produce any visual changes.

> [!TIP] 
> This PR is easier to review [hiding whitespaces](https://github.com/hypothesis/client/pull/7292/files?w=1)