### PR TITLE
Update titles for toolbar buttons that open panels

### DIFF
--- a/src/sidebar/components/TopBar.tsx
+++ b/src/sidebar/components/TopBar.tsx
@@ -120,7 +120,7 @@ function TopBar({
                   expanded={isAnnotationsPanelOpen}
                   pressed={isAnnotationsPanelOpen}
                   onClick={toggleSharePanel}
-                  title="Share annotations on this page"
+                  title="Show share panel"
                   data-testid="share-icon-button"
                 />
               )}
@@ -132,7 +132,7 @@ function TopBar({
               expanded={isHelpPanelOpen}
               pressed={isHelpPanelOpen}
               onClick={requestHelp}
-              title="Help"
+              title="Show help panel"
               data-testid="help-icon-button"
             />
           )}

--- a/src/sidebar/components/search/SearchIconButton.tsx
+++ b/src/sidebar/components/search/SearchIconButton.tsx
@@ -66,7 +66,7 @@ export default function SearchIconButton() {
           expanded={isSearchPanelOpen}
           pressed={isSearchPanelOpen}
           onClick={toggleSearchPanel}
-          title="Search"
+          title="Show search panel"
         />
       )}
     </>

--- a/src/sidebar/components/test/TopBar-test.js
+++ b/src/sidebar/components/test/TopBar-test.js
@@ -170,7 +170,7 @@ describe('TopBar', () => {
   context('when using a first-party service', () => {
     it('shows the share annotations button', () => {
       const wrapper = createTopBar();
-      assert.isTrue(wrapper.exists('[title="Share annotations on this page"]'));
+      assert.isTrue(wrapper.exists('[title="Show share panel"]'));
     });
   });
 


### PR DESCRIPTION
Part of https://github.com/hypothesis/client/issues/6307

As suggested in https://github.com/hypothesis/client/pull/7310#issuecomment-3307478892, update the titles for all sidebar toolbar buttons that open a sidebar panel, so that they follow the `Show {panel_name}` pattern, where `{panel_name}` matches the value on the `aria-label` for the panel they open.

For example, for the panel with `[aria-label="Search panel"]`, the button should have `[title="Show search panel"]`.