### PR TITLE
Recalculate sidebar position when annotator styles load

### DIFF
--- a/src/annotator/sidebar.tsx
+++ b/src/annotator/sidebar.tsx
@@ -264,8 +264,14 @@ export class Sidebar implements Destroyable {
       // Wrap up the 'iframeContainer' element into a shadow DOM, so it is not
       // affected by host CSS styles
       this._hypothesisSidebar = document.createElement('hypothesis-sidebar');
-      const shadowRoot = createShadowRoot(this._hypothesisSidebar);
+      const { shadowRoot, stylesLoaded } = createShadowRoot(
+        this._hypothesisSidebar,
+      );
       shadowRoot.appendChild(this.iframeContainer);
+
+      // If the sidebar is opened before styles have finished loading, then we
+      // may need to adjust the size afterwards.
+      stylesLoaded.then(() => this._onResize());
 
       element.appendChild(this._hypothesisSidebar);
 
@@ -603,15 +609,21 @@ export class Sidebar implements Destroyable {
   }
 
   /**
-   * On window resize events, update the marginLeft of the sidebar by calling hide/show methods.
+   * Update the horizontal position of the sidebar.
+   *
+   * This should be invoked when the window is resized or the intrinsic size
+   * of the sidebar changes (eg. because asynchronously loaded styles finish
+   * loading).
    */
   _onResize() {
-    if (this.toolbar.sidebarOpen === true) {
-      if (window.innerWidth < MIN_RESIZE) {
-        this.close();
-      } else {
-        this.open();
-      }
+    if (!this.toolbar.sidebarOpen) {
+      return;
+    }
+
+    if (window.innerWidth < MIN_RESIZE) {
+      this.close();
+    } else {
+      this.open();
     }
   }
 

--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -909,12 +909,18 @@ describe('Sidebar', () => {
 
   describe('window resize events', () => {
     let sidebar;
+    let initialWindowWidth;
 
     beforeEach(async () => {
       // Configure the sidebar to open on load and wait for the initial open to
       // complete.
       sidebar = createSidebar({ openSidebar: true });
       connectSidebarApp();
+      initialWindowWidth = window.innerWidth;
+    });
+
+    afterEach(() => {
+      window.innerWidth = initialWindowWidth;
     });
 
     it('hides the sidebar if window width is < MIN_RESIZE', () => {

--- a/src/annotator/util/preact-container.ts
+++ b/src/annotator/util/preact-container.ts
@@ -33,7 +33,9 @@ export class PreactContainer implements Destroyable {
   constructor(name: string, render: () => ComponentChild) {
     const tag = `hypothesis-${name}`;
     this._element = document.createElement(tag);
-    this._shadowRoot = createShadowRoot(this._element);
+
+    const { shadowRoot } = createShadowRoot(this._element);
+    this._shadowRoot = shadowRoot;
     this._render = render;
   }
 

--- a/src/annotator/util/shadow-root.ts
+++ b/src/annotator/util/shadow-root.ts
@@ -22,7 +22,7 @@ export function resetPropertyStyleSheet() {
 /**
  * Load stylesheets for annotator UI components into the shadow DOM root.
  */
-function loadStyles(shadowRoot: ShadowRoot) {
+function loadStyles(shadowRoot: ShadowRoot): Promise<void> {
   // Find the preloaded stylesheet added by the boot script.
   const url = (
     document.querySelector(
@@ -31,7 +31,7 @@ function loadStyles(shadowRoot: ShadowRoot) {
   )?.href;
 
   if (!url) {
-    return;
+    return Promise.resolve();
   }
 
   const linkEl = document.createElement('link');
@@ -64,7 +64,18 @@ function loadStyles(shadowRoot: ShadowRoot) {
       { once: true },
     );
   }
+
+  return new Promise(resolve => {
+    linkEl.addEventListener('load', () => resolve());
+  });
 }
+
+export type ShadowRootContainer = {
+  shadowRoot: ShadowRoot;
+
+  /** Promise that resolves when styles have completed loading. */
+  stylesLoaded: Promise<void>;
+};
 
 /**
  * Create the shadow root for an annotator UI component and load the annotator
@@ -72,8 +83,8 @@ function loadStyles(shadowRoot: ShadowRoot) {
  *
  * @param container - Container element to render the UI into
  */
-export function createShadowRoot(container: HTMLElement): ShadowRoot {
+export function createShadowRoot(container: HTMLElement): ShadowRootContainer {
   const shadowRoot = container.attachShadow({ mode: 'open' });
-  loadStyles(shadowRoot);
-  return shadowRoot;
+  const stylesLoaded = loadStyles(shadowRoot);
+  return { shadowRoot, stylesLoaded };
 }

--- a/src/annotator/util/test/shadow-root-test.js
+++ b/src/annotator/util/test/shadow-root-test.js
@@ -28,7 +28,7 @@ describe('annotator/util/shadow-root', () => {
 
   describe('createShadowRoot', () => {
     it('attaches a shadow root to the container', () => {
-      const shadowRoot = createShadowRoot(container);
+      const { shadowRoot } = createShadowRoot(container);
 
       assert.ok(shadowRoot);
       assert.equal(container.shadowRoot, shadowRoot);
@@ -57,7 +57,7 @@ describe('annotator/util/shadow-root', () => {
     });
 
     it('registers CSS @property declarations in a new stylesheet in the main document', async () => {
-      const root = createShadowRoot(container);
+      const { shadowRoot: root } = createShadowRoot(container);
       const propertySheet = getPropertyStyleSheet();
 
       // Simulate annotator.css styles loading.


### PR DESCRIPTION
If the annotator.css bundle loads after the sidebar is opened, the `margin-left` property on the `.sidebar-container` element can be set incorrectly. Fix this problem by invoking `Sidebar._onResize` when styles finish loading. This is the same way we handle "resize" events on the window.

Part of https://github.com/hypothesis/client/issues/7307.

**Testing:**

1. Apply this diff to simulate slow style bundle loading:

```diff
diff --git a/src/annotator/util/shadow-root.ts b/src/annotator/util/shadow-root.ts
index 18ef86a01..5a6218888 100644
--- a/src/annotator/util/shadow-root.ts
+++ b/src/annotator/util/shadow-root.ts
@@ -36,10 +36,13 @@ function loadStyles(shadowRoot: ShadowRoot): Promise<void> {
 
   const linkEl = document.createElement('link');
   linkEl.rel = 'stylesheet';
-  linkEl.href = url;
   linkEl.crossOrigin = 'anonymous';
   shadowRoot.appendChild(linkEl);
 
+  setTimeout(() => {
+    linkEl.href = url;
+  }, 1000);
+
   // When styles are loaded for the first time, wait for the stylesheet to load,
   // then extract `@property` declarations and append them to a stylesheet in
   // the top-level document.
```

The minimum timeout delay needed to trigger the problem varies. Locally I need it to be at least 100.

2. Visit http://localhost:3000.

On `main`, the sidebar ends up positioned on the left side. On this branch it will initially appear there, but then update its position once styles loading.

There is further improvement needed here, as ideally we want to prevent the sidebar from being displayed until styles have loaded. That will need more refactoring, and I think it is valuable to get this partial fix out first.