### PR TITLE
Enable Prettier formatting of .css files

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,8 +112,8 @@
   "scripts": {
     "build": "cross-env NODE_ENV=production gulp build",
     "lint": "eslint --cache .",
-    "checkformatting": "prettier --cache --check '**/*.{js,scss,ts,tsx,d.ts}'",
-    "format": "prettier --cache --list-different --write '**/*.{js,scss,ts,tsx,d.ts}'",
+    "checkformatting": "prettier --cache --check '**/*.{css,js,scss,ts,tsx,d.ts}'",
+    "format": "prettier --cache --list-different --write '**/*.{css,js,scss,ts,tsx,d.ts}'",
     "test": "gulp test",
     "test:watch": "gulp test --live",
     "typecheck": "tsc --build tsconfig.json"

--- a/src/styles/sidebar/sidebar.css
+++ b/src/styles/sidebar/sidebar.css
@@ -13,7 +13,6 @@
     @apply bg-white text-color-text;
   }
 
-
   /* See https://tailwindcss.com/docs/upgrade-guide#default-border-color. */
   * {
     border-color: #dbdbdb;
@@ -77,14 +76,14 @@
 
   /* Applies to any text: strikeout effect. */
   .p-redacted-text {
-	  @apply line-through grayscale contrast-50 text-color-text-light;
+    @apply line-through grayscale contrast-50 text-color-text-light;
   }
 
   /* Disable scroll anchoring as it interferes with `ThreadList` and
 	   `visible-threads` calculations and can cause a render loop. */
-	.js-thread-list-scroll-root {
-		overflow-anchor: none;
-	}
+  .js-thread-list-scroll-root {
+    overflow-anchor: none;
+  }
 }
 
 @utility container {

--- a/src/styles/sidebar/sidebar.css
+++ b/src/styles/sidebar/sidebar.css
@@ -8,8 +8,9 @@
     @apply h-full;
   }
 
+  /* Set text styles except for font-family and font-size, which are defined separately. */
   body {
-    @apply bg-white font-sans text-base text-color-text;
+    @apply bg-white text-color-text;
   }
 
 
@@ -88,4 +89,14 @@
 
 @utility container {
   @apply m-auto px-[9px] max-w-[768px];
+}
+
+/* Set the main font-family and font-size.
+
+   These are defined in unlayered styles rather than the base layer so that
+   they take precedence over default styles that Chrome sets in all pages
+   served from an extension. See https://stackoverflow.com/a/72050395/434243
+   and https://source.chromium.org/chromium/chromium/src/+/main:extensions/renderer/resources/extension_fonts.css;drc=60039d4d4bd70512e21a2dfe586602aca1d9d35e. */
+body {
+  @apply font-sans text-base;
 }


### PR DESCRIPTION
This is needed after we changed some .scss files to be plain .css files during the Tailwind v4 migration.

We'll need to make the same change in several other repos.