### PR TITLE
Use named regions instead of dialogs for sidebar panels

### DIFF
--- a/src/sidebar/components/HelpPanel.tsx
+++ b/src/sidebar/components/HelpPanel.tsx
@@ -109,10 +109,9 @@ function HelpPanel({ session }: HelpPanelProps) {
 
   return (
     <SidebarPanel
-      title="Help"
+      label="Help panel"
       panelName="help"
       onActiveChanged={onActiveChanged}
-      variant="custom"
     >
       <TabHeader closeTitle="Close help panel">
         <Tab

--- a/src/sidebar/components/LoginPromptPanel.tsx
+++ b/src/sidebar/components/LoginPromptPanel.tsx
@@ -1,6 +1,10 @@
 import {
   Button,
+  Card,
   CardActions,
+  CardContent,
+  CardHeader,
+  CardTitle,
   RestrictedIcon,
 } from '@hypothesis/frontend-shared';
 
@@ -25,20 +29,24 @@ export default function LoginPromptPanel({
     return null;
   }
   return (
-    <SidebarPanel
-      icon={RestrictedIcon}
-      title="Login needed"
-      panelName="loginPrompt"
-    >
-      <p>Please log in to create annotations or highlights.</p>
-      <CardActions>
-        <Button title="Sign up" onClick={onSignUp}>
-          Sign up
-        </Button>
-        <Button title="Log in" variant="primary" onClick={onLogin}>
-          Log in
-        </Button>
-      </CardActions>
+    <SidebarPanel label="Login panel" panelName="loginPrompt">
+      <Card>
+        <CardHeader>
+          <RestrictedIcon className="w-em h-em" />
+          <CardTitle>Login needed</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p>Please log in to create annotations or highlights.</p>
+          <CardActions>
+            <Button title="Sign up" onClick={onSignUp}>
+              Sign up
+            </Button>
+            <Button title="Log in" variant="primary" onClick={onLogin}>
+              Log in
+            </Button>
+          </CardActions>
+        </CardContent>
+      </Card>
     </SidebarPanel>
   );
 }

--- a/src/sidebar/components/ShareDialog/ShareDialog.tsx
+++ b/src/sidebar/components/ShareDialog/ShareDialog.tsx
@@ -34,11 +34,7 @@ export default function ShareDialog({ shareTab }: ShareDialogProps) {
   const isFirstTabSelected = selectedTab === initialTab;
 
   return (
-    <SidebarPanel
-      title={panelTitle}
-      panelName="shareGroupAnnotations"
-      variant="custom"
-    >
+    <SidebarPanel label="Share panel" panelName="shareGroupAnnotations">
       <TabHeader closeTitle="Close share panel">
         {shareTab && (
           <Tab
@@ -76,6 +72,7 @@ export default function ShareDialog({ shareTab }: ShareDialogProps) {
       <Card classes={classnames({ 'rounded-tl-none': isFirstTabSelected })}>
         <TabPanel
           id="share-panel"
+          data-testid="share-panel"
           active={selectedTab === 'share'}
           aria-labelledby="share-panel-tab"
           title={panelTitle}

--- a/src/sidebar/components/ShareDialog/test/ShareDialog-test.js
+++ b/src/sidebar/components/ShareDialog/test/ShareDialog-test.js
@@ -4,6 +4,7 @@ import {
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
 import { mount } from '@hypothesis/frontend-testing';
+import sinon from 'sinon';
 
 import ShareDialog from '../ShareDialog';
 import { $imports } from '../ShareDialog';
@@ -40,22 +41,22 @@ describe('ShareDialog', () => {
     $imports.$restore();
   });
 
-  describe('panel dialog title', () => {
-    it("sets sidebar panel dialog title to include group's name", () => {
+  describe('share tab title', () => {
+    it("includes group's name", () => {
       const wrapper = createComponent();
 
       assert.equal(
-        wrapper.find('SidebarPanel').prop('title'),
+        wrapper.find('TabPanel[data-testid="share-panel"]').prop('title'),
         'Share Annotations in Test Private Group',
       );
     });
 
-    it('sets a temporary title if focused group not available', () => {
+    it('sets a temporary label if focused group not available', () => {
       fakeStore.focusedGroup = sinon.stub().returns({});
 
       const wrapper = createComponent();
       assert.equal(
-        wrapper.find('SidebarPanel').prop('title'),
+        wrapper.find('TabPanel[data-testid="share-panel"]').prop('title'),
         'Share Annotations in ...',
       );
     });

--- a/src/sidebar/components/SidebarPanel.tsx
+++ b/src/sidebar/components/SidebarPanel.tsx
@@ -1,8 +1,6 @@
-import type { DialogProps } from '@hypothesis/frontend-shared';
-import { Dialog, Slider } from '@hypothesis/frontend-shared';
-import type { IconComponent } from '@hypothesis/frontend-shared';
-import type { ComponentChildren } from 'preact';
-import { useCallback, useEffect, useRef } from 'preact/hooks';
+import { CloseableContext, Slider } from '@hypothesis/frontend-shared';
+import type { ComponentChildren, RefObject } from 'preact';
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 import scrollIntoView from 'scroll-into-view';
 
 import type { PanelName } from '../../types/sidebar';
@@ -10,20 +8,20 @@ import { useSidebarStore } from '../store';
 
 export type SidebarPanelProps = {
   children: ComponentChildren;
-  /** An optional icon name for display next to the panel's title */
-  icon?: IconComponent;
+
   /**
    * A string identifying this panel. Only one `panelName` may be active at any
    * time. Multiple panels with the same `panelName` would be "in sync", opening
    * and closing together.
    */
   panelName: PanelName;
-  title: string;
+
+  /** A label to be set on the panel's `aria-label` */
+  label: string;
   /** Optional callback to invoke when this panel's active status changes */
   onActiveChanged?: (active: boolean) => void;
-  /** What Dialog variant to use */
-  variant?: 'panel' | 'custom';
-  initialFocus?: DialogProps['initialFocus'];
+  /** If provided, an element to focus on open */
+  initialFocus?: RefObject<HTMLOrSVGElement | null>;
 };
 
 /**
@@ -32,20 +30,28 @@ export type SidebarPanelProps = {
  */
 export default function SidebarPanel({
   children,
-  icon,
   panelName,
-  title,
-  variant = 'panel',
+  label,
   onActiveChanged,
   initialFocus,
 }: SidebarPanelProps) {
   const store = useSidebarStore();
   const panelIsActive = store.isSidebarPanelOpen(panelName);
+  const [showPanelContent, setShowPanelContent] = useState(false);
+  // The panel content should be mounted when it is active or being closed, but
+  // once it's fully closed we can unmount it.
+  // We use this because `panelIsActive` changes immediately, but the panel is
+  // closed with a transition, changing `showPanelContent` once finished.
+  const mountContent = panelIsActive || showPanelContent;
 
   const panelElement = useRef<HTMLDivElement | null>(null);
   const panelWasActive = useRef(panelIsActive);
+  const sectionRef = useRef<HTMLElement | null>(null);
+  const originalFocusRef = useRef<HTMLElement | null>(null);
 
-  // Scroll the panel into view if it has just been opened
+  // Scroll the panel into view if it has just been opened.
+  // We do this via a panelIsActive-based effect, rather than via `onTransitionEnd`,
+  // so that scroll happens right when the transition starts.
   useEffect(() => {
     if (panelWasActive.current !== panelIsActive) {
       panelWasActive.current = panelIsActive;
@@ -56,28 +62,55 @@ export default function SidebarPanel({
     }
   }, [panelIsActive, onActiveChanged]);
 
-  const closePanel = useCallback(() => {
-    store.toggleSidebarPanel(panelName, false);
-  }, [store, panelName]);
+  const onTransitionEnd = useCallback(
+    (direction: 'in' | 'out') => {
+      setShowPanelContent(direction === 'in');
+
+      if (direction === 'out') {
+        // When the panel is closed, move focus back to originally focused element
+        originalFocusRef.current?.focus();
+        return;
+      }
+
+      const initialFocusEl = initialFocus?.current as HTMLElement & {
+        disabled?: boolean;
+      };
+      const focusEl =
+        initialFocusEl && !initialFocusEl.disabled
+          ? initialFocusEl
+          : sectionRef.current;
+
+      // When the panel is opened, track element that was focused, then focus
+      // the initial element or the panel itself
+      originalFocusRef.current = document.activeElement as HTMLElement | null;
+      focusEl?.focus();
+    },
+    [initialFocus],
+  );
+
+  const closePanel = useCallback(
+    () => store.toggleSidebarPanel(panelName, false),
+    [store, panelName],
+  );
 
   return (
-    <>
-      {panelIsActive && (
-        <Dialog
-          initialFocus={initialFocus}
-          restoreFocus
-          ref={panelElement}
-          classes="mb-4"
-          title={title}
-          icon={icon}
-          onClose={closePanel}
-          transitionComponent={Slider}
-          variant={variant}
-          scrollable={false}
-        >
-          {children}
-        </Dialog>
-      )}
-    </>
+    <CloseableContext.Provider value={{ onClose: closePanel }}>
+      <Slider
+        direction={panelIsActive ? 'in' : 'out'}
+        onTransitionEnd={onTransitionEnd}
+        elementRef={panelElement}
+      >
+        {mountContent && (
+          <section
+            aria-label={label}
+            className="mb-4 focus-visible-ring rounded-lg"
+            ref={sectionRef}
+            tabIndex={-1}
+          >
+            {children}
+          </section>
+        )}
+      </Slider>
+    </CloseableContext.Provider>
   );
 }

--- a/src/sidebar/components/search/SearchPanel.tsx
+++ b/src/sidebar/components/search/SearchPanel.tsx
@@ -19,8 +19,7 @@ export default function SearchPanel() {
   return (
     <SidebarPanel
       panelName="searchAnnotations"
-      variant="custom"
-      title="Search"
+      label="Search panel"
       initialFocus={inputRef}
       onActiveChanged={active => {
         if (!active) {


### PR DESCRIPTION
Closes https://github.com/hypothesis/client/issues/6307

Refactor sidebar panels so that they are not `role="dialog"` but named `section`s.

The reason for this change is that in our last accessibility review we were told those elements had a `dialog` role but they were not behaving like that. Some investigation led us to the conclusion that non-modal dialogs are a bit odd to interact with assistive technologies.

As a side effect, the changes in this PR fix https://github.com/hypothesis/client/issues/6055

https://github.com/user-attachments/assets/f81953c9-56a8-4c51-8c75-d9d6a7a66474

### TODO

- [x] Panels are not scrolled into the viewport when opened.
- [x] ~Replace `Dialog` with `Panel` in component names.~ I'm going to do this separately once this is merged, as is causes a lot of changes that are going to make it harder to review this PR.
- [x] Make focus move to the panel when opened, and back to the button when closed.
  
  https://github.com/user-attachments/assets/54444b9f-ada5-4d56-a90e-75fc5222d684