### PR TITLE
Import from frontend-shared root when possible

### DIFF
--- a/src/annotator/components/AdderToolbar.tsx
+++ b/src/annotator/components/AdderToolbar.tsx
@@ -5,7 +5,7 @@ import {
   PointerDownIcon,
   PointerUpIcon,
 } from '@hypothesis/frontend-shared';
-import type { IconComponent } from '@hypothesis/frontend-shared/lib/types';
+import type { IconComponent } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 
 import { useShortcut } from '../../shared/shortcut';

--- a/src/annotator/components/Toolbar.tsx
+++ b/src/annotator/components/Toolbar.tsx
@@ -10,11 +10,11 @@ import {
   PinIcon,
   ShowIcon,
 } from '@hypothesis/frontend-shared';
-import type { ButtonProps } from '@hypothesis/frontend-shared/lib/components/input/Button';
+import type { ButtonProps } from '@hypothesis/frontend-shared';
 import type {
   IconComponent,
   PresentationalProps,
-} from '@hypothesis/frontend-shared/lib/types';
+} from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import type { JSX, RefObject } from 'preact';
 

--- a/src/sidebar/components/FilterSelect.tsx
+++ b/src/sidebar/components/FilterSelect.tsx
@@ -1,4 +1,4 @@
-import type { IconComponent } from '@hypothesis/frontend-shared/lib/types';
+import type { IconComponent } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 
 import type { FilterOption } from '../store/modules/filters';

--- a/src/sidebar/components/MarkdownEditor.tsx
+++ b/src/sidebar/components/MarkdownEditor.tsx
@@ -18,7 +18,7 @@ import {
   ListUnorderedIcon,
   useArrowKeyNavigation,
 } from '@hypothesis/frontend-shared';
-import type { IconComponent } from '@hypothesis/frontend-shared/lib/types';
+import type { IconComponent } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import type { Ref, JSX } from 'preact';
 import {

--- a/src/sidebar/components/MentionSuggestionsPopover.tsx
+++ b/src/sidebar/components/MentionSuggestionsPopover.tsx
@@ -1,5 +1,5 @@
 import { Popover } from '@hypothesis/frontend-shared';
-import type { PopoverProps } from '@hypothesis/frontend-shared/lib/components/feedback/Popover';
+import type { PopoverProps } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 
 import type { UserItem } from '../helpers/mention-suggestions';

--- a/src/sidebar/components/MenuItem.tsx
+++ b/src/sidebar/components/MenuItem.tsx
@@ -3,7 +3,7 @@ import {
   MenuExpandIcon,
   Slider,
 } from '@hypothesis/frontend-shared';
-import type { IconComponent } from '@hypothesis/frontend-shared/lib/types';
+import type { IconComponent } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import type { ComponentChildren, Ref } from 'preact';
 import { useEffect, useRef } from 'preact/hooks';

--- a/src/sidebar/components/ProfileView.tsx
+++ b/src/sidebar/components/ProfileView.tsx
@@ -6,7 +6,7 @@ import {
   Scroll,
   SpinnerSpokesIcon,
 } from '@hypothesis/frontend-shared';
-import type { PresentationalProps } from '@hypothesis/frontend-shared/lib/types';
+import type { PresentationalProps } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 import type { ComponentChildren, JSX } from 'preact';
 import { useEffect, useState } from 'preact/hooks';

--- a/src/sidebar/components/SidebarPanel.tsx
+++ b/src/sidebar/components/SidebarPanel.tsx
@@ -1,6 +1,6 @@
 import type { DialogProps } from '@hypothesis/frontend-shared';
 import { Dialog, Slider } from '@hypothesis/frontend-shared';
-import type { IconComponent } from '@hypothesis/frontend-shared/lib/types';
+import type { IconComponent } from '@hypothesis/frontend-shared';
 import type { ComponentChildren } from 'preact';
 import { useCallback, useEffect, useRef } from 'preact/hooks';
 import scrollIntoView from 'scroll-into-view';

--- a/src/sidebar/components/Tutorial.tsx
+++ b/src/sidebar/components/Tutorial.tsx
@@ -4,7 +4,7 @@ import {
   HighlightIcon,
   ReplyIcon,
 } from '@hypothesis/frontend-shared';
-import type { IconComponent } from '@hypothesis/frontend-shared/lib/types';
+import type { IconComponent } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
 
 import type { SidebarSettings } from '../../types/config';


### PR DESCRIPTION
Refactor a few imports from `@hypothesis/frontend-shared` to import from the package's root when possible.