### PR TITLE
Extract group name component from GroupsList

### DIFF
--- a/src/sidebar/components/GroupList/GroupList.tsx
+++ b/src/sidebar/components/GroupList/GroupList.tsx
@@ -24,6 +24,40 @@ function publisherProvidedIcon(settings: SidebarSettings) {
   return svc && svc.icon ? svc.icon : null;
 }
 
+type GroupNameProps = {
+  group: Group;
+  settings: SidebarSettings;
+};
+
+function GroupName({ group, settings }: GroupNameProps) {
+  const icon = group.organization.logo || publisherProvidedIcon(settings) || '';
+  const altName = orgName(group);
+
+  return (
+    <>
+      {icon && (
+        <img
+          className={classnames(
+            // Tiny adjustment to make H logo align better with group name
+            'relative top-[1px] w-4 h-4',
+          )}
+          src={icon}
+          alt={altName}
+        />
+      )}
+      <span
+        className={classnames(
+          'text-md text-color-text font-bold truncate',
+          // Add some vertical padding so that the dropdown has some space
+          'py-1',
+        )}
+      >
+        {group.name}
+      </span>
+    </>
+  );
+}
+
 export type GroupListProps = {
   settings: SidebarSettings;
 };
@@ -70,40 +104,11 @@ function GroupList({ settings }: GroupListProps) {
   // to move this state to the `Menu` component.
   const [expandedGroup, setExpandedGroup] = useState<Group | null>(null);
 
-  let label;
-  if (focusedGroup) {
-    const icon =
-      focusedGroup.organization.logo || publisherProvidedIcon(settings) || '';
-
-    // If org name is missing, then treat this icon like decoration
-    // and pass an empty string.
-    const altName = orgName(focusedGroup) ? orgName(focusedGroup) : '';
-    label = (
-      <>
-        {icon && (
-          <img
-            className={classnames(
-              // Tiny adjustment to make H logo align better with group name
-              'relative top-[1px] w-4 h-4',
-            )}
-            src={icon}
-            alt={altName}
-          />
-        )}
-        <span
-          className={classnames(
-            'text-md text-color-text font-bold truncate',
-            // Add some vertical padding so that the dropdown has some space
-            'py-1',
-          )}
-        >
-          {focusedGroup.name}
-        </span>
-      </>
-    );
-  } else {
-    label = <span>…</span>;
-  }
+  const label = focusedGroup ? (
+    <GroupName group={focusedGroup} settings={settings} />
+  ) : (
+    <span>…</span>
+  );
 
   const isThirdParty = isThirdPartyService(settings);
 

--- a/src/sidebar/components/GroupList/test/GroupList-test.js
+++ b/src/sidebar/components/GroupList/test/GroupList-test.js
@@ -197,13 +197,6 @@ describe('GroupList', () => {
       assert.equal(wrapper.find('img').prop('alt'), 'Test Org');
     });
 
-    it('uses a blank string for the `alt` attribute if the organization name is missing', () => {
-      fakeServiceConfig.returns({ icon: 'test-icon' });
-      testGroup.organization = {};
-      const wrapper = createGroupList();
-      assert.equal(wrapper.find('img').prop('alt'), '');
-    });
-
     it('does not show group icons', () => {
       populateGroupSections();
       const wrapper = createGroupList();

--- a/src/sidebar/helpers/group-list-item-common.ts
+++ b/src/sidebar/helpers/group-list-item-common.ts
@@ -1,5 +1,5 @@
 import type { Group } from '../../types/api';
 
 export function orgName(group: Group): string {
-  return group.organization && group.organization.name;
+  return group.organization.name;
 }

--- a/src/sidebar/helpers/test/group-list-item-common-test.js
+++ b/src/sidebar/helpers/test/group-list-item-common-test.js
@@ -8,11 +8,5 @@ describe('sidebar/helpers/group-list-item-common', () => {
       const organizationName = groupListItemCommon.orgName(fakeGroup);
       assert.equal(organizationName, fakeGroup.organization.name);
     });
-
-    it('returns undefined if group has no organization', () => {
-      const fakeGroup = { id: 'groupid' };
-
-      assert.isUndefined(groupListItemCommon.orgName(fakeGroup));
-    });
   });
 });


### PR DESCRIPTION
For the next pieces of work of https://github.com/hypothesis/product-backlog/issues/1660, I'm using hooks and logic that only affect the group name in `GroupList`.

This PR extracts that as its own component, as I'm finding it easier to work on it like this.

