### PR TITLE
Allow display name mentions to be next to other text

### DIFF
--- a/src/sidebar/helpers/test/mentions-test.js
+++ b/src/sidebar/helpers/test/mentions-test.js
@@ -204,6 +204,18 @@ Hello ${mentionTag('jane.doe', 'example.com')}.`,
     ]),
     textWithTags: `Hello ${displayNameMentionTag('Dwayne "The Rock" Johnson', 'djohnson')}`,
   },
+  // Mentions with other text right before
+  {
+    text: 'Hello@[Jane]',
+    usersMap: new Map([['Jane', { userid: 'acct:jane@hypothes.is' }]]),
+    textWithTags: `Hello${displayNameMentionTag('Jane', 'jane')}`,
+  },
+  // Mentions with other text right after
+  {
+    text: '@[Jane]look at this',
+    usersMap: new Map([['Jane', { userid: 'acct:jane@hypothes.is' }]]),
+    textWithTags: `${displayNameMentionTag('Jane', 'jane')}look at this`,
+  },
 ].forEach(({ text, usersMap, textWithTags }) => {
   describe('wrapDisplayNameMentions', () => {
     it('wraps every display-name mention in a mention tag', () => {


### PR DESCRIPTION
Fixes https://github.com/hypothesis/product-backlog/issues/1684

Allow mentions in the LMS to be right before or after other pieces of plain text, without requiring an empty character in between, so that mentions are created even if the user introduced a typo, and they can correct it afterwards.

https://github.com/user-attachments/assets/8fd6e988-bf93-41ef-9f6d-fa4d3e4ba73c

This is something we don't want to do in the web app, as it would cause a lot of false positives (for example, any email address would be treated as a mention), and in case of a typo, editing the annotation and adding the missing space would correctly create the mention, so this is not needed.

In the LMS however, only mentions selected from the dropdown will work, and the fact that they need to be enclosed with brackets, makes it safer to do this, and solves the problem where a user mentions someone properly (via dropdown selection), but then edits the text adding something before or after, but forgets to add a space.

This will cause the mention to not be created, and editing the annotation to add the missing space will not solve it.

### Considerations

One thing I did not change in this PR is the fact that the mentions dropdown is only displayed if there's in fact a space before the `@` character. That way we avoid displaying it when manually typing an `@` character as part of other text.

### Test steps

1. Open an assignment
2. Type `@` to get the mentions dropdown displayed, and select a student.
3. Add some text right before or after the mention, with no spaces in between.
4. Save the annotation.
5. The mention should be properly created, and editing the annotation allows for the missing space to be added.

In `main` branch this would cause the mention to not be created.

In the web app, mentions right after other text should continue being treated as plain-text.