### PR TITLE
Add hack to work around issue with shadow DOM and @property

### DIFF
--- a/src/boot/boot.ts
+++ b/src/boot/boot.ts
@@ -95,17 +95,30 @@ function injectLink(
   doc.head.appendChild(link);
 }
 
+type PreloadOptions = {
+  crossOrigin?: boolean;
+};
+
 /**
  * Preload a URL using a `<link rel="preload" as="<type>" ...>` element
  *
  * This can be used to preload an API request or other resource which we know
  * that the client will load.
  */
-function preloadURL(doc: Document, type: string, url: string) {
+function preloadURL(
+  doc: Document,
+  type: string,
+  url: string,
+  { crossOrigin }: PreloadOptions = {},
+) {
   const link = doc.createElement('link');
   link.rel = 'preload';
   link.as = type;
   link.href = url;
+
+  if (crossOrigin) {
+    link.crossOrigin = 'anonymous';
+  }
 
   // If this is a resource that we are going to read the contents of, then we
   // need to make a cross-origin request. For other types, use a non cross-origin
@@ -150,7 +163,10 @@ export function bootHypothesisClient(doc: Document, config: AnnotatorConfig) {
   injectLink(doc, 'profile', 'html', config.profileAppUrl);
 
   // Preload the styles used by the shadow roots of annotator UI elements.
-  preloadURL(doc, 'style', assetURL(config, 'styles/annotator.css'));
+  preloadURL(doc, 'style', assetURL(config, 'styles/annotator.css'), {
+    // Enable style rules to be accessed from JS. See notes in shadow-root.ts.
+    crossOrigin: true,
+  });
 
   // Register the URL of the annotation client which is currently being used to drive
   // annotation interactions.

--- a/src/boot/test/boot-test.js
+++ b/src/boot/test/boot-test.js
@@ -132,7 +132,7 @@ describe('bootstrap', () => {
         'https://marginal.ly/client/build/styles/annotator.1234.css',
       );
       assert.equal(preloadLinks[0].as, 'style');
-      assert.equal(preloadLinks[0].crossOrigin, null);
+      assert.equal(preloadLinks[0].crossOrigin, 'anonymous');
     });
 
     it('creates the link to the sidebar iframe', () => {


### PR DESCRIPTION
In preparation for the migration to Tailwind v4, add a workaround for https://github.com/tailwindlabs/tailwindcss/issues/15005.

`@property` declarations are ignored by current browsers in Shadow DOM. Tailwind v4's styles rely on these properties. In the Hypothesis client this noticeably affects borders of elements in the sidebar container and shadows on the adder.

This commit works around this by duplicating `@property` declarations from annotator.css inside the main document. In order to make this possible, the annotator.css stylesheet must be loaded with the `crossOrigin` property set so that it can be read by JS code.