### PR TITLE
Avoid annotation buttons from overflowing the card

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationPublishControl.tsx
+++ b/src/sidebar/components/Annotation/AnnotationPublishControl.tsx
@@ -7,10 +7,12 @@ import {
   MenuExpandIcon,
 } from '@hypothesis/frontend-shared';
 import classnames from 'classnames';
+import { useRef } from 'preact/hooks';
 
 import type { Group } from '../../../types/api';
 import type { SidebarSettings } from '../../../types/config';
 import { applyTheme } from '../../helpers/theme';
+import { useContentTruncated } from '../../hooks/use-content-truncated';
 import { withServices } from '../../service-context';
 import Menu from '../Menu';
 import MenuItem from '../MenuItem';
@@ -71,13 +73,21 @@ function AnnotationPublishControl({
     </div>
   );
 
+  const postButtonText = `Post to ${isPrivate ? 'Only Me' : group.name}`;
+  const postButtonRef = useRef<HTMLButtonElement | null>(null);
+  const isButtonContentTruncated = useContentTruncated(postButtonRef);
+
   return (
     <div className="flex flex-row gap-x-3">
-      <div className="flex relative">
+      <div className="flex relative max-w-full min-w-0">
         <Button
           classes={classnames(
             // Turn off right-side border radius to align with menu-open button
             'rounded-r-none',
+            // Truncate text in this button. It also requires overwriting its
+            // `display` property from flex to block, as `text-overflow: ellipsis`
+            // does not work with flex elements
+            'truncate !block',
           )}
           data-testid="publish-control-button"
           style={buttonStyle}
@@ -85,8 +95,10 @@ function AnnotationPublishControl({
           disabled={isDisabled}
           size="lg"
           variant="primary"
+          title={isButtonContentTruncated ? postButtonText : undefined}
+          elementRef={postButtonRef}
         >
-          Post to {isPrivate ? 'Only Me' : group.name}
+          {postButtonText}
         </Button>
         {/* This wrapper div is necessary because of peculiarities with
              Safari: see https://github.com/hypothesis/client/issues/2302 */}

--- a/src/sidebar/components/Annotation/test/AnnotationPublishControl-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationPublishControl-test.js
@@ -8,6 +8,7 @@ import {
   mockImportedComponents,
 } from '@hypothesis/frontend-testing';
 import { mount } from '@hypothesis/frontend-testing';
+import sinon from 'sinon';
 
 import AnnotationPublishControl, {
   $imports,
@@ -17,6 +18,7 @@ describe('AnnotationPublishControl', () => {
   let fakeGroup;
   let fakeSettings;
   let fakeApplyTheme;
+  let fakeUseContentTruncated;
 
   let fakeOnSave;
   let fakeOnCancel;
@@ -54,11 +56,15 @@ describe('AnnotationPublishControl', () => {
     };
 
     fakeApplyTheme = sinon.stub();
+    fakeUseContentTruncated = sinon.stub().returns(false);
 
     $imports.$mock(mockImportedComponents());
     $imports.$mock({
       '../../helpers/theme': {
         applyTheme: fakeApplyTheme,
+      },
+      '../../hooks/use-content-truncated': {
+        useContentTruncated: fakeUseContentTruncated,
       },
     });
   });
@@ -199,6 +205,16 @@ describe('AnnotationPublishControl', () => {
       cancelBtn.props().onClick();
 
       assert.calledOnce(fakeOnCancel);
+    });
+  });
+
+  [true, false].forEach(isTruncated => {
+    it('adds title to publish button when its content is truncated', () => {
+      fakeUseContentTruncated.returns(isTruncated);
+
+      const wrapper = createAnnotationPublishControl();
+
+      assert.equal(!!getPublishButton(wrapper).prop('title'), isTruncated);
     });
   });
 

--- a/src/sidebar/hooks/test/use-content-truncated-test.js
+++ b/src/sidebar/hooks/test/use-content-truncated-test.js
@@ -1,0 +1,76 @@
+import { mount } from '@hypothesis/frontend-testing';
+import { useRef } from 'preact/hooks';
+
+import { useContentTruncated } from '../use-content-truncated';
+
+describe('useContentTruncated', () => {
+  function FakeComponent({ children }) {
+    const truncatedElementRef = useRef(null);
+    const isTruncated = useContentTruncated(truncatedElementRef);
+
+    return (
+      <div data-testid="container">
+        <div
+          style={{ width: '100px', maxWidth: '100%' }}
+          className="truncate"
+          ref={truncatedElementRef}
+        >
+          {children}
+        </div>
+        <div data-testid="is-truncated">{isTruncated ? 'Yes' : 'No'}</div>
+      </div>
+    );
+  }
+
+  function createComponent(content) {
+    return mount(<FakeComponent>{content}</FakeComponent>, { connected: true });
+  }
+
+  function isTruncated(wrapper) {
+    return wrapper.find('[data-testid="is-truncated"]').text() === 'Yes';
+  }
+
+  function waitForResize(element) {
+    return new Promise(resolve => {
+      const observer = new ResizeObserver(() => {
+        observer.disconnect();
+        resolve();
+      });
+      observer.observe(element);
+    });
+  }
+
+  [
+    {
+      content: 'foo',
+      shouldBeTruncated: false,
+    },
+    {
+      content: 'foo'.repeat(1000),
+      shouldBeTruncated: true,
+    },
+  ].forEach(({ content, shouldBeTruncated }) => {
+    it('checks if content is truncated once mounted', () => {
+      const wrapper = createComponent(content);
+      assert.equal(isTruncated(wrapper), shouldBeTruncated);
+    });
+  });
+
+  it('checks if content is truncated when resized', async () => {
+    const wrapper = createComponent('some content');
+
+    // Content is initially not truncated
+    assert.isFalse(isTruncated(wrapper));
+
+    // When we resize the container to make it smaller, the content gets
+    // truncated
+    const container = wrapper.find('[data-testid="container"]').getDOMNode();
+    const resizePromise = waitForResize(container);
+    container.style.width = '10px';
+
+    await resizePromise;
+    wrapper.update();
+
+    assert.isTrue(isTruncated(wrapper));
+  });
+});

--- a/src/sidebar/hooks/use-content-truncated.ts
+++ b/src/sidebar/hooks/use-content-truncated.ts
@@ -1,0 +1,35 @@
+import type { RefObject } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
+
+/**
+ * Determines if the content of an element is truncated.
+ *
+ * Useful to use with elements with hidden overflow and ellipsis text-overflow,
+ * to know if the content is truncated and the ellipsis is being shown.
+ *
+ * Be careful not to change the element's content based on this hooks result, or
+ * you could end up triggering an infinite render loop.
+ */
+export function useContentTruncated(elementRef: RefObject<HTMLElement | null>) {
+  const [isTruncated, setIsTruncated] = useState<boolean>(false);
+  useEffect(() => {
+    const buttonEl = elementRef.current;
+    /* istanbul ignore next */
+    if (!buttonEl) {
+      return () => {};
+    }
+
+    const checkIsTruncated = () =>
+      setIsTruncated(buttonEl.scrollWidth > buttonEl.clientWidth);
+
+    // Check immediately if the element's content is truncated, and then again
+    // every time it is resized
+    checkIsTruncated();
+    const observer = new ResizeObserver(checkIsTruncated);
+    observer.observe(buttonEl);
+
+    return () => observer.disconnect();
+  }, [elementRef]);
+
+  return isTruncated;
+}


### PR DESCRIPTION
Fixes https://github.com/hypothesis/client/issues/7250

Truncate annotation post button content to ensure the buttons do not overflow the thread card.

Additionally, dynamically add a title to the button if the content is in fact being truncated.

https://github.com/user-attachments/assets/c3315f2d-c8ab-4f96-a31d-1e6f107ba22b

This is how it looks in main branch without these changes:

<img width="431" height="166" alt="image" src="https://github.com/user-attachments/assets/481d8cfd-48d1-4c35-b512-261c80b81a07" />

### Considerations

~I added a side effect with a resize observer that checks if the content of the button is being in fact truncated, and in that case adding a title to it. However, this might be overkill, maybe it's ok to just add the title unconditionally.~ We decided to go ahead with this conditional behavior.

### TODO

- [x] Add tests