### PR TITLE
Revert "Temporarily disable fix introduced in #7477"

### DIFF
--- a/src/sidebar/components/SidebarTabs.tsx
+++ b/src/sidebar/components/SidebarTabs.tsx
@@ -111,6 +111,7 @@ function SidebarTabs({
   annotationsService,
   isLoading,
   settings,
+  frameSync,
 }: SidebarTabsProps) {
   const { rootThread, tabCounts } = useRootThread();
   const store = useSidebarStore();
@@ -147,9 +148,9 @@ function SidebarTabs({
   const tabCountsSummary = tabCountsSummaryPieces.join(', ');
 
   const createPageNoteWithDocumentMeta = useCallback(async () => {
-    // const { metadata } = await frameSync.getDocumentInfo();
-    annotationsService.createPageNote(/* metadata */);
-  }, [annotationsService]);
+    const { metadata } = await frameSync.getDocumentInfo();
+    annotationsService.createPageNote(metadata);
+  }, [annotationsService, frameSync]);
 
   return (
     <>

--- a/src/sidebar/components/test/SidebarTabs-test.js
+++ b/src/sidebar/components/test/SidebarTabs-test.js
@@ -166,7 +166,7 @@ describe('SidebarTabs', () => {
           .props()
           .onClick();
 
-        // assert.calledOnce(fakeFrameSync.getDocumentInfo);
+        assert.calledOnce(fakeFrameSync.getDocumentInfo);
         assert.calledOnce(fakeAnnotationsService.createPageNote);
       });
     });


### PR DESCRIPTION
This pull request updates the `SidebarTabs` component to correctly include document metadata when creating a new page note, and updates the related test to reflect this behavior.

Reverts hypothesis/client#7478

**Feature improvement:**

* The `SidebarTabs` component now retrieves document metadata using `frameSync.getDocumentInfo()` and passes it to `annotationsService.createPageNote`, ensuring that new page notes include relevant document information. [[1]](diffhunk://#diff-d17e3c2180c1d5b565e0faab5cc2756e78ca44d6ba80764c5578c13b10c4949aR114) [[2]](diffhunk://#diff-d17e3c2180c1d5b565e0faab5cc2756e78ca44d6ba80764c5578c13b10c4949aL150-R153)

**Test update:**

* The test for `SidebarTabs` now asserts that `frameSync.getDocumentInfo` is called when creating a page note, matching the updated implementation.
