### PR TITLE
Restore all sinon stubs after each test

### DIFF
--- a/src/annotator/test/sidebar-test.js
+++ b/src/annotator/test/sidebar-test.js
@@ -30,16 +30,6 @@ describe('Sidebar', () => {
   let fakeSendErrorsTo;
   let fakeEmitter;
 
-  beforeAll(() => {
-    // Make `requestAnimationFrame` invoke its callback synchronously. rAF is
-    // used to debounce some internal actions.
-    sinon.stub(window, 'requestAnimationFrame').yields();
-  });
-
-  afterAll(() => {
-    window.requestAnimationFrame.restore();
-  });
-
   // Helpers for getting the channels used for host <-> guest/sidebar communication.
   // These currently rely on knowing the implementation detail of which order
   // the channels are created in.
@@ -132,6 +122,10 @@ describe('Sidebar', () => {
   };
 
   beforeEach(() => {
+    // Make `requestAnimationFrame` invoke its callback synchronously. rAF is
+    // used to debounce some internal actions.
+    sinon.stub(window, 'requestAnimationFrame').yields();
+
     sidebars = [];
     containers = [];
 

--- a/src/sidebar/test/bootstrap.js
+++ b/src/sidebar/test/bootstrap.js
@@ -19,7 +19,9 @@ globalThis.context ??= globalThis.describe;
 // Configure Enzyme for UI tests.
 configure({ adapter: new Adapter() });
 
-// Unmount all UI components after each test.
 afterEach(() => {
+  // Unmount all UI components after each test.
   unmountAll();
+  // Restore all created mocks during a test, to free-up memory
+  sinon.restore();
 });


### PR DESCRIPTION
Fixes https://github.com/hypothesis/client/issues/7033

Add a call to `sinon.restore()` in our tests bootstrap's `afterEach`, so that all mocks are restored after each test.

This is necessary because sinon keeps track of all mocks created via `sinon.stub()`, and you need to either call `restore()` on the mock itself, or do it "globally" to ensure memory can be released.

If more than 10,000 stubs are created, then sinon prints a warning message.

Since having to remember to call `restore()` every time is error prone, this PR adds a global call that makes it unnecessary.

Before this PR, the tests output would include a line like this:

<img width="1301" height="371" alt="image" src="https://github.com/user-attachments/assets/5e96a568-a69f-4baa-ac2e-49baba8f12da" />

With these changese, that warning is no longer reported:

<img width="1301" height="332" alt="image" src="https://github.com/user-attachments/assets/b2fe7c29-2121-402f-8549-95bde025398d" />

### Considerations

This PR makes individual `restore` calls no longer needed, but I decided to not remove them here to reduce the noise.