### PR TITLE
Protect crossorigin attribute of annotator.css stylesheet

### DIFF
--- a/src/annotator/util/shadow-root.ts
+++ b/src/annotator/util/shadow-root.ts
@@ -37,7 +37,16 @@ function loadStyles(shadowRoot: ShadowRoot): Promise<void> {
   const linkEl = document.createElement('link');
   linkEl.rel = 'stylesheet';
   linkEl.href = url;
+
+  // Enable JS to read the response. Needed for the @property workaround below.
   linkEl.crossOrigin = 'anonymous';
+
+  // Prevent the frontend part of pywb (wombat) in viahtml from removing the
+  // `crossorigin` attribute.
+  //
+  // See https://github.com/webrecorder/wombat/blob/7433dede629b1c919c4c9c1e2c2daf1ac6665973/src/wombat.js#L2422
+  linkEl.removeAttribute = () => {};
+
   shadowRoot.appendChild(linkEl);
 
   // When styles are loaded for the first time, wait for the stylesheet to load,

--- a/src/annotator/util/test/shadow-root-test.js
+++ b/src/annotator/util/test/shadow-root-test.js
@@ -40,6 +40,11 @@ describe('annotator/util/shadow-root', () => {
       const linkEl = container.shadowRoot.querySelector('link[rel=stylesheet]');
       assert.ok(linkEl);
       assert.include(linkEl.href, 'annotator.css');
+      assert.equal(linkEl.crossOrigin, 'anonymous');
+
+      // Make sure we prevented Via from removing the `crossorigin` attribute.
+      linkEl.removeAttribute('crossorigin');
+      assert.equal(linkEl.crossOrigin, 'anonymous');
     });
 
     it('does not inject stylesheets into the shadow root if style is not found', () => {

--- a/src/boot/boot.ts
+++ b/src/boot/boot.ts
@@ -116,15 +116,16 @@ function preloadURL(
   link.as = type;
   link.href = url;
 
-  if (crossOrigin) {
+  // Enable JS to read the response if opted-in, or this is a URL we're going to
+  // use via `fetch` in JS.
+  if (crossOrigin || type === 'fetch') {
     link.crossOrigin = 'anonymous';
-  }
 
-  // If this is a resource that we are going to read the contents of, then we
-  // need to make a cross-origin request. For other types, use a non cross-origin
-  // request which returns a response that is opaque.
-  if (type === 'fetch') {
-    link.crossOrigin = 'anonymous';
+    // Prevent the frontend part of pywb (wombat) in viahtml from removing the
+    // `crossorigin` attribute.
+    //
+    // See https://github.com/webrecorder/wombat/blob/7433dede629b1c919c4c9c1e2c2daf1ac6665973/src/wombat.js#L2422
+    link.removeAttribute = () => {};
   }
 
   tagElement(link);

--- a/src/boot/test/boot-test.js
+++ b/src/boot/test/boot-test.js
@@ -133,6 +133,10 @@ describe('bootstrap', () => {
       );
       assert.equal(preloadLinks[0].as, 'style');
       assert.equal(preloadLinks[0].crossOrigin, 'anonymous');
+
+      // Make sure we prevented Via from removing the `crossorigin` attribute.
+      preloadLinks[0].removeAttribute('crossorigin');
+      assert.equal(preloadLinks[0].crossOrigin, 'anonymous');
     });
 
     it('creates the link to the sidebar iframe', () => {


### PR DESCRIPTION
pywb's frontend JS has logic that removes the "crossorigin" attribute from `<link>` elements [^1]. This causes problems for annotator.css because this stylesheet is fetched cross-origin (we exclude it from being proxied) and we need to read the response in JS to apply a workaround for `@property` and shadow DOM. To prevent this, override `Element.prototype.removeAttribute` with a no-op function. This hack is used because pywb doesn't have a built-in method to disable rewriting for a specific element that I can see.

This fixes an issue where the annotator.css was loaded non-cross-origin in Via, making the response opaque and preventing our `@property` workaround from being applied, breaking some styles in the adder and annotator toolbar.

[^1]: https://github.com/webrecorder/wombat/blob/7433dede629b1c919c4c9c1e2c2daf1ac6665973/src/wombat.js#L2422