### PR TITLE
Fix sidebar font size in Chrome extension

### DIFF
--- a/src/styles/sidebar/sidebar.css
+++ b/src/styles/sidebar/sidebar.css
@@ -8,8 +8,9 @@
     @apply h-full;
   }
 
+  /* Set text styles except for font-family and font-size, which are defined separately. */
   body {
-    @apply bg-white font-sans text-base text-color-text;
+    @apply bg-white text-color-text;
   }
 
 
@@ -88,4 +89,14 @@
 
 @utility container {
   @apply m-auto px-[9px] max-w-[768px];
+}
+
+/* Set the main font-family and font-size.
+
+   These are defined in unlayered styles rather than the base layer so that
+   they take precedence over default styles that Chrome sets in all pages
+   served from an extension. See https://stackoverflow.com/a/72050395/434243
+   and https://source.chromium.org/chromium/chromium/src/+/main:extensions/renderer/resources/extension_fonts.css;drc=60039d4d4bd70512e21a2dfe586602aca1d9d35e. */
+body {
+  @apply font-sans text-base;
 }


### PR DESCRIPTION
The migration to Tailwind v4 resulted in the CSS rules defining the body's font-family and font-size being moved to the base layer. This gave the rules lower priority than some default styles which Chrome injects into all HTML pages served from an extension (see links in code). As a result in the extension the font size was being set to 12px (or 75% of the default) rather than our default of 13px.

Work around this by changing these specific styles to be unlayered, like they were when using Tailwind v3.