### PR TITLE
ci: guard PRs against boot-script byte drift and deploy-dep breakage

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -33,3 +33,75 @@ jobs:
       with:
         files: ./coverage/coverage-final.json
         token: ${{ secrets.CODECOV_TOKEN }}
+
+  # Guard against changes that only break after merge (see the 2026-07-01
+  # incident): the production build - whose boot script bytes are gated by a
+  # CSP `script-src` sha256 where the client is embedded - and the deploy
+  # script's dependency chain both run for the first time in the post-merge
+  # Release workflow, so a PR that alters either is green here and fails (or
+  # silently breaks the shipped client) in production.
+  prod-build-guard:
+    name: Prod build & boot hash guard
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout PR branch
+      uses: actions/checkout@v4
+      with:
+        path: pr
+    - name: Checkout base branch
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.base.sha }}
+        path: base
+    - name: Cache the PR node_modules dir
+      uses: actions/cache@v4
+      with:
+        path: pr/node_modules
+        key: ${{ runner.os }}-node_modules-guard-pr-${{ hashFiles('pr/yarn.lock') }}
+    - name: Cache the base node_modules dir
+      uses: actions/cache@v4
+      with:
+        path: base/node_modules
+        key: ${{ runner.os }}-node_modules-guard-base-${{ hashFiles('base/yarn.lock') }}
+    - name: Build production bundles (PR)
+      run: cd pr && yarn install --immutable && yarn build
+    - name: Build production bundles (base)
+      run: cd base && yarn install --immutable && yarn build
+    - name: Smoke-check deploy-time dependencies
+      run: |
+        cd pr
+        node scripts/check-deploy-deps.js
+        node scripts/deploy-to-s3.js --help > /dev/null
+    - name: Check boot script for byte drift
+      env:
+        DRIFT_APPROVED: ${{ contains(github.event.pull_request.labels.*.name, 'boot-bytes-approved') }}
+      run: |
+        # Cache-buster fingerprints (`?abc123`) in the inlined asset manifest
+        # legitimately change whenever any asset's content changes, so they are
+        # stripped before comparing: only drift in the boot script's *code*
+        # (the 2026-07-01 incident class) should fail the check.
+        normalized_hash() { sed -E 's/\?[0-9a-f]{6}//g' "$1" | sha256sum | awk '{print $1}'; }
+        drift=""
+        for f in boot-template.js boot.js; do
+          base_hash=$(normalized_hash "base/build/$f")
+          pr_hash=$(normalized_hash "pr/build/$f")
+          echo "$f (fingerprints stripped): base=$base_hash pr=$pr_hash"
+          echo "$f (raw): base=$(sha256sum "base/build/$f" | awk '{print $1}') pr=$(sha256sum "pr/build/$f" | awk '{print $1}')"
+          if [ "$base_hash" != "$pr_hash" ]; then
+            drift="$drift $f"
+          fi
+        done
+        if [ -n "$drift" ]; then
+          msg="Boot script bytes changed vs the base branch:$drift. Where the client \
+        is embedded via an inline script gated by a CSP script-src sha256, this change \
+        invalidates that hash and the browser will block the client (2026-07-01 outage). \
+        If the change is intentional, coordinate refreshing the CSP hash allowlist with \
+        the deploy, then add the 'boot-bytes-approved' label to this PR and re-run."
+          if [ "$DRIFT_APPROVED" = "true" ]; then
+            echo "::warning::$msg (approved via 'boot-bytes-approved' label)"
+          else
+            echo "::error::$msg"
+            exit 1
+          fi
+        fi

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,6 +7,7 @@ import {
 } from '@hypothesis/frontend-build';
 import gulp from 'gulp';
 import changed from 'gulp-changed';
+import { writeFileSync } from 'node:fs';
 
 import { serveDev } from './dev-server/serve-dev.js';
 import { servePackage } from './dev-server/serve-package.js';
@@ -89,7 +90,21 @@ const manifestSourceFiles = 'build/{scripts,styles}/*.{css,js,map}';
 
 gulp.task('build-boot-script', async () => {
   // Generate the manifest containing cache-busted asset URLs
-  await generateManifest({ pattern: manifestSourceFiles });
+  const manifest = await generateManifest({ pattern: manifestSourceFiles });
+  // Rewrite the manifest with sorted keys. `generateManifest` inserts entries
+  // in file-read-completion order, which varies between runs, and the boot
+  // bundle inlines this JSON — key order must be stable for the boot script's
+  // bytes (and any CSP hash derived from them) to be reproducible.
+  writeFileSync(
+    'build/manifest.json',
+    JSON.stringify(
+      Object.fromEntries(
+        Object.entries(manifest).sort(([a], [b]) => a.localeCompare(b)),
+      ),
+      null,
+      2,
+    ),
+  );
   // Generate the boot script template
   await buildJS('./rollup-boot.config.js');
   // Replace variables in the template with real URLs

--- a/scripts/check-deploy-deps.js
+++ b/scripts/check-deploy-deps.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/**
+ * Smoke-check the release-time deploy dependencies that PR CI otherwise never
+ * exercises.
+ *
+ * Context: on 2026-07-01 a `fast-xml-parser` pin made the AWS SDK reject the
+ * `&#xD;` (carriage return) entity that S3 returns in `GetBucketLocation`
+ * responses, blocking every deploy while PR CI stayed green, because the
+ * deploy script's dependency chain only runs in the post-merge Release
+ * workflow. This script exercises that chain on every PR:
+ *
+ * 1. The AWS SDK S3 client can be imported and constructed.
+ * 2. The XML parser resolved for the AWS SDK accepts the `&#xD;` entity.
+ *
+ * `deploy-to-s3.js --help` is run separately by CI to cover the deploy
+ * script's own import chain (commander, arborist, npm-packlist).
+ */
+import { S3Client } from '@aws-sdk/client-s3';
+import { XMLParser } from 'fast-xml-parser';
+
+new S3Client({ region: 'us-west-1' });
+
+// Mirrors the shape of a real S3 `GetBucketLocation` response, including the
+// carriage-return entity that broke deploys on 2026-07-01.
+const xml =
+  '<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">us-west-1&#xD;</LocationConstraint>';
+const parsed = new XMLParser({ ignoreAttributes: false }).parse(xml);
+const value =
+  parsed?.LocationConstraint?.['#text'] ?? parsed?.LocationConstraint;
+
+if (typeof value !== 'string' || !value.startsWith('us-west-1')) {
+  console.error('Unexpected S3 XML parse result:', JSON.stringify(parsed));
+  process.exit(1);
+}
+
+console.log('Deploy dependency smoke checks passed.');


### PR DESCRIPTION
## Why

The 2026-07-01 incident (#7557 → hotfix #7560, rollback #7561) had **two failure modes that were invisible to PR CI**, because the production build and the deploy script's dependency chain run for the first time **post-merge** in the Release workflow:

1. **CSP break**: a build-tooling transitive (`serialize-javascript` v6→v7, pulled in via `resolutions`) changed the boot script's bytes, so the CSP `script-src` sha256 gating the client's inline bootstrap no longer matched → browsers blocked the client in prod (~37 min partial outage).
2. **Deploy break**: a `fast-xml-parser: 5.7.0` pin made `@aws-sdk`'s S3 response parsing reject the `&#xD;` entity S3 returns → every deploy blocked.

Several currently-open Dependabot PRs (#7546 rollup/terser majors, #7544 babel group) touch the same toolchain and are green for the same vacuous reason. This PR is the guard that makes them safely mergeable.

## What this adds

**A `prod-build-guard` job in PR CI** that:

- builds the production bundles (`yarn build`) for **both the PR and its base branch**;
- **fails if the boot script's code bytes drift** (`build/boot-template.js` / `build/boot.js`). Asset cache-buster fingerprints (`?abc123`) are normalized away first, so routine asset changes don't trip it — only drift in the boot *code* (the incident class) fails. Intentional changes are acknowledged with the `boot-bytes-approved` label, which downgrades the failure to a warning;
- **smoke-checks the deploy-time dependency chain** on every PR: `scripts/check-deploy-deps.js` (constructs the S3 client and regression-tests the XML parser against an S3-style `&#xD;` response — the exact 2026-07-01 deploy bug) plus `deploy-to-s3.js --help` to exercise the deploy script's full import chain.

**A determinism fix the guard surfaced**: `generateManifest` (from `@hypothesis/frontend-build`) fills the manifest object in *file-read-completion order*, which varies run to run, and the boot bundle inlines that JSON — so two builds of identical source produced different boot bytes. The gulpfile now rewrites `build/manifest.json` with sorted keys before the boot bundle is built. (Proper long-term fix belongs upstream in `frontend-build`; follow-up worth opening there.)

## Verification (local)

- Before the manifest sort: two consecutive `yarn build` runs produced **different** `boot-template.js` hashes (manifest key order raced). After: **identical hashes across rebuilds**.
- `node scripts/check-deploy-deps.js` passes; `node scripts/deploy-to-s3.js --help` exits 0.
- `prettier` / `eslint` / `tsc` clean on the changed files.

## Notes for review

- **This PR's own guard check will flag drift** — expected and correct: the manifest key ordering change alters `boot.js` bytes once. That is strictly *less* churn than today (ordering is currently random every build, so releases already reshuffle it and prod tolerates it). The `boot-bytes-approved` label demonstrates the acknowledgement flow.
- The job only runs on `pull_request` (skipped when this workflow is `workflow_call`ed from Release).
- To make it merge-blocking, add `Prod build & boot hash guard` to the branch-protection required checks (repo admin).
- Unblocks (merge one at a time, watching the deploy): #7546, #7544 (then close #7555 as superseded), #7537.

🤖 Generated with [Claude Code](https://claude.com/claude-code)