### PR TITLE
Make annotation cards focusable

### DIFF
--- a/src/sidebar/components/ThreadCard.tsx
+++ b/src/sidebar/components/ThreadCard.tsx
@@ -81,7 +81,9 @@ function ThreadCard({ frameSync, thread }: ThreadCardProps) {
       )}
       data-testid="thread-card"
       elementRef={cardRef}
-      tabIndex={-1}
+      tabIndex={0}
+      role="article"
+      aria-label="Press Enter to scroll annotation into view"
       onClick={e => {
         // Prevent click events intended for another action from
         // triggering a page scroll.
@@ -91,6 +93,20 @@ function ThreadCard({ frameSync, thread }: ThreadCardProps) {
       }}
       onMouseEnter={() => setThreadHovered(thread.annotation ?? null)}
       onMouseLeave={() => setThreadHovered(null)}
+      onKeyDown={e => {
+        // Simulate default button behavior, where `Enter` and `Space` trigger
+        // click action
+        if (
+          // Trigger event only if the target is the card itself, so that we do
+          // not scroll to the annotation while editing it, or if the key is
+          // pressed to interact with a child button or link.
+          e.target === cardRef.current &&
+          ['Enter', ' '].includes(e.key) &&
+          thread.annotation
+        ) {
+          scrollToAnnotation(thread.annotation);
+        }
+      }}
       key={thread.id}
     >
       <CardContent>{threadContent}</CardContent>


### PR DESCRIPTION
Part of https://github.com/hypothesis/client/issues/6306

This PR brings back the changes from https://github.com/hypothesis/client/pull/5539 and https://github.com/hypothesis/client/pull/5570, that we then had to roll back because of the issues reported in https://github.com/hypothesis/support/issues/31

However, by implementing this again I cannot reproduce any of those issues anymore. Since the event handler ignores events not targeting the card itself, it should not be triggered while editing an annotation or interacting with other child controls.

### TODO

- [ ] Decide what is the right role for card elements. We originally used `button`, but I was never 100% sure about that.
    Bluesky uses `link` role for their posts in the feed, but we don't link anywhere from an anno card.
    Twitter uses `article`, which is what I provisionally used here.
- [ ] Consider adding vertical arrow key navigation to cards, so that you can move the focus to the next/previous one via <kbd>ArrowDown</kbd> or <kbd>ArrowUp</kbd>.
    The regular tab sequence has a lot of elements, making it odd to move the focus between cards.
- [ ] Add tests.