### PR TITLE
Restructure development server index page

### DIFF
--- a/dev-server/templates/index.mustache
+++ b/dev-server/templates/index.mustache
@@ -15,69 +15,116 @@
 <body>
   <svg xmlns="http://www.w3.org/2000/svg" height="28" viewBox="0 0 24 28" width="24"><path d="M3.886 3.945H21.03v16.047H3.886z" fill="#fff"></path><path d="M0 2.005C0 .898.897 0 2.005 0h19.99C23.102 0 24 .897 24 2.005v19.99A2.005 2.005 0 0121.995 24H2.005A2.005 2.005 0 010 21.995V2.005zM9 24l3 4 3-4H9zM7.008 4H4v16h3.008v-4.997C7.008 12.005 8.168 12.01 9 12c1 .007 2.019.06 2.019 2.003V20h3.008v-6.891C14.027 10 12 9.003 10 9.003c-1.99 0-2 0-2.992 1.999V4zM19 19.987c1.105 0 2-.893 2-1.994A1.997 1.997 0 0019 16c-1.105 0-2 .892-2 1.993s.895 1.994 2 1.994z" fill="currentColor" fill-rule="evenodd"></path></svg>
   <h1>Hypothesis Client development server</h1>
-  <p>Welcome to the Hypothesis client's development server.</p>
-  <h2>Test HTML documents</h2>
-    <h3>General HTML test documents</h3>
-    <p>These document test typical/simple scenarios.</p>
+  <nav>
     <ul>
-      <li><a href="/document/burns">Poems and Songs of Robert Burns</a></li>
-      <li><a href="/document/doyle"><i>The Disappearance of Lady Carfax</i>, by Arthur Conan Doyle</a></li>
-      <li><a href="/document/tolstoy"><i>Anna Karenina</i>, by Leo Tolstoy</a></li>
-      <li><a href="/document/raven"><i>The Raven</i> by Edgar Allen Poe</a> (light text on dark background)</li>
+      <li><a href="#html-tests">HTML test documents</a></li>
+      <li><a href="#pdf-tests">PDF test documents</a></li>
+      <li><a href="#vitalsource-tests">VitalSource test documents</a></li>
+      <li><a href="#page-elements">Page elements</a></li>
+      <li><a href="/ui-playground">UI component playground</a></li>
+      <li><a href="#useful-links">Useful links</a></li>
     </ul>
-
-    <h3>Scenario HTML test documents</h3>
-    <p>These documents test less common scenarios and edge cases.</p>
-    <ul>
-      <li><a href="/document/client-side-navigation">Client-side navigation / SPA</a></li>
-      <li><a href="/document/z-index">Content with high <code>z-index</code> style</a></li>
-      <li><a href="/document/shadow-dom">Content in shadow DOM</a></li>
-      <li><a href="/document/coop-test"><code>Cross-Origin-Opener-Policy</code> test</a></li>
-      <li><a href="/document/host-in-shadow-root">Hypothesis loaded into frame in shadow root</a></li>
-      <li><a href="/document/parent-frame">Annotation-enabled iframe</a></li>
-      <li><a href="/document/sidebar-external-container">Sidebar in external container</a></li>
-      <li><a href="/document/multi-frames">Page containing multiple iframes with Hypothesis loaded</a></li>
-      <li><a href="/document/cross-origin-iframe">Page containing a cross-origin guest iframe</a></li>
-      <li><a href="/document/ignore-other-configuration"><code>ignoreOtherConfiguration</code>
-          configuration option enabled</a></li>
-      <li><a href="/document/doyle-tiny"><i>The Disappearance of Lady Carfax</i> with tiny (10px) root font size in host page</a></li>
-      <li><a href="/document/doyle-huge"><i>The Disappearance of Lady Carfax</i> with huge (24px) root font size in host page</a></li>
-      <li><a href="/document/doyle-centered"><i>The Disappearance of Lady Carfax</i> with a centered, max-width body</a></li>
-      <li><a href="/document/xhtml-test">XHTML document (served with XHTML mime type)</a></li>
-      <li><a href="/document/whitespace">HTML document with different types of whitespace content</a></li>
-    </ul>
-
-    <h3>VitalSource test documents</h3>
-    <p>These documents simulate VitalSource's book reader.</p>
-    <ul>
-      <li><a href="/document/vitalsource-epub">Mock VitalSource EPUB (aka. "reflowable") book</a></li>
-      <li><a href="/document/vitalsource-pdf">Mock VitalSource PDF (aka. "fixed") book</a></li>
-    </ul>
-
-  <h2>Test PDF documents</h2>
-  <h3>General test documents</h3>
-  <p>These documents test typical/simple scenarios.</p>
+  </nav>
+  <p>This page contains test documents for checking behavior with different document types,
+     content attributes and configuration options.</p>
+  <h2 id="html-tests">HTML test documents</h2>
+  <p>Tests for annotating web pages.</p>
+  <h3>General tests</h3>
   <ul>
-    <li><a href="/pdf/nils-olav">Brigadier Sir Nils Olav III</a></li>
+    <li><a href="/document/burns">Poems and Songs of Robert Burns</a></li>
+    <li><a href="/document/doyle"><i>The Disappearance of Lady Carfax</i>, by Arthur Conan Doyle</a></li>
+    <li><a href="/document/tolstoy"><i>Anna Karenina</i>, by Leo Tolstoy</a></li>
+  </ul>
+
+  <h3>Content and configuration tests</h3>
+
+  <h4>Client-side navigation</h4>
+  <p>Tests for sites that use client-side navigation.</p>
+  <ul>
+    <li><a href="/document/client-side-navigation">Client-side navigation / SPA</a></li>
+  </ul>
+
+  <h4>Iframe support</h4>
+  <p>Tests for annotating content inside iframes.</p>
+  <ul>
+    <li><a href="/document/cross-origin-iframe">Page containing a cross-origin guest iframe</a></li>
+    <li><a href="/document/host-in-shadow-root">Hypothesis loaded into frame in shadow root</a></li>
+    <li><a href="/document/multi-frames">Page containing multiple iframes with Hypothesis loaded</a></li>
+    <li><a href="/document/parent-frame">Annotation-enabled iframe</a></li>
+  </ul>
+
+  <h4>Content tests</h4>
+  <p>
+    Tests related to handling of web pages with characteristics that cause challenges
+    or require special handling.
+  </p>
+  <ul>
+    <li><a href="/document/coop-test">Page served with <code>Cross-Origin-Opener-Policy</code> header</a></li>
+    <li><a href="/document/doyle-tiny">Page with tiny root font</a></li>
+    <li><a href="/document/doyle-huge">Page with huge root font</a></li>
+    <li><a href="/document/doyle-centered">Centered, max-width body</a></li>
+    <li><a href="/document/raven">Light text on dark background (<i>The Raven</i> by Edgar Allen Poe</a>)</li>
+    <li><a href="/document/shadow-dom">Content in shadow DOM</a></li>
+    <li><a href="/document/whitespace">Different kinds of whitespace</a></li>
+    <li><a href="/document/xhtml-test">XHTML document (served with XHTML mime type)</a></li>
+    <li><a href="/document/z-index">High <code>z-index</code> style</a></li>
+  </ul>
+
+  <h4>Configuration tests</h4>
+  <p>Tests for configuration options.</p>
+  <ul>
+    <li><a href="/document/ignore-other-configuration"><code>ignoreOtherConfiguration</code> option enabled</a></li>
+    <li><a href="/document/sidebar-external-container">Sidebar in external container</a></li>
+  </ul>
+
+  <h2 id="pdf-tests">PDF test documents</h2>
+  <p>Tests for annotating PDFs.</p>
+
+  <h3>General tests</h3>
+  <ul>
     <li><a href="/pdf/budlong">The Budlong Pickle Company (Wikipedia)</a></li>
+    <li><a href="/pdf/nils-olav">Brigadier Sir Nils Olav III</a></li>
     <li><a href="/pdf/widdershins">Widdershins (Wikipedia)</a></li>
   </ul>
 
-  <h3>Scenario PDF test documents</h3>
-  <p>These documents test less common scenarios and edge cases.</p>
+  <h3>Content and configuration tests</h3>
+
+  <h4>PDF identity / fingerprints</h4>
+  <p>Tests related to how Hypothesis identifies PDFs (via URL, fingerprint etc).</p>
   <ul>
     <li><a href="/pdf/nils-olav" class="js-randomize-url">PDF with URL that changes on each
         visit</a></li>
-    <li><a href="/pdf/painting">PDF without selectable text</a></li>
-    <li><a href="/pdf/gatsby">The Great Gatsby</a> (A long document)</li>
-    <li><a href="/pdf/gatsby-section">The Great Gatsby - Page range focus active</a></li>
-    <li><a href="/pdf/jstor">PDF with JSTOR banner</a></li>
+  </ul>
+
+  <h4>Content tests</h4>
+  <p>
+    Tests related to handling of PDFs with characteristics that cause challenges
+    or require special handling.
+  </p>
+  <ul>
     <li><a href="/pdf/custom-page-numbers">PDF with custom page numbers</a></li>
+    <li><a href="/pdf/gatsby">A long document (Great Gatsby)</a></li>
+    <li><a href="/pdf/painting">PDF without selectable text</a></li>
     <li><a href="/pdf/rotated">PDF with rotated pages</a></li>
   </ul>
 
-  <h2>Page feature tests</h2>
-  <p>Page elements that interact with the Hypothesis client.</p>
+  <h4>Configuration tests</h4>
+  <p>Tests for configuration options.</p>
+  <ul>
+    <li><a href="/pdf/gatsby-section">Page range filter active</a></li>
+    <li><a href="/pdf/jstor">JSTOR banner enabled</a></li>
+  </ul>
+
+  <h2 id="vitalsource-tests">VitalSource test documents</h2>
+  <p>These documents simulate VitalSource's book reader.</p>
+  <ul>
+    <li><a href="/document/vitalsource-epub">Mock VitalSource EPUB (aka. "reflowable") book</a></li>
+    <li><a href="/document/vitalsource-pdf">Mock VitalSource PDF (aka. "fixed") book</a></li>
+  </ul>
+
+  <h2 id="page-elements">Page elements</h2>
+  <p>Tests for HTML elements on the page configured to interact with or
+     display information related to Hypothesis.</p>
   <div>
     Number of annotations on this page:
     <span data-hypothesis-annotation-count>...</span>
@@ -87,12 +134,7 @@
   </button>
   <button class="js-toggle-client">Load client</button>
 
-  <h2>Development tools</h2>
-  <ul>
-    <li><a href="/ui-playground">UI component playground</a></li>
-  </ul>
-
-  <h2>Useful links</h2>
+  <h2 id="useful-links">Useful links</h2>
   <ul>
     <li><a href="https://github.com/hypothesis/client">GitHub project</a></li>
     <li><a href="https://h-client.readthedocs.io">Documentation for publishers and


### PR DESCRIPTION
Reorganize the index page to make it easier to find specific test documents and add new ones.

 - Split the tests for each document type into several subsections: general tests, content tests, configuration tests and sub-sections unique to that content type.

 - Add quick-links at the top of the page

 - Revise text of several test document links to make it more obvious what is unique about each document